### PR TITLE
Support writing settings attributes to first node inside instance

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -27,6 +27,7 @@ DEFAULT_LANGUAGE = u"default_language"
 LABEL = u"label"
 HINT = u"hint"
 STYLE = u"style"
+ATTRIBUTE = u"attribute"
 
 BIND = u"bind"  # TODO: What should I do with the nested types? (readonly and relevant) # noqa
 MEDIA = u"media"

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -45,7 +45,8 @@ class Survey(Section):
             u"instance_xmlns": unicode,
             u"version": unicode,
             u"choices": dict,
-            u"style": unicode
+            u"style": unicode,
+            u"attribute": dict
         }
     )
 
@@ -138,6 +139,11 @@ class Survey(Section):
 
     def xml_instance(self):
         result = Section.xml_instance(self)
+
+        # set these first to prevent overwriting id and version
+        for key, value in self.attribute.items():
+            result.setAttribute(unicode(key), value)
+
         result.setAttribute(u"id", self.id_string)
 
         # add instance xmlns attribute to the instance node
@@ -146,6 +152,7 @@ class Survey(Section):
 
         if self.version:
             result.setAttribute(u"version", self.version)
+
         return result
 
     def _add_to_nested_dict(self, dicty, path, value):


### PR DESCRIPTION
We'd like add a 'attribute::something' to the settings sheet and have that something show up in the XML.

form_id  |  attribute::my_number  |  attribute::my_string
------------ | ------------ | -------------
my_form | 1234567890 | lorém ipsum

```xml
<instance>
  <test id="attribute_test" my_number="1234567890" my_string="lorém ipsum" />
</instance>
```
