### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - pip install -q -r requirements.pip
 env:
   - "RUNTESTS=nosetests"
-  - "RUNTESTS='nosetests -w pyxform/tests_v1/ -s'"
-script: $RUNTESTS
+  - "RUNTESTS='nosetests --tests pyxform/tests_v1/'"
+script: python setup.py $RUNTESTS
 notifications:
   irc: "irc.freenode.org#moditest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
 install:
   - pip install -q -r requirements.pip
 env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include *.txt
-include *.rst
-recursive-include pyxform/odk_validate *.rst *.jar *.java

--- a/fixers/fix_unicode.py
+++ b/fixers/fix_unicode.py
@@ -1,0 +1,24 @@
+from lib2to3 import fixer_base
+from lib2to3.pgen2 import token
+
+
+class FixUnicode(fixer_base.BaseFix):
+    """
+    Renames:
+       def __unicode__(self):
+    to:
+       def __str__(self):
+
+    2to3 already handles converting unicode() to str().
+    """
+
+    _accept_type = token.NAME
+
+    def match(self, node):
+        if node.value == '__unicode__':
+            return True
+        return False
+
+    def transform(self, node, results):
+        node.value = '__str__'
+        node.changed()

--- a/pyxform/odk_validate/__init__.py
+++ b/pyxform/odk_validate/__init__.py
@@ -106,6 +106,7 @@ def check_xform(path_to_xform):
     returncode, timeout, stdout, stderr = run_popen_with_timeout(
         ["java", "-jar", ODK_VALIDATE_JAR, path_to_xform], 100)
     warnings = []
+    stderr = stderr.decode('utf-8')
 
     if timeout:
         return ["XForm took to long to completely validate."]

--- a/pyxform/tests/attribute_columns_test.py
+++ b/pyxform/tests/attribute_columns_test.py
@@ -11,11 +11,12 @@ parentdir = os.path.dirname(os.path.dirname(
 sys.path.insert(0, parentdir)
 import pyxform
 from pyxform.errors import PyXFormError
+from .utils import XFormTestCase
 
 DIR = os.path.dirname(__file__)
 
 
-class attribute_columns_test(unittest.TestCase):
+class attribute_columns_test(XFormTestCase):
 
     maxDiff = None
 
@@ -39,7 +40,7 @@ class attribute_columns_test(unittest.TestCase):
                 as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") \
                     as actual_file:
-                self.assertMultiLineEqual(
+                self.assertXFormEqual(
                     expected_file.read(), actual_file.read())
 
 

--- a/pyxform/tests/bug_tests.py
+++ b/pyxform/tests/bug_tests.py
@@ -13,6 +13,7 @@ sys.path.insert(0, parentdir)
 import pyxform
 from pyxform.utils import has_external_choices
 from pyxform.xls2json import SurveyReader
+from .utils import XFormTestCase
 
 DIR = os.path.dirname(__file__)
 
@@ -55,7 +56,7 @@ class duplicate_columns(unittest.TestCase):
             survey.print_xform_to_file(output_path, warnings=warnings)
 
 
-class repeat_date_test(unittest.TestCase):
+class repeat_date_test(XFormTestCase):
 
     maxDiff = None
 
@@ -79,11 +80,10 @@ class repeat_date_test(unittest.TestCase):
                 expected_output_path, 'rb', encoding="utf-8") as expected_file:
             with codecs.open(
                     output_path, 'rb', encoding="utf-8") as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
 
-class xml_escaping(unittest.TestCase):
+class xml_escaping(XFormTestCase):
 
     maxDiff = None
 
@@ -107,11 +107,10 @@ class xml_escaping(unittest.TestCase):
                 expected_output_path, 'rb', encoding="utf-8") as expected_file:
             with codecs.open(
                     output_path, 'rb', encoding="utf-8") as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
 
-class DefaultTimeTest(unittest.TestCase):
+class DefaultTimeTest(XFormTestCase):
 
     maxDiff = None
 
@@ -135,8 +134,7 @@ class DefaultTimeTest(unittest.TestCase):
                 expected_output_path, 'rb', encoding="utf-8") as expected_file:
             with codecs.open(
                     output_path, 'rb', encoding="utf-8") as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
 
 class cascade_old_format(unittest.TestCase):

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -56,7 +56,7 @@ class BuilderTests(TestCase):
 
     def test_create_from_file_object(self):
         path = utils.path_to_text_fixture('yes_or_no_question.xls')
-        with open(path) as f:
+        with open(path, 'rb') as f:
             create_survey_from_xls(f)
 
     def tearDown(self):

--- a/pyxform/tests/new_cascading_select_test.py
+++ b/pyxform/tests/new_cascading_select_test.py
@@ -6,10 +6,11 @@ import sys
 parentdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0,parentdir)
 import pyxform
+from .utils import XFormTestCase
 
 DIR = os.path.dirname(__file__)
 
-class main_test(unittest.TestCase):
+class main_test(XFormTestCase):
     
     maxDiff = None
     
@@ -36,8 +37,7 @@ class main_test(unittest.TestCase):
                     expected_file:
                 with codecs.open(output_path, 'rb', encoding="utf-8") as \
                         actual_file:
-                    self.assertMultiLineEqual(
-                        expected_file.read(), actual_file.read())
+                    self.assertXFormEqual(expected_file.read(), actual_file.read())
                 
 if __name__ == '__main__':
     unittest.main()

--- a/pyxform/tests/or_other_test.py
+++ b/pyxform/tests/or_other_test.py
@@ -9,10 +9,11 @@ import sys
 parentdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0,parentdir)
 import pyxform
+from .utils import XFormTestCase
 
 DIR = os.path.dirname(__file__)
 
-class main_test(unittest.TestCase):
+class main_test(XFormTestCase):
     
     maxDiff = None
     
@@ -32,7 +33,7 @@ class main_test(unittest.TestCase):
         #Compare with the expected output:
         with codecs.open(expected_output_path, 'rb', encoding="utf-8") as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") as actual_file:
-                self.assertMultiLineEqual(expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyxform/tests/select_one_external_test.py
+++ b/pyxform/tests/select_one_external_test.py
@@ -7,10 +7,11 @@ parentdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 sys.path.insert(0,parentdir)
 import pyxform
 from pyxform.utils import sheet_to_csv
+from .utils import XFormTestCase
 
 DIR = os.path.dirname(__file__)
 
-class main_test(unittest.TestCase):
+class main_test(XFormTestCase):
     
     maxDiff = None
     
@@ -41,8 +42,7 @@ class main_test(unittest.TestCase):
                     expected_file:
                 with codecs.open(output_path, 'rb', encoding="utf-8") as \
                         actual_file:
-                    self.assertMultiLineEqual(
-                        expected_file.read(), actual_file.read())
+                    self.assertXFormEqual(expected_file.read(), actual_file.read())
                 
 if __name__ == '__main__':
     unittest.main()

--- a/pyxform/tests/test_file_type.py
+++ b/pyxform/tests/test_file_type.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 from pyxform.builder import create_survey_from_path
 from pyxform.builder import create_survey_element_from_json
 import utils
@@ -6,7 +5,7 @@ import os
 import codecs
 
 
-class TestFileType(TestCase):
+class TestFileType(utils.XFormTestCase):
 
     maxDiff = None
 
@@ -18,7 +17,7 @@ class TestFileType(TestCase):
 
         with codecs.open(path, encoding='utf-8') as f:
             expected_xml = f.read()
-            self.assertMultiLineEqual(survey.to_xml(), expected_xml)
+            self.assertXFormEqual(survey.to_xml(), expected_xml)
 
             survey = create_survey_element_from_json(survey.to_json())
-            self.assertMultiLineEqual(survey.to_xml(), expected_xml)
+            self.assertXFormEqual(survey.to_xml(), expected_xml)

--- a/pyxform/tests/test_osm.py
+++ b/pyxform/tests/test_osm.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 from pyxform.builder import create_survey_from_path
 from pyxform.builder import create_survey_element_from_json
 import utils
@@ -6,7 +5,7 @@ import os
 import codecs
 
 
-class OSMTests(TestCase):
+class OSMTests(utils.XFormTestCase):
 
     maxDiff = None
 
@@ -18,7 +17,7 @@ class OSMTests(TestCase):
 
         with codecs.open(path, encoding='utf-8') as f:
             expected_xml = f.read()
-            self.assertMultiLineEqual(survey.to_xml(), expected_xml)
+            self.assertXFormEqual(survey.to_xml(), expected_xml)
 
             survey = create_survey_element_from_json(survey.to_json())
-            self.assertMultiLineEqual(survey.to_xml(), expected_xml)
+            self.assertXFormEqual(survey.to_xml(), expected_xml)

--- a/pyxform/tests/utils.py
+++ b/pyxform/tests/utils.py
@@ -1,6 +1,10 @@
 import os
 from pyxform import file_utils
 from pyxform.builder import create_survey, create_survey_from_path
+from unittest2 import TestCase
+from lxml import etree
+from formencode.doctest_xml_compare import xml_compare
+
 
 def path_to_text_fixture(filename):
     directory = os.path.dirname(__file__)
@@ -20,3 +24,67 @@ def create_survey_from_fixture(fixture_name, filetype="xls", include_directory=F
         directory, noop = os.path.split(fixture_path)
         pkg[u'sections'] = file_utils.collect_compatible_files_in_directory(directory)
     return create_survey(**pkg)
+
+
+class XFormTestCase(TestCase):
+    """
+    XFormTestCase provides an assertion for comparing two XForms for
+    equivalence.  It relies on the xml_compare function provided by FormEncode,
+    but with some extra logic to handle the essentially random order of tags in
+    the <model> section.  The iteration order of dict keys in Python 3 is
+    unpredictable, and many of the elements in <model> tag are generated from
+    dicts.  A simple workaround is to just reorder those tags here.  An ideal
+    solution might be to rewrite the code that generates an XForm to use
+    OrderedDicts where appropriate.
+    """
+
+    def assertXFormEqual(self, xform1, xform2):
+        xform1 = etree.fromstring(xform1)
+        xform2 = etree.fromstring(xform2)
+
+        # Sort tags under <model> section in each form
+        self.sort_model(xform1)
+        self.sort_model(xform2)
+
+        # Report any errors returned from xform_compare
+        errs = []
+        def reporter(msg):
+            errs.append(msg)
+
+        self.assertTrue(
+            xml_compare(xform1, xform2, reporter),
+            "\n\n" + "\n".join(reversed(errs))
+        )
+
+    def sort_elems(self, elems, attr=None):
+         if attr:
+             key = lambda elem: elem.get(attr, '')
+         else:
+             key = lambda elem: elem.tag
+         elems[:] = sorted(elems, key=key)
+
+    def sort_model(self, xform):
+        ns = "{http://www.w3.org/2002/xforms}"
+        model = xform.find('.//' + ns + 'model')
+
+        # Sort multiple <instance> tags, if any
+        self.sort_elems(model, 'id')
+
+        # Sort any <item> tags in each <instance>
+        for instance in model.findall(ns + 'instance'):
+            if instance.get('id', None):
+                root = instance.find(ns + 'root')
+                if root is not None:
+                    for item in root:
+                        self.sort_elems(item)
+
+        # Sort <translation> tags as well as inner <text> and <value> tags.
+        itext = model.find(ns + 'itext')
+        if itext is None:
+            return
+
+        self.sort_elems(itext, 'lang')
+        for translation in itext:
+            self.sort_elems(translation, 'id')
+            for text in translation:
+                self.sort_elems(text, 'form')

--- a/pyxform/tests/xform2json_test.py
+++ b/pyxform/tests/xform2json_test.py
@@ -1,11 +1,10 @@
-from unittest2 import TestCase
 from pyxform.builder import create_survey_from_path
 from pyxform.xform2json import create_survey_element_from_xml
 import os
 import utils
 
 
-class DumpAndLoadXForm2JsonTests(TestCase):
+class DumpAndLoadXForm2JsonTests(utils.XFormTestCase):
 
     maxDiff = None
 
@@ -39,7 +38,7 @@ class DumpAndLoadXForm2JsonTests(TestCase):
         for filename, survey in self.surveys.items():
             survey.json_dump()
             survey_from_dump = create_survey_element_from_xml(survey.to_xml())
-            self.assertMultiLineEqual(
+            self.assertXFormEqual(
                 survey.to_xml(), survey_from_dump.to_xml())
 
     def tearDown(self):

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -32,7 +32,9 @@ class BasicXls2JsonApiTests(TestCase):
         #Compare with the expected output:
         with codecs.open(expected_output_path, 'rb', encoding="utf-8") as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") as actual_file:
-                self.assertMultiLineEqual(expected_file.read(), actual_file.read())
+                expected_json = json.load(expected_file)
+                actual_json = json.load(actual_file)
+                self.assertEqual(expected_json, actual_json)
 
 #        expected_dict = [
 #            {
@@ -179,7 +181,9 @@ class BasicXls2JsonApiTests(TestCase):
         #Compare with the expected output:
         with codecs.open(expected_output_path, 'rb', encoding="utf-8") as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") as actual_file:
-                self.assertMultiLineEqual(expected_file.read(), actual_file.read())
+                expected_json = json.load(expected_file)
+                actual_json = json.load(actual_file)
+                self.assertEqual(expected_json, actual_json)
 
 
 

--- a/pyxform/tests/xlsform_spec_test.py
+++ b/pyxform/tests/xlsform_spec_test.py
@@ -11,11 +11,12 @@ parentdir = os.path.dirname(os.path.dirname(
 sys.path.insert(0, parentdir)
 import pyxform
 from pyxform.errors import PyXFormError
+from .utils import XFormTestCase
 
 DIR = os.path.dirname(__file__)
 
 
-class main_test(unittest.TestCase):
+class main_test(XFormTestCase):
 
     maxDiff = None
 
@@ -39,11 +40,10 @@ class main_test(unittest.TestCase):
                 as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") \
                     as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
 
-class flat_xlsform_test(unittest.TestCase):
+class flat_xlsform_test(XFormTestCase):
 
     maxDiff = None
 
@@ -67,11 +67,10 @@ class flat_xlsform_test(unittest.TestCase):
                 as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") \
                     as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
 
-class test_new_widgets(unittest.TestCase):
+class test_new_widgets(XFormTestCase):
 
     maxDiff = None
 
@@ -95,8 +94,7 @@ class test_new_widgets(unittest.TestCase):
                 as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") \
                     as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
 
 class warnings_test(unittest.TestCase):
@@ -125,7 +123,7 @@ class calculate_without_calculation_test(unittest.TestCase):
                           path_to_excel_file)
 
 
-class PullDataTest(unittest.TestCase):
+class PullDataTest(XFormTestCase):
 
     maxDiff = None
 
@@ -149,14 +147,13 @@ class PullDataTest(unittest.TestCase):
                 as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") \
                     as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
         # cleanup
         os.remove(output_path)
 
 
-class SeachAndSelectTest(unittest.TestCase):
+class SeachAndSelectTest(XFormTestCase):
 
     maxDiff = None
 
@@ -180,8 +177,7 @@ class SeachAndSelectTest(unittest.TestCase):
                 as expected_file:
             with codecs.open(output_path, 'rb', encoding="utf-8") \
                     as actual_file:
-                self.assertMultiLineEqual(
-                    expected_file.read(), actual_file.read())
+                self.assertXFormEqual(expected_file.read(), actual_file.read())
 
         # cleanup
         os.remove(output_path)

--- a/pyxform/tests/xml_tests.py
+++ b/pyxform/tests/xml_tests.py
@@ -1,10 +1,9 @@
-from unittest2 import TestCase
 from pyxform import create_survey_from_xls
 import re
 import utils
 
 
-class XMLTests(TestCase):
+class XMLTests(utils.XFormTestCase):
 
     def setUp(self):
         self.survey = create_survey_from_xls(
@@ -59,4 +58,4 @@ class XMLTests(TestCase):
         xml_str = re.sub(r"yes_or_no_question_2011_04_22",
                          self.survey.id_string, xml_str)
         self.maxDiff = None
-        self.assertMultiLineEqual(xml_str, self.survey.to_xml())
+        self.assertXFormEqual(xml_str, self.survey.to_xml())

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -3,7 +3,7 @@ import re
 import codecs
 import json
 import copy
-import csv
+import unicodecsv as csv
 import xlrd
 
 SEP = "_"
@@ -15,6 +15,20 @@ XFORM_TAG_REGEXP = "%(start)s%(char)s*" % {
     "start": TAG_START_CHAR,
     "char": TAG_CHAR
     }
+
+class DetachableElement(Element):
+    """
+    Element classes are not meant to be instantiated directly.   This
+    restriction was not strictly enforced in Python 2, but is effectively
+    enforced in Python 3 via http://bugs.python.org/issue15290.
+
+    A simple workaround (for now) is to set an extra attribute on the Element
+    class.  The long term fix will probably be to rewrite node() to use
+    document.createElement rather than Element.
+    """
+    def __init__(self, *args, **kwargs):
+        Element.__init__(self, *args, **kwargs)
+        self.ownerDocument = None
 
 
 def is_valid_xml_tag(tag):
@@ -35,7 +49,7 @@ def node(*args, **kwargs):
     blocked_attributes = ['tag']
     tag = args[0] if len(args) > 0 else kwargs['tag']
     args = args[1:]
-    result = Element(tag)
+    result = DetachableElement(tag)
     unicode_args = [u for u in args if type(u) == unicode]
     assert len(unicode_args) <= 1
     parsedString = False
@@ -63,7 +77,7 @@ def node(*args, **kwargs):
         text_node.data = unicode_args[0]
         result.appendChild(text_node)
     for n in args:
-        if type(n) == int or type(n) == float or type(n) == str:
+        if type(n) == int or type(n) == float:
             text_node = Text()
             text_node.data = unicode(n)
             result.appendChild(text_node)

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -77,7 +77,7 @@ def node(*args, **kwargs):
         text_node.data = unicode_args[0]
         result.appendChild(text_node)
     for n in args:
-        if type(n) == int or type(n) == float:
+        if type(n) == int or type(n) == float or type(n) == bytes:
             text_node = Text()
             text_node.data = unicode(n)
             result.appendChild(text_node)

--- a/requirements.pip
+++ b/requirements.pip
@@ -4,3 +4,4 @@ lxml==3.5.0
 modilabs-python-utils==0.1.5
 xlrd==0.9.4
 unittest2==1.1.0
+unicodecsv==0.14.1

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
-nose==1.0.0
-FormEncode==1.2.4
-lxml==2.3.4
+nose==1.3.7
+FormEncode==1.3
+lxml==3.5.0
 modilabs-python-utils==0.1.5
-xlrd==0.8.0
-unittest2==0.5.1
+xlrd==0.9.4
+unittest2==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description='A Python package to create XForms for ODK Collect.',
     long_description=open('README.rst', 'rt').read(),
     install_requires=[
-        'xlrd==0.8.0',
-        'lxml==2.3.4',
+        'xlrd==0.9.4',
+        'lxml==3.5.0',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,6 @@ setup(
         'xlrd==0.9.4',
         'lxml==3.5.0',
     ],
+    use_2to3=True,
+    use_2to3_fixers=['fixers'],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires=[
         'xlrd==0.9.4',
         'lxml==3.5.0',
+        'unicodecsv==0.14.1',
     ],
     use_2to3=True,
     use_2to3_fixers=['fixers'],

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,21 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name='pyxform',
     version='0.9.22',
     author='modilabs',
     author_email='info@modilabs.org',
-    packages=['pyxform', 'pyxform.odk_validate'],
-    package_dir={'pyxform': 'pyxform'},
+    packages=find_packages(),
     package_data={
-        'pyxform': [
-            'odk_validate/ODK_Validate.jar',
+        'pyxform.odk_validate': [
+            'ODK_Validate.jar',
         ],
+        'pyxform.tests': [
+            'example_xls/*.*',
+            'bug_example_xls/*.*',
+            'test_output/*.*',
+            'test_expected_output/*.*',
+        ]
     },
     url='http://pypi.python.org/pypi/pyxform/',
     description='A Python package to create XForms for ODK Collect.',


### PR DESCRIPTION
Hi all, this is a patch to add support for Python 3 (see #53).  Most of the actual work is done by [setuptools' use_2to3 option](https://pythonhosted.org/setuptools/python3.html) during install, which fortunately means the actual code changes are minimal.  I did have to make a few changes to deal with different expectations regarding binary file modes, DOM element initialization, and dictionary key ordering.

I broke this up into multiple commits to make it easier to test each change separately.  Let me know if you would like separate pull requests for any of this as well.