### PR TITLE
use built-in xml.etree rather than lxml

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -9,8 +9,9 @@ import re
 from odk_validate import check_xform
 from survey_element import SurveyElement
 from errors import PyXFormError
-import constants
+from pyxform import constants
 import os
+import xml.etree.ElementTree as ET
 
 
 nsmap = {
@@ -22,6 +23,9 @@ nsmap = {
     u"xmlns:orx": u"http://openrosa.org/xforms"
     }
 
+for prefix, uri in nsmap.items():
+    prefix = prefix.replace("xmlns", "").replace(":", "")
+    ET.register_namespace(prefix, uri)
 
 class Survey(Section):
 

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -1,5 +1,5 @@
 import re
-from lxml import etree
+import xml.etree.ElementTree as ET
 from unittest import TestCase
 from pyxform.builder import SurveyElementBuilder, create_survey_from_xls
 from pyxform.xls2json import print_pyobj_to_json
@@ -20,8 +20,8 @@ class BuilderTests(TestCase):
 #        path = utils.path_to_text_fixture('widgets.xml')
 #        survey.to_xml
 #        with open(path) as f:
-#            expected = etree.fromstring(survey.to_xml())
-#            result = etree.fromstring(f.read())
+#            expected = ET.fromstring(survey.to_xml())
+#            result = ET.fromstring(f.read())
 #            self.assertTrue(xml_compare(expected, result))
 
     def test_unknown_question_type(self):
@@ -567,7 +567,7 @@ class BuilderTests(TestCase):
             "settings", filetype=FIXTURE_FILETYPE)
         xml = survey.to_xml()
         # find the body tag
-        root_elm = etree.fromstring(xml)
+        root_elm = ET.fromstring(xml.encode('utf-8'))
         body_elms = filter(
             lambda e: self.STRIP_NS_FROM_TAG_RE.sub('', e.tag) == 'body',
             [c for c in root_elm.getchildren()])
@@ -579,7 +579,7 @@ class BuilderTests(TestCase):
             "style_settings", filetype=FIXTURE_FILETYPE)
         xml = survey.to_xml()
         # find the body tag
-        root_elm = etree.fromstring(xml)
+        root_elm = ET.fromstring(xml.encode('utf-8'))
         body_elms = filter(
             lambda e: self.STRIP_NS_FROM_TAG_RE.sub('', e.tag) == 'body',
             [c for c in root_elm.getchildren()])

--- a/pyxform/tests/j2x_question_tests.py
+++ b/pyxform/tests/j2x_question_tests.py
@@ -15,7 +15,7 @@ TESTING_BINDINGS = True
 def ctw(control):
     """
     ctw stands for control_test_wrap, but ctw is shorter and easier. using begin_str and end_str to
-    take out the wrap that lxml gives us
+    take out the wrap that xml gives us
     """
     return control.toxml()
 

--- a/pyxform/tests/tests_by_file.py
+++ b/pyxform/tests/tests_by_file.py
@@ -4,7 +4,7 @@ with a matching prefix before the . is as expected. Possibly risky: all tests in
 are defined according to matching files. 
 """
 
-from lxml import etree
+import xml.etree.ElementTree as ET
 from formencode.doctest_xml_compare import xml_compare
 from unittest import TestCase
 import pyxform
@@ -34,8 +34,8 @@ class main_test(TestCase):
             
             #Compare with the expected output:
             with codecs.open(path_to_expected_xform, 'rb', encoding="utf-8") as expected_file:
-                expected = etree.fromstring(expected_file.read())
-                result = etree.fromstring(survey.to_xml())
+                expected = ET.fromstring(expected_file.read())
+                result = ET.fromstring(survey.to_xml())
                 reporter = lambda x: sys.stdout.write(x + "\n")
                 self.assertTrue(xml_compare(expected, result, reporter=reporter))
             os.remove(path_to_output_xform)

--- a/pyxform/tests/utils.py
+++ b/pyxform/tests/utils.py
@@ -2,7 +2,7 @@ import os
 from pyxform import file_utils
 from pyxform.builder import create_survey, create_survey_from_path
 from unittest2 import TestCase
-from lxml import etree
+import xml.etree.ElementTree as ET
 from formencode.doctest_xml_compare import xml_compare
 
 
@@ -39,8 +39,8 @@ class XFormTestCase(TestCase):
     """
 
     def assertXFormEqual(self, xform1, xform2):
-        xform1 = etree.fromstring(xform1)
-        xform2 = etree.fromstring(xform2)
+        xform1 = ET.fromstring(xform1.encode('utf-8'))
+        xform2 = ET.fromstring(xform2.encode('utf-8'))
 
         # Sort tags under <model> section in each form
         self.sort_model(xform1)

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 from unittest import TestCase
 from pyxform.errors import PyXFormError
-from lxml import etree
+import xml.etree.ElementTree as ET
 import re
 import tempfile
 import codecs
@@ -12,6 +12,7 @@ from pyxform.xls2json import workbook_to_json
 from pyxform.builder import create_survey_element_from_dict
 from pyxform.odk_validate import check_xform, ODKValidateError
 import os
+from pyxform.survey import nsmap
 
 
 class PyxformTestError(Exception):
@@ -71,14 +72,17 @@ class PyxformTestCase(TestCase):
                     kwargs.get('ss_structure'), kwargs)
 
             xml = survey._to_pretty_xml()
-            root = etree.fromstring(xml)
+            root = ET.fromstring(xml.encode('utf-8'))
+
+            # Ensure all namespaces are present, even if unused
+            root.attrib.update(**nsmap)
 
             xml_nodes['xml'] = root
 
             def _pull_xml_node_from_root(element_selector):
                 NS = 'http://www.w3.org/2002/xforms'
-                _r = etree.XPath('//n:%s' % element_selector,
-                                 namespaces={'n': NS})(root)
+                _r = root.findall('.//n:%s' % element_selector,
+                                  namespaces={'n': NS})
                 if len(_r) == 0:
                     return False
                 else:
@@ -145,7 +149,7 @@ class PyxformTestCase(TestCase):
             for code in ['xml', 'instance', 'model', 'itext']:
                 (code__str, checker) = _check_contains(code)
                 if kwargs.get(code__str):
-                    checker(etree.tounicode(xml_nodes[code]))
+                    checker(ET.tostring(xml_nodes[code], encoding='utf-8').decode('utf-8'))
                 bad_kwarg = '%s_contains' % code
                 if bad_kwarg in kwargs:
                     good_kwarg = '%s__contains' % code
@@ -224,7 +228,9 @@ class PyxformTestCase(TestCase):
         if msg_prefix:
             msg_prefix += ": "
 
+        # Account for space in self-closing tags
         text_repr = repr(text)
+        content = content.replace(" />", "/>")
         real_count = content.count(text)
 
         return (text_repr, real_count, msg_prefix)

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,5 @@
 nose==1.3.7
 FormEncode==1.3
-lxml==3.5.0
 modilabs-python-utils==0.1.5
 xlrd==0.9.4
 unittest2==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     long_description=open('README.rst', 'rt').read(),
     install_requires=[
         'xlrd==0.9.4',
-        'lxml==3.5.0',
         'unicodecsv==0.14.1',
     ],
     use_2to3=True,


### PR DESCRIPTION
This makes installing on various platforms a bit easier since there's one less thing to compile.  The API for `xml.etree.ElementTree` covers most of what `lxml.etree` provides, with some minor differences.