### PR TITLE
Changed "from pyxform import constants" to "import constants" in survey.py

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -9,7 +9,7 @@ import re
 from odk_validate import check_xform
 from survey_element import SurveyElement
 from errors import PyXFormError
-from pyxform import constants
+import constants
 
 
 nsmap = {


### PR DESCRIPTION
Hi, I just tried to use xls2xform from a fresh download, and got an error related to the import of constants in survey.py.  Turns out the import read 'from pyxform import constants', so it was looking for a file called pyxform.py.  I changed the import to read simply 'import constants' (referring to constants.py, which does exist and appears to contain the relevant code), this appears to have fixed the problem; I can now convert forms from the command line.  

I don't know the codebase, so I may very well have missed some other reason why this is not correct. I'm fine working from my temporary fork if you don't want to merge this, or if you want to take the time to do something more sensible!  

Thanks (and thanks for creating this; it's incredibly useful to me and the organizations I work for, Medecins Sans Frontieres and the Red Cross)!