### PR TITLE
We should not add default hints into forms

### DIFF
--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -381,8 +381,7 @@ QUESTION_TYPE_DICT = \
             },
             "bind": {
                 "type": "geopoint"
-            },
-            "hint": "GPS coordinates can only be collected when outside."
+            }
         },
         "geoshape": {
             "control": {
@@ -390,8 +389,7 @@ QUESTION_TYPE_DICT = \
             },
             "bind": {
                 "type": "geoshape"
-            },
-            "hint": "GPS coordinates can only be collected when outside."
+            }
         },
         "geotrace": {
             "control": {
@@ -399,8 +397,7 @@ QUESTION_TYPE_DICT = \
             },
             "bind": {
                 "type": "geotrace"
-            },
-            "hint": "GPS coordinates can only be collected when outside."
+            }
         },
         "select multiple from": {
             "control": {
@@ -542,8 +539,7 @@ QUESTION_TYPE_DICT = \
             },
             "bind": {
                 "type": "geopoint"
-            },
-            "hint": "GPS coordinates can only be collected when outside."
+            }
         },
         "q date": {
             "control": {

--- a/pyxform/tests/example_xls/spec_test_expected_output.xml
+++ b/pyxform/tests/example_xls/spec_test_expected_output.xml
@@ -850,7 +850,6 @@
       </input>
       <input ref="/xlsform_spec_test/everything/geopoint_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/geopoint_test:label')"/>
-        <hint>GPS coordinates can only be collected when outside.</hint>
       </input>
       <input ref="/xlsform_spec_test/everything/barcode_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/barcode_test:label')"/>

--- a/pyxform/tests/test_expected_output/attribute_columns_test.xml
+++ b/pyxform/tests/test_expected_output/attribute_columns_test.xml
@@ -904,7 +904,6 @@
       </input>
       <input bodyAttribute="test" bodyAttribute2="test" ref="/attribute_columns_test/everything/geopoint_test">
         <label ref="jr:itext('/attribute_columns_test/everything/geopoint_test:label')"/>
-        <hint>GPS coordinates can only be collected when outside.</hint>
       </input>
       <input bodyAttribute="test" bodyAttribute2="test" ref="/attribute_columns_test/everything/barcode_test">
         <label ref="jr:itext('/attribute_columns_test/everything/barcode_test:label')"/>

--- a/pyxform/tests/test_expected_output/flat_xlsform_test.xml
+++ b/pyxform/tests/test_expected_output/flat_xlsform_test.xml
@@ -876,7 +876,6 @@
       </input>
       <input ref="/flat_xlsform_test/geopoint_test">
         <label ref="jr:itext('/flat_xlsform_test/geopoint_test:label')"/>
-        <hint>GPS coordinates can only be collected when outside.</hint>
       </input>
       <input ref="/flat_xlsform_test/barcode_test">
         <label ref="jr:itext('/flat_xlsform_test/barcode_test:label')"/>

--- a/pyxform/tests/test_expected_output/xlsform_spec_test.xml
+++ b/pyxform/tests/test_expected_output/xlsform_spec_test.xml
@@ -903,7 +903,6 @@
       </input>
       <input ref="/xlsform_spec_test/everything/geopoint_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/geopoint_test:label')"/>
-        <hint>GPS coordinates can only be collected when outside.</hint>
       </input>
       <input ref="/xlsform_spec_test/everything/barcode_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/barcode_test:label')"/>

--- a/pyxform/tests/test_output/attribute_columns_test.xml
+++ b/pyxform/tests/test_output/attribute_columns_test.xml
@@ -904,7 +904,6 @@
       </input>
       <input bodyAttribute="test" bodyAttribute2="test" ref="/attribute_columns_test/everything/geopoint_test">
         <label ref="jr:itext('/attribute_columns_test/everything/geopoint_test:label')"/>
-        <hint>GPS coordinates can only be collected when outside.</hint>
       </input>
       <input bodyAttribute="test" bodyAttribute2="test" ref="/attribute_columns_test/everything/barcode_test">
         <label ref="jr:itext('/attribute_columns_test/everything/barcode_test:label')"/>

--- a/pyxform/tests/test_output/flat_xlsform_test.xml
+++ b/pyxform/tests/test_output/flat_xlsform_test.xml
@@ -876,7 +876,6 @@
       </input>
       <input ref="/flat_xlsform_test/geopoint_test">
         <label ref="jr:itext('/flat_xlsform_test/geopoint_test:label')"/>
-        <hint>GPS coordinates can only be collected when outside.</hint>
       </input>
       <input ref="/flat_xlsform_test/barcode_test">
         <label ref="jr:itext('/flat_xlsform_test/barcode_test:label')"/>

--- a/pyxform/tests/test_output/xlsform_spec_test.xml
+++ b/pyxform/tests/test_output/xlsform_spec_test.xml
@@ -903,7 +903,6 @@
       </input>
       <input ref="/xlsform_spec_test/everything/geopoint_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/geopoint_test:label')"/>
-        <hint>GPS coordinates can only be collected when outside.</hint>
       </input>
       <input ref="/xlsform_spec_test/everything/barcode_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/barcode_test:label')"/>


### PR DESCRIPTION
This is behavior is not great for three reasons.

1. It's not transparent. When a user converts the form, it's not clear where the hint comes from. It took way too long to find which tool in the ecosystem was adding this (e.g., Javarosa, Collect, xlsform.opendatakit.org, pyxform)
2. It's not easy to localize. We should make things easy to localize and putting this in the source of a library makes that hard.
3. It's not that accurate. Geopoint isn't just for GPS. It has Wi-Fi and cell localization that works indoors. Also outdoors isn't sufficient to get a lock. You need to have a clear view of the sky.