### PR TITLE
Don't pip-install in developer mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Installing pyxform from remote source
 =====================================
 `pip` can install from any GitHub repository::
 
-	pip install -e git+https://github.com/XLSForm/pyxform.git@master#egg=pyxform
+	pip install git+https://github.com/XLSForm/pyxform.git@master#egg=pyxform
 
 You can then run xls2xform from the commandline::
 


### PR DESCRIPTION
From `pip help install`:

> -e, --editable <path/url>  Install a project in editable mode (i.e. setuptools
>                            "develop mode") from a local project path or a VCS
>                            url.

As the instructions above this section are for installing for developers, I
don't think it's helpful for general users to be encouraged here to install in
dev mode.