### PR TITLE
Add user facing install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,13 @@ pyxform is a major rewrite of `xls2xform <http://github.com/mvpdev/xls2xform/>`_
 
 Running the latest release of pyxform
 =====================================
+For those who want to convert forms at the command line, the latest official release of pyxform can be installed using `pip <https://en.wikipedia.org/wiki/Pip_(package_manager)>`::
+    
+    pip install pyxform
+
+The `xls2xform` command can then be used::
+
+    xls2xform path_to_XLSForm output_path
 
 Running pyxform from local source
 =================================

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ pyxform v0.9
     :target: https://travis-ci.org/XLSForm/pyxform
 
 pyxform is a Python library that makes writing XForms for ODK Collect and enketo
-easy by converting XLS(X) spreadsheets into XForms.
+easy by converting XLS(X) spreadsheets into XForms. It is used as a library in a number of tools including [the ODK online converter](http://opendatakit.org/xiframe/) and [Ona](https://ona.io).
 
 XLS(X) documents used as input must follow to the `XLSForm standard <http://xlsform.org/>`_ and the resulting output follows the `ODK XForms <https://github.com/opendatakit/xforms-spec>`_ standard. 
 
@@ -14,6 +14,9 @@ XLS(X) documents used as input must follow to the `XLSForm standard <http://xlsf
 https://github.com/modilabs/pyxform
 
 pyxform is a major rewrite of `xls2xform <http://github.com/mvpdev/xls2xform/>`_.
+
+Running the latest release of pyxform
+=====================================
 
 Running pyxform from local source
 =================================

--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,7 @@ pyxform v0.9
     :target: https://travis-ci.org/XLSForm/pyxform
 
 pyxform is a Python library that makes writing XForms for ODK Collect and enketo
-easy by converting XLS(X) spreadsheets into XForms. A new user of pyxform should
-look at the documentation `here <https://formhub.org/syntax/>`_ or
-`here <http://opendatakit.org/help/form-design/xlsform/>`_. 
+easy by converting XLS(X) spreadsheets into XForms.
 
 XLS(X) documents used as input must follow to the `XLSForm standard <http://xlsform.org/>`_ and the resulting output follows the `ODK XForms <https://github.com/opendatakit/xforms-spec>`_ standard. 
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ pyxform v0.9
     :target: https://travis-ci.org/XLSForm/pyxform
 
 pyxform is a Python library that makes writing XForms for ODK Collect and enketo
-easy by converting XLS(X) spreadsheets into XForms. It is used as a library in a number of tools including [the ODK online converter](http://opendatakit.org/xiframe/) and [Ona](https://ona.io).
+easy by converting XLS(X) spreadsheets into XForms. It is used as a library in a number of tools including `the ODK online converter <http://opendatakit.org/xiframe/>`_ and `Ona <https://ona.io>`_.
 
 XLS(X) documents used as input must follow to the `XLSForm standard <http://xlsform.org/>`_ and the resulting output follows the `ODK XForms <https://github.com/opendatakit/xforms-spec>`_ standard. 
 
@@ -17,18 +17,18 @@ pyxform is a major rewrite of `xls2xform <http://github.com/mvpdev/xls2xform/>`_
 
 Running the latest release of pyxform
 =====================================
-For those who want to convert forms at the command line, the latest official release of pyxform can be installed using `pip <https://en.wikipedia.org/wiki/Pip_(package_manager)>`::
+For those who want to convert forms at the command line, the latest official release of pyxform can be installed using `pip <https://en.wikipedia.org/wiki/Pip_(package_manager)>`_::
     
     pip install pyxform
 
-The `xls2xform` command can then be used::
+The ``xls2xform`` command can then be used::
 
     xls2xform path_to_XLSForm output_path
 
 Running pyxform from local source
 =================================
 
-Note that you must uninstall any globally installed `pyxform` instance in order to use local modules.
+Note that you must uninstall any globally installed ``pyxform`` instance in order to use local modules.
 
 From the command line::
 


### PR DESCRIPTION
I tried to make it clear that most users will want to use GUI-based tools but that those who want to use `pyxform` but not develop for it can install through `pip`.