### PR TITLE
Add support for numeric range questions

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -91,9 +91,7 @@ survey_header = {
     u"required_message": u"bind::jr:requiredMsg",
     u"required message": u"bind::jr:requiredMsg",
     u"body": u"control",
-    u"properties": u"properties",
-    u"parameters": u"properties",
-    u"attributes": u"properties",
+    u"parameters": u"parameters",
 }
 list_header = {
     u"caption": constants.LABEL,

--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -90,7 +90,8 @@ survey_header = {
     u"requiredMsg": u"bind::jr:requiredMsg",
     u"required_message": u"bind::jr:requiredMsg",
     u"required message": u"bind::jr:requiredMsg",
-    u"body": u"control"
+    u"body": u"control",
+    u"properties": u"properties",
 }
 list_header = {
     u"caption": constants.LABEL,

--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -92,6 +92,8 @@ survey_header = {
     u"required message": u"bind::jr:requiredMsg",
     u"body": u"control",
     u"properties": u"properties",
+    u"parameters": u"properties",
+    u"attributes": u"properties",
 }
 list_header = {
     u"caption": constants.LABEL,

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -1,16 +1,16 @@
 import copy
-from pyxform import file_utils
 import os
-from pyxform import utils
 
+from pyxform import file_utils, utils
 from pyxform.errors import PyXFormError
-from pyxform.section import RepeatingSection, GroupedSection
-from pyxform.survey import Survey
-from pyxform.question import Question, InputQuestion, TriggerQuestion, \
-    UploadQuestion, MultipleChoiceQuestion, OsmUploadQuestion
+from pyxform.question import (InputQuestion, MultipleChoiceQuestion,
+                              OsmUploadQuestion, Question, RangeQuestion,
+                              TriggerQuestion, UploadQuestion)
 from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
-from pyxform.xls2json import SurveyReader
+from pyxform.section import GroupedSection, RepeatingSection
+from pyxform.survey import Survey
 from pyxform.utils import unicode
+from pyxform.xls2json import SurveyReader
 
 
 def copy_json_dict(json_dict):
@@ -46,6 +46,7 @@ class SurveyElementBuilder(object):
         u"select1": MultipleChoiceQuestion,
         u"upload": UploadQuestion,
         u"osm": OsmUploadQuestion,
+        u'range': RangeQuestion,
         }
 
     SECTION_CLASSES = {

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -257,7 +257,8 @@ class RangeQuestion(Question):
             control_dict[key] = survey.insert_xpaths(value)
         control_dict['ref'] = self.get_xpath()
         props = self.get('properties', {})
-        result = node(**control_dict, **props)
+        control_dict.update(props)
+        result = node(**control_dict)
         if label_and_hint:
             for element in self.xml_label_and_hint():
                 result.appendChild(element)

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -1,8 +1,9 @@
 import os.path
-from pyxform.utils import node, unicode, basestring
-from pyxform.survey_element import SurveyElement
-from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
+
 from pyxform.errors import PyXFormError
+from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
+from pyxform.survey_element import SurveyElement
+from pyxform.utils import basestring, node, unicode
 
 
 class Question(SurveyElement):
@@ -238,5 +239,27 @@ class OsmUploadQuestion(UploadQuestion):
 
         for osm_tag in self.children:
             result.appendChild(osm_tag.xml())
+
+        return result
+
+
+class RangeQuestion(Question):
+    """
+    This control string is the same for: strings, integers, decimals,
+    dates, geopoints, barcodes ...
+    """
+    def xml_control(self):
+        control_dict = self.control
+        label_and_hint = self.xml_label_and_hint()
+        survey = self.get_root()
+        # Resolve field references in attributes
+        for key, value in control_dict.items():
+            control_dict[key] = survey.insert_xpaths(value)
+        control_dict['ref'] = self.get_xpath()
+        props = self.get('properties', {})
+        result = node(**control_dict, **props)
+        if label_and_hint:
+            for element in self.xml_label_and_hint():
+                result.appendChild(element)
 
         return result

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -256,8 +256,8 @@ class RangeQuestion(Question):
         for key, value in control_dict.items():
             control_dict[key] = survey.insert_xpaths(value)
         control_dict['ref'] = self.get_xpath()
-        props = self.get('properties', {})
-        control_dict.update(props)
+        params = self.get('parameters', {})
+        control_dict.update(params)
         result = node(**control_dict)
         if label_and_hint:
             for element in self.xml_label_and_hint():

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -844,4 +844,12 @@ QUESTION_TYPE_DICT = \
                 "type": "binary"
             }
         },
+        "range": {
+            "control": {
+                "tag": "range"
+            },
+            "bind": {
+                "type": "int"
+            }
+        },
     }

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -31,7 +31,7 @@ class SurveyElement(dict):
         u"default": unicode,
         u"type": unicode,
         u"appearance": unicode,
-        u"properties": unicode,
+        u"parameters": unicode,
         u"intent": unicode,
         u"jr:count": unicode,
         u"bind": dict,

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -31,6 +31,7 @@ class SurveyElement(dict):
         u"default": unicode,
         u"type": unicode,
         u"appearance": unicode,
+        u"properties": unicode,
         u"intent": unicode,
         u"jr:count": unicode,
         u"bind": dict,

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -3,20 +3,6 @@ from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 
 class RangeWidgetTest(PyxformTestCase):
     def test_range_type(self):
-        # properties column
-        self.assertPyxformXform(
-            debug=True,
-            name="data",
-            md="""
-            | survey |        |          |       |                     |
-            |        | type   |   name   | label | properties          |
-            |        | range  |   level  | Scale | min=1 max=10 step=1 |
-            """,
-            xml__contains=[
-                '<bind nodeset="/data/level" type="int"/>',
-                '<range end="10" ref="/data/level" start="1" step="1">'],
-        )
-
         # parameters column
         self.assertPyxformXform(
             debug=True,
@@ -24,25 +10,11 @@ class RangeWidgetTest(PyxformTestCase):
             md="""
             | survey |        |          |       |                     |
             |        | type   |   name   | label | parameters          |
-            |        | range  |   level  | Scale | min=1 max=10 step=2 |
+            |        | range  |   level  | Scale | min=1 max=10 step=1 |
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="int"/>',
-                '<range end="10" ref="/data/level" start="1" step="2">'],
-        )
-
-        # attributes column
-        self.assertPyxformXform(
-            debug=True,
-            name="data",
-            md="""
-            | survey |        |          |       |                     |
-            |        | type   |   name   | label | attributes          |
-            |        | range  |   level  | Scale | min=1 max=10 step=2 |
-            """,
-            xml__contains=[
-                '<bind nodeset="/data/level" type="int"/>',
-                '<range end="10" ref="/data/level" start="1" step="2">'],
+                '<range end="10" ref="/data/level" start="1" step="1">'],
         )
 
         # mixed case parameters
@@ -51,7 +23,7 @@ class RangeWidgetTest(PyxformTestCase):
             name="data",
             md="""
             | survey |        |          |       |                     |
-            |        | type   |   name   | label | properties          |
+            |        | type   |   name   | label | parameters          |
             |        | range  |   level  | Scale | Min=3 Max=14 STEP=2 |
             """,
             xml__contains=[
@@ -65,7 +37,7 @@ class RangeWidgetTest(PyxformTestCase):
             name="data",
             md="""
             | survey |        |          |       |                     |
-            |        | type   |   name   | label | properties          |
+            |        | type   |   name   | label | parameters          |
             |        | range  |   level  | Scale |                     |
             """,
             xml__contains=[
@@ -78,7 +50,7 @@ class RangeWidgetTest(PyxformTestCase):
             name="data",
             md="""
             | survey |        |          |       |                     |
-            |        | type   |   name   | label | properties          |
+            |        | type   |   name   | label | parameters          |
             |        | range  |   level  | Scale | max=20              |
             """,
             xml__contains=[
@@ -105,7 +77,7 @@ class RangeWidgetTest(PyxformTestCase):
             name="data",
             md="""
             | survey |        |          |       |                     |
-            |        | type   |   name   | label | properties          |
+            |        | type   |   name   | label | parameters          |
             |        | range  |   level  | Scale | min=0.5 max=5.0 step=0.5 |
             """,
             xml__contains=[
@@ -120,7 +92,7 @@ class RangeWidgetTest(PyxformTestCase):
             name="data",
             md="""
             | survey |        |          |       |                        |
-            |        | type   |   name   | label | properties             |
+            |        | type   |   name   | label | parameters             |
             |        | range  |   level  | Scale | increment=0.5 max=21.5 |
             """,
             errored=True,
@@ -130,7 +102,7 @@ class RangeWidgetTest(PyxformTestCase):
             name="data",
             md="""
             | survey |        |          |       |                     |
-            |        | type   |   name   | label | properties          |
+            |        | type   |   name   | label | parameters          |
             |        | range  |   level  | Scale | min=0.5 max=X step=0.5 |
             """,
             errored=True,

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -91,7 +91,6 @@ class RangeWidgetTest(PyxformTestCase):
             errored=True,
         )
 
-        # end=X
         self.assertPyxformXform(
             name="data",
             md="""
@@ -110,4 +109,30 @@ class RangeWidgetTest(PyxformTestCase):
             |        | range  |   level  | Scale | start               |
             """,
             errored=True,
+        )
+
+    def test_range_semicolon_separator(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                       |
+            |        | type   |   name   | label | parameters            |
+            |        | range  |   level  | Scale | start=1;end=10;step=1 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="1">'],
+        )
+
+    def test_range_comma_separator(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                       |
+            |        | type   |   name   | label | parameters            |
+            |        | range  |   level  | Scale | start=1,end=10,step=1 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="1">'],
         )

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -5,7 +5,6 @@ class RangeWidgetTest(PyxformTestCase):
     def test_range_type(self):
         # parameters column
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |                     |
@@ -19,7 +18,6 @@ class RangeWidgetTest(PyxformTestCase):
 
         # mixed case parameters
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |                     |
@@ -33,7 +31,6 @@ class RangeWidgetTest(PyxformTestCase):
 
     def test_range_type_defaults(self):
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |                     |
@@ -46,7 +43,6 @@ class RangeWidgetTest(PyxformTestCase):
         )
 
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |                     |
@@ -59,7 +55,6 @@ class RangeWidgetTest(PyxformTestCase):
         )
 
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |
@@ -73,7 +68,6 @@ class RangeWidgetTest(PyxformTestCase):
 
     def test_range_type_float(self):
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |                     |
@@ -88,7 +82,6 @@ class RangeWidgetTest(PyxformTestCase):
     def test_range_type_invvalid_parameters(self):
         # 'increment' is an invalid property
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |                        |
@@ -98,7 +91,6 @@ class RangeWidgetTest(PyxformTestCase):
             errored=True,
         )
         self.assertPyxformXform(
-            debug=True,
             name="data",
             md="""
             | survey |        |          |       |                     |

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -10,7 +10,7 @@ class RangeWidgetTest(PyxformTestCase):
             md="""
             | survey |        |          |       |                     |
             |        | type   |   name   | label | parameters          |
-            |        | range  |   level  | Scale | min=1 max=10 step=1 |
+            |        | range  |   level  | Scale | start=1 end=10 step=1 |
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="int"/>',
@@ -24,7 +24,7 @@ class RangeWidgetTest(PyxformTestCase):
             md="""
             | survey |        |          |       |                     |
             |        | type   |   name   | label | parameters          |
-            |        | range  |   level  | Scale | Min=3 Max=14 STEP=2 |
+            |        | range  |   level  | Scale | Start=3 End=14 STEP=2 |
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="int"/>',
@@ -51,7 +51,7 @@ class RangeWidgetTest(PyxformTestCase):
             md="""
             | survey |        |          |       |                     |
             |        | type   |   name   | label | parameters          |
-            |        | range  |   level  | Scale | max=20              |
+            |        | range  |   level  | Scale | end=20              |
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="int"/>',
@@ -78,7 +78,7 @@ class RangeWidgetTest(PyxformTestCase):
             md="""
             | survey |        |          |       |                     |
             |        | type   |   name   | label | parameters          |
-            |        | range  |   level  | Scale | min=0.5 max=5.0 step=0.5 |
+            |        | range  |   level  | Scale | start=0.5 end=5.0 step=0.5 |
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="decimal"/>',
@@ -93,7 +93,7 @@ class RangeWidgetTest(PyxformTestCase):
             md="""
             | survey |        |          |       |                        |
             |        | type   |   name   | label | parameters             |
-            |        | range  |   level  | Scale | increment=0.5 max=21.5 |
+            |        | range  |   level  | Scale | increment=0.5 end=21.5 |
             """,
             errored=True,
         )
@@ -103,7 +103,7 @@ class RangeWidgetTest(PyxformTestCase):
             md="""
             | survey |        |          |       |                     |
             |        | type   |   name   | label | parameters          |
-            |        | range  |   level  | Scale | min=0.5 max=X step=0.5 |
+            |        | range  |   level  | Scale | start=0.5 end=X step=0.5 |
             """,
             errored=True,
         )

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -1,0 +1,31 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class RangeWidgetTest(PyxformTestCase):
+    def test_range_type(self):
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | properties          |
+            |        | range  |   level  | Scale | min=1 max=10 step=1 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="1">'],
+        )
+
+    def test_range_type_float(self):
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | properties          |
+            |        | range  |   level  | Scale | min=0.5 max=5.0 step=0.5 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="decimal"/>',
+                '<range end="5.0" ref="/data/level" start="0.5" step="0.5">'],
+        )

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -90,12 +90,24 @@ class RangeWidgetTest(PyxformTestCase):
             """,
             errored=True,
         )
+
+        # end=X
         self.assertPyxformXform(
             name="data",
             md="""
             | survey |        |          |       |                     |
             |        | type   |   name   | label | parameters          |
             |        | range  |   level  | Scale | start=0.5 end=X step=0.5 |
+            """,
+            errored=True,
+        )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | parameters          |
+            |        | range  |   level  | Scale | start               |
             """,
             errored=True,
         )

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -136,3 +136,27 @@ class RangeWidgetTest(PyxformTestCase):
                 '<bind nodeset="/data/level" type="int"/>',
                 '<range end="10" ref="/data/level" start="1" step="1">'],
         )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                           |
+            |        | type   |   name   | label | parameters                |
+            |        | range  |   level  | Scale | start=1 , end=10 , step=1 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="1">'],
+        )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                                 |
+            |        | type   |   name   | label | parameters                      |
+            |        | range  |   level  | Scale | start = 1 , end = 10 , step = 2 |
+            """,  # noqa
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="2">'],
+        )

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -16,6 +16,19 @@ class RangeWidgetTest(PyxformTestCase):
                 '<range end="10" ref="/data/level" start="1" step="1">'],
         )
 
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | properties          |
+            |        | range  |   level  | Scale | Min=3 Max=14 STEP=2 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="14" ref="/data/level" start="3" step="2">'],
+        )
+
     def test_range_type_defaults(self):
         self.assertPyxformXform(
             debug=True,
@@ -68,4 +81,27 @@ class RangeWidgetTest(PyxformTestCase):
             xml__contains=[
                 '<bind nodeset="/data/level" type="decimal"/>',
                 '<range end="5.0" ref="/data/level" start="0.5" step="0.5">'],
+        )
+
+    def test_range_type_invvalid_parameters(self):
+        # 'increment' is an invalid property
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                        |
+            |        | type   |   name   | label | properties             |
+            |        | range  |   level  | Scale | increment=0.5 max=21.5 |
+            """,
+            errored=True,
+        )
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | properties          |
+            |        | range  |   level  | Scale | min=0.5 max=X step=0.5 |
+            """,
+            errored=True,
         )

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -3,6 +3,7 @@ from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 
 class RangeWidgetTest(PyxformTestCase):
     def test_range_type(self):
+        # properties column
         self.assertPyxformXform(
             debug=True,
             name="data",
@@ -16,6 +17,35 @@ class RangeWidgetTest(PyxformTestCase):
                 '<range end="10" ref="/data/level" start="1" step="1">'],
         )
 
+        # parameters column
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | parameters          |
+            |        | range  |   level  | Scale | min=1 max=10 step=2 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="2">'],
+        )
+
+        # attributes column
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | attributes          |
+            |        | range  |   level  | Scale | min=1 max=10 step=2 |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="2">'],
+        )
+
+        # mixed case parameters
         self.assertPyxformXform(
             debug=True,
             name="data",

--- a/pyxform/tests_v1/test_range.py
+++ b/pyxform/tests_v1/test_range.py
@@ -16,6 +16,46 @@ class RangeWidgetTest(PyxformTestCase):
                 '<range end="10" ref="/data/level" start="1" step="1">'],
         )
 
+    def test_range_type_defaults(self):
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | properties          |
+            |        | range  |   level  | Scale |                     |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="1">'],
+        )
+
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | properties          |
+            |        | range  |   level  | Scale | max=20              |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="20" ref="/data/level" start="1" step="1">'],
+        )
+
+        self.assertPyxformXform(
+            debug=True,
+            name="data",
+            md="""
+            | survey |        |          |       |
+            |        | type   |   name   | label |
+            |        | range  |   level  | Scale |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/level" type="int"/>',
+                '<range end="10" ref="/data/level" start="1" step="1">'],
+        )
+
     def test_range_type_float(self):
         self.assertPyxformXform(
             debug=True,

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -283,9 +283,9 @@ def process_range_question_type(row):
             raise PyXFormError("Expecting parameters to be in the form of "
                                "'start=X end=X step=X'.")
         k, v = param.split('=')[:2]
-        key = parameters_map.get(k.lower())
+        key = parameters_map.get(k.lower().strip())
         if key:
-            params[key] = v
+            params[key] = v.strip()
         else:
             raise PyXFormError(
                 "Range has the parameters 'start', 'end' and"

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -259,30 +259,30 @@ def add_flat_annotations(prompt_list, parent_relevant='', name_prefix=''):
 
 def process_range_question_type(row):
     new_dict = row.copy()
-    properties = new_dict.get('properties', '')
-    properties_map = {'min': 'start', 'max': 'end', 'step': 'step'}
+    parameters = new_dict.get('parameters', '')
+    parameters_map = {'min': 'start', 'max': 'end', 'step': 'step'}
     defaults = {'start': '1', 'end': '10', 'step': '1'}
-    props = {}
-    for prop in properties.split():
+    params = {}
+    for prop in parameters.split():
         k, v = prop.split('=')
-        key = properties_map.get(k.lower())
+        key = parameters_map.get(k.lower())
         if key:
-            props[key] = v
+            params[key] = v
         else:
             raise PyXFormError(
-                "Range properties have the properties 'min', 'max' and"
+                "Range parameters have the parameters 'min', 'max' and"
                 " 'step': '%s' is invalid." % k)
 
     # set defaults
-    for key in properties_map.values():
-        if key not in props:
-            props[key] = defaults[key]
+    for key in parameters_map.values():
+        if key not in params:
+            params[key] = defaults[key]
 
     try:
         has_float = any(
-            [float(x) and '.' in str(x) for x in props.values()])
+            [float(x) and '.' in str(x) for x in params.values()])
     except ValueError:
-        raise PyXFormError("Range properties 'min', "
+        raise PyXFormError("Range parameters 'min', "
                            "'max' or 'step' must all be numbers.")
     else:
         # is integer by default, convert to decimal if it has any float values
@@ -290,7 +290,7 @@ def process_range_question_type(row):
             new_dict['bind'] = new_dict.get('bind', {})
             new_dict['bind'].update({'type': 'decimal'})
 
-    new_dict['properties'] = props
+    new_dict['parameters'] = params
 
     return new_dict
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -268,11 +268,11 @@ def process_range_question_type(row):
     parameters_map = {'start': 'start', 'end': 'end', 'step': 'step'}
     defaults = {'start': '1', 'end': '10', 'step': '1'}
     params = {}
-    for prop in parameters.split():
-        if '=' not in prop:
+    for param in parameters.split():
+        if '=' not in param:
             raise PyXFormError("Expecting parameters to be in the form of "
                                "'start=X end=X step=X'.")
-        k, v = prop.split('=')
+        k, v = param.split('=')[:2]
         key = parameters_map.get(k.lower())
         if key:
             params[key] = v

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -258,9 +258,14 @@ def add_flat_annotations(prompt_list, parent_relevant='', name_prefix=''):
 
 
 def process_range_question_type(row):
+    """Returns a new row that includes the Range parameters start, end and
+    step.
+
+    Raises PyXFormError when invalid range parameters are used.
+    """
     new_dict = row.copy()
     parameters = new_dict.get('parameters', '')
-    parameters_map = {'min': 'start', 'max': 'end', 'step': 'step'}
+    parameters_map = {'start': 'start', 'end': 'end', 'step': 'step'}
     defaults = {'start': '1', 'end': '10', 'step': '1'}
     params = {}
     for prop in parameters.split():
@@ -270,7 +275,7 @@ def process_range_question_type(row):
             params[key] = v
         else:
             raise PyXFormError(
-                "Range parameters have the parameters 'min', 'max' and"
+                "Range parameters have the parameters 'start', 'end' and"
                 " 'step': '%s' is invalid." % k)
 
     # set defaults
@@ -282,8 +287,8 @@ def process_range_question_type(row):
         has_float = any(
             [float(x) and '.' in str(x) for x in params.values()])
     except ValueError:
-        raise PyXFormError("Range parameters 'min', "
-                           "'max' or 'step' must all be numbers.")
+        raise PyXFormError("Range parameters 'start', "
+                           "'end' or 'step' must all be numbers.")
     else:
         # is integer by default, convert to decimal if it has any float values
         if has_float:

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -986,8 +986,10 @@ def organize_by_values(dict_list, key):
 class SpreadsheetReader(object):
     def __init__(self, path_or_file):
         path = path_or_file
-        if type(path_or_file) is file:
+        try:
             path = path.name
+        except AttributeError:
+            pass
         self._dict = parse_file_to_workbook_dict(path)
         self._path = path
         self._id = unicode(get_filename(path))

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -265,9 +265,13 @@ def process_range_question_type(row):
     props = {}
     for prop in properties.split():
         k, v = prop.split('=')
-        key = properties_map.get(k)
+        key = properties_map.get(k.lower())
         if key:
             props[key] = v
+        else:
+            raise PyXFormError(
+                "Range properties have the properties 'min', 'max' and"
+                " 'step': '%s' is invalid." % k)
 
     # set defaults
     for key in properties_map.values():

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -261,12 +261,19 @@ def process_range_question_type(row):
     new_dict = row.copy()
     properties = new_dict.get('properties', '')
     properties_map = {'min': 'start', 'max': 'end', 'step': 'step'}
+    defaults = {'start': '1', 'end': '10', 'step': '1'}
     props = {}
     for prop in properties.split():
         k, v = prop.split('=')
         key = properties_map.get(k)
         if key:
             props[key] = v
+
+    # set defaults
+    for key in properties_map.values():
+        if key not in props:
+            props[key] = defaults[key]
+
     try:
         has_float = any(
             [float(x) and '.' in str(x) for x in props.values()])

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -263,12 +263,22 @@ def process_range_question_type(row):
 
     Raises PyXFormError when invalid range parameters are used.
     """
+    def _parameters(parameters):
+        parts = parameters.split(';')
+        if len(parts) == 1:
+            parts = parameters.split(',')
+        if len(parts) == 1:
+            parts = parameters.split()
+
+        return parts
+
     new_dict = row.copy()
-    parameters = new_dict.get('parameters', '')
+    parameters = _parameters(new_dict.get('parameters', ''))
     parameters_map = {'start': 'start', 'end': 'end', 'step': 'step'}
     defaults = {'start': '1', 'end': '10', 'step': '1'}
     params = {}
-    for param in parameters.split():
+
+    for param in parameters:
         if '=' not in param:
             raise PyXFormError("Expecting parameters to be in the form of "
                                "'start=X end=X step=X'.")

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -275,8 +275,8 @@ def process_range_question_type(row):
             params[key] = v
         else:
             raise PyXFormError(
-                "Range parameters have the parameters 'start', 'end' and"
-                " 'step': '%s' is invalid." % k)
+                "Range has the parameters 'start', 'end' and"
+                " 'step': '%s' is an invalid parameter." % k)
 
     # set defaults
     for key in parameters_map.values():

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -269,6 +269,9 @@ def process_range_question_type(row):
     defaults = {'start': '1', 'end': '10', 'step': '1'}
     params = {}
     for prop in parameters.split():
+        if '=' not in prop:
+            raise PyXFormError("Expecting parameters to be in the form of "
+                               "'start=X end=X step=X'.")
         k, v = prop.split('=')
         key = parameters_map.get(k.lower())
         if key:


### PR DESCRIPTION
See details in #79 

- [x] introduce a new column called parameters, attributes or properties
- [x] use name/value pairs separated by `=` in those cells
- [x] separate name/value pairs by spaces or comma or semicolon.
- [x] for `range`, allow `min`, `max` and `step` with defaults `1`, `10` and `1` respectively.