### PR TITLE
Fixed #96: Whitespace after ${} should not be trimmed

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -425,9 +425,9 @@ class Survey(Section):
         # TODO: check out pyxml
         # http://ronrothman.com/public/leftbraned/xml-dom-minidom-toprettyxml-and-silly-whitespace/
         xml_with_linebreaks = self.xml().toprettyxml(indent='  ')
-        text_re = re.compile('>\n\s+([^<>\s].*?)\n\s+</', re.DOTALL)
+        text_re = re.compile('(>)\n\s*(\s[^<>\s].*?)\n\s*(\s</)', re.DOTALL)
         output_re = re.compile('\n.*(<output.*>)\n(  )*')
-        pretty_xml = text_re.sub('>\g<1></', xml_with_linebreaks)
+        pretty_xml = text_re.sub(lambda m: ''.join(m.group(1, 2, 3)), xml_with_linebreaks)
         inline_output = output_re.sub('\g<1>', pretty_xml)
         inline_output = re.compile('<label>\s*\n*\s*\n*\s*</label>')\
             .sub('<label></label>', inline_output)

--- a/pyxform/tests_v1/test_whitespace.py
+++ b/pyxform/tests_v1/test_whitespace.py
@@ -1,0 +1,15 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+class WhitespaceTest(PyxformTestCase):
+    def test_over_trim(self):
+        self.assertPyxformXform(
+            name='issue96',
+            md="""
+            | survey  |                 |             |       |
+            |         | type            | label       | name  |
+            |         | text            | Ignored     | var   |
+            |         | note            | ${var} text | label |
+            """,
+            xml__contains=[
+                '<label><output value=" /issue96/var "/> text </label>',
+            ])


### PR DESCRIPTION
This fixes corrupted labels when they contain variable references. The problem is due to pretty printing (and subsequent attempts at whitespace compacting) as described in #96.