### PR TITLE
Add audit

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -134,7 +134,8 @@ label_optional_types = [
     u"calculate",
     u"start",
     u"end",
-    u"today"
+    u"today",
+    u"audit"
 ]
 osm = {
     u"osm": constants.OSM_TYPE

--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -134,8 +134,7 @@ label_optional_types = [
     u"calculate",
     u"start",
     u"end",
-    u"today",
-    u"audit"
+    u"today"
 ]
 osm = {
     u"osm": constants.OSM_TYPE

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -852,4 +852,9 @@ QUESTION_TYPE_DICT = \
                 "type": "int"
             }
         },
+        "audit": {
+            "bind": {
+                "type": "binary"
+            }
+        }
     }

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -852,9 +852,4 @@ QUESTION_TYPE_DICT = \
                 "type": "int"
             }
         },
-        "audit": {
-            "bind": {
-                "type": "binary"
-            }
-        }
     }

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -1,0 +1,18 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class AuditTest(PyxformTestCase):
+    def test_audit(self):
+        self.assertPyxformXform(
+            name="meta_audit",
+            md="""
+            | survey |        |          |       |                     |
+            |        | type   |   name   | label | parameters          |
+            |        | audit  |   audit  |       |                     |
+            """,
+            xml__contains=[
+                '<meta>',
+                '<audit/>',
+                '</meta>', 
+                '<bind nodeset="/meta_audit/meta/audit" type="binary"/>'],
+        )

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -6,9 +6,9 @@ class AuditTest(PyxformTestCase):
         self.assertPyxformXform(
             name="meta_audit",
             md="""
-            | survey |        |          |       |                     |
-            |        | type   |   name   | label | parameters          |
-            |        | audit  |   audit  |       |                     |
+            | survey |        |          |       |
+            |        | type   |   name   | label |
+            |        | audit  |   audit  |       |
             """,
             xml__contains=[
                 '<meta>',

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -25,7 +25,8 @@ class AuditTest(PyxformTestCase):
             |        | type   |   name   | label |
             |        | audit  |   bobby  |       |
             """,
-            errored=True
+            errored=True,
+            error__contains=['Audits must always be named \'audit.\''],
         )
 
     def test_audit_blank_name(self):

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -25,11 +25,7 @@ class AuditTest(PyxformTestCase):
             |        | type   |   name   | label |
             |        | audit  |   bobby  |       |
             """,
-            xml__contains=[
-                '<meta>',
-                '<audit/>',
-                '</meta>',
-                '<bind nodeset="/meta_audit/meta/audit" type="binary"/>'],
+            errored=True
         )
 
     def test_audit_blank_name(self):

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -13,6 +13,21 @@ class AuditTest(PyxformTestCase):
             xml__contains=[
                 '<meta>',
                 '<audit/>',
-                '</meta>', 
+                '</meta>',
+                '<bind nodeset="/meta_audit/meta/audit" type="binary"/>'],
+        )
+
+    def test_audit_random_name(self):
+        self.assertPyxformXform(
+            name="meta_audit",
+            md="""
+            | survey |        |          |       |
+            |        | type   |   name   | label |
+            |        | audit  |   bobby  |       |
+            """,
+            xml__contains=[
+                '<meta>',
+                '<audit/>',
+                '</meta>',
                 '<bind nodeset="/meta_audit/meta/audit" type="binary"/>'],
         )

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -31,3 +31,18 @@ class AuditTest(PyxformTestCase):
                 '</meta>',
                 '<bind nodeset="/meta_audit/meta/audit" type="binary"/>'],
         )
+
+    def test_audit_blank_name(self):
+        self.assertPyxformXform(
+            name="meta_audit",
+            md="""
+            | survey |        |          |       |
+            |        | type   |   name   | label |
+            |        | audit  |          |       |
+            """,
+            xml__contains=[
+                '<meta>',
+                '<audit/>',
+                '</meta>',
+                '<bind nodeset="/meta_audit/meta/audit" type="binary"/>'],
+        )

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -552,6 +552,11 @@ def workbook_to_json(
         # Pull out questions that will go in meta block
         if question_type == 'audit':
             # Force audit name to always be "audit" to follow XForms spec
+            if 'name' in row and row['name'] not in [None, '', 'audit']:
+                raise PyXFormError(row_format_string % row_number +
+                    " Audits must always be named 'audit.'" +
+                    " The name column should be left blank.")
+
             row['name'] = 'audit'
             survey_meta.append(row)
             continue

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -551,6 +551,8 @@ def workbook_to_json(
 
         # Pull out questions that will go in meta block
         if question_type == 'audit':
+            # Force audit name to always be "audit" to follow XForms spec
+            row['name'] = 'audit'
             survey_meta.append(row)
             continue
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -513,6 +513,9 @@ def workbook_to_json(
         r"(?P<osm_command>(" + '|'.join(aliases.osm.keys()) +
         ')) (?P<list_name>\S+)')
 
+    # Rows from the survey sheet that should be nested in meta
+    survey_meta = []
+
     for row in survey_sheet:
         row_number += 1
         prev_control_type, parent_children_array = stack[-1]
@@ -545,6 +548,11 @@ def workbook_to_json(
             raise PyXFormError(
                 row_format_string % row_number +
                 " Question with no type.\n" + str(row))
+
+        # Pull out questions that will go in meta block
+        if question_type == 'audit':
+            survey_meta.append(row)
+            continue
 
         if question_type == 'calculate':
             calculation = row.get('bind', {}).get('calculate')
@@ -887,7 +895,7 @@ def workbook_to_json(
         # print "Generating flattened instance..."
         add_flat_annotations(stack[0][1])
 
-    meta_children = []
+    meta_children = [] + survey_meta
 
     if aliases.yes_no.get(settings.get("omit_instanceID")):
         if settings.get("public_key"):

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -513,59 +513,6 @@ def workbook_to_json(
         r"(?P<osm_command>(" + '|'.join(aliases.osm.keys()) +
         ')) (?P<list_name>\S+)')
 
-    # Create and populate meta block
-    meta_children = []
-
-    if aliases.yes_no.get(settings.get("omit_instanceID")):
-        if settings.get("public_key"):
-            raise PyXFormError(
-                "Cannot omit instanceID, it is required for encryption.")
-    else:
-        # Automatically add an instanceID element:
-        meta_children.append({
-            "name": "instanceID",
-            "bind": {
-                "readonly": "true()",
-                "calculate": settings.get(
-                    "instance_id", "concat('uuid:', uuid())"),
-            },
-            "type": "calculate",
-        })
-
-    if 'instance_name' in settings:
-        # Automatically add an instanceName element:
-        meta_children.append({
-            "name": "instanceName",
-            "bind": {
-                "calculate": settings['instance_name']
-            },
-            "type": "calculate",
-        })
-
-    # audit goes in meta block
-    if {u'type': u'audit', u'name': u'audit'} in survey_sheet:
-        meta_children.append({
-            "name": "audit",
-            "bind": {
-                "type": "binary"
-            },
-            "type": "audit"
-        })
-        survey_sheet.remove({u'type': u'audit', u'name': u'audit'})
-
-    if len(meta_children) > 0:
-        meta_element = \
-            {
-                "name": "meta",
-                "type": "group",
-                "control": {
-                    "bodyless": True
-                },
-                "children": meta_children
-            }
-        noop, survey_children_array = stack[0]
-        survey_children_array.append(meta_element)
-
     for row in survey_sheet:
         row_number += 1
         prev_control_type, parent_children_array = stack[-1]
@@ -939,6 +886,47 @@ def workbook_to_json(
     if settings.get('flat', False):
         # print "Generating flattened instance..."
         add_flat_annotations(stack[0][1])
+
+    meta_children = []
+
+    if aliases.yes_no.get(settings.get("omit_instanceID")):
+        if settings.get("public_key"):
+            raise PyXFormError(
+                "Cannot omit instanceID, it is required for encryption.")
+    else:
+        # Automatically add an instanceID element:
+        meta_children.append({
+            "name": "instanceID",
+            "bind": {
+                "readonly": "true()",
+                "calculate": settings.get(
+                    "instance_id", "concat('uuid:', uuid())"),
+            },
+            "type": "calculate",
+        })
+
+    if 'instance_name' in settings:
+        # Automatically add an instanceName element:
+        meta_children.append({
+            "name": "instanceName",
+            "bind": {
+                "calculate": settings['instance_name']
+            },
+            "type": "calculate",
+        })
+
+    if len(meta_children) > 0:
+        meta_element = \
+            {
+                "name": "meta",
+                "type": "group",
+                "control": {
+                    "bodyless": True
+                },
+                "children": meta_children
+            }
+        noop, survey_children_array = stack[0]
+        survey_children_array.append(meta_element)
 
     # print_pyobj_to_json(json_dict)
     return json_dict


### PR DESCRIPTION
Closes #128. @MartijnR are you ok with this moving forward without #105 for now?

I tried to do this in the least invasive way I could think of. I moved the generation of the meta block to the top so that the audit field could be removed from `survey_sheet` but those changes to `xls2json.py` don't look great to me. @dorey @ukanga would be great to get your expert feedback!