### PR TITLE
Remove no-op XML formatting code

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -432,8 +432,6 @@ class Survey(Section):
         output_re = re.compile('\n.*(<output.*>)\n(  )*')
         pretty_xml = text_re.sub(lambda m: ''.join(m.group(1, 2, 3)), xml_with_linebreaks)
         inline_output = output_re.sub('\g<1>', pretty_xml)
-        inline_output = re.compile('<label>\s*\n*\s*\n*\s*</label>')\
-            .sub('<label></label>', inline_output)
         return '<?xml version="1.0"?>\n' + inline_output
 
     def __repr__(self):

--- a/pyxform/tests_v1/test_whitespace.py
+++ b/pyxform/tests_v1/test_whitespace.py
@@ -13,3 +13,13 @@ class WhitespaceTest(PyxformTestCase):
             xml__contains=[
                 '<label><output value=" /issue96/var "/> text </label>',
             ])
+
+    def empty_label_squashing(self):
+        self.assertPyxformXform(
+            name='empty_label',
+            debug=True,
+            ss_structure={'survey': [
+                    { 'type':'note', 'label':'', 'name':'label' } ] },
+            xml__contains=[
+                '<label></label>',
+            ])

--- a/pyxform/tests_v1/test_whitespace.py
+++ b/pyxform/tests_v1/test_whitespace.py
@@ -13,13 +13,3 @@ class WhitespaceTest(PyxformTestCase):
             xml__contains=[
                 '<label><output value=" /issue96/var "/> text </label>',
             ])
-
-    def test_empty_label_squashing(self):
-        self.assertPyxformXform(
-            name='empty_label',
-            debug=True,
-            ss_structure={'survey': [
-                    { 'type':'note', 'label':'', 'name':'label' } ] },
-            xml__contains=[
-                '<label></label>',
-            ])

--- a/pyxform/tests_v1/test_whitespace.py
+++ b/pyxform/tests_v1/test_whitespace.py
@@ -14,7 +14,7 @@ class WhitespaceTest(PyxformTestCase):
                 '<label><output value=" /issue96/var "/> text </label>',
             ])
 
-    def empty_label_squashing(self):
+    def test_empty_label_squashing(self):
         self.assertPyxformXform(
             name='empty_label',
             debug=True,


### PR DESCRIPTION
From what I can see, this code doesn't do anything.  Possibly I just can't work out a test to demonstrate its current behaviour.  