### PR TITLE
Fixed import error calling for missing module pyxform

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -1,4 +1,4 @@
-import constants
+from . import constants
 
 # Aliases:
 # Ideally aliases should resolve to elements in the json form schema

--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -1,4 +1,4 @@
-from . import constants
+import constants
 
 # Aliases:
 # Ideally aliases should resolve to elements in the json form schema

--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -1,4 +1,4 @@
-from pyxform import constants
+import constants
 
 # Aliases:
 # Ideally aliases should resolve to elements in the json form schema

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -1,7 +1,7 @@
 import copy
 import os
 
-from . import file_utils, utils
+import file_utils, utils
 from errors import PyXFormError
 from question import (InputQuestion, MultipleChoiceQuestion,
                               OsmUploadQuestion, Question, RangeQuestion,

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -1,16 +1,16 @@
 import copy
 import os
 
-from pyxform import file_utils, utils
-from pyxform.errors import PyXFormError
-from pyxform.question import (InputQuestion, MultipleChoiceQuestion,
+import file_utils, utils
+from errors import PyXFormError
+from question import (InputQuestion, MultipleChoiceQuestion,
                               OsmUploadQuestion, Question, RangeQuestion,
                               TriggerQuestion, UploadQuestion)
-from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
-from pyxform.section import GroupedSection, RepeatingSection
-from pyxform.survey import Survey
-from pyxform.utils import unicode
-from pyxform.xls2json import SurveyReader
+from question_type_dictionary import QUESTION_TYPE_DICT
+from section import GroupedSection, RepeatingSection
+from survey import Survey
+from utils import unicode
+from xls2json import SurveyReader
 
 
 def copy_json_dict(json_dict):

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -1,7 +1,7 @@
 import copy
 import os
 
-import file_utils, utils
+from . import file_utils, utils
 from errors import PyXFormError
 from question import (InputQuestion, MultipleChoiceQuestion,
                               OsmUploadQuestion, Question, RangeQuestion,

--- a/pyxform/file_utils.py
+++ b/pyxform/file_utils.py
@@ -1,6 +1,6 @@
 import os
 import glob
-from . import utils
+import utils
 
 from xls2json import SurveyReader
 

--- a/pyxform/file_utils.py
+++ b/pyxform/file_utils.py
@@ -1,8 +1,8 @@
 import os
 import glob
-from pyxform import utils
+import utils
 
-from pyxform.xls2json import SurveyReader
+from xls2json import SurveyReader
 
 
 def _section_name(path_or_file_name):

--- a/pyxform/file_utils.py
+++ b/pyxform/file_utils.py
@@ -1,6 +1,6 @@
 import os
 import glob
-import utils
+from . import utils
 
 from xls2json import SurveyReader
 

--- a/pyxform/instance.py
+++ b/pyxform/instance.py
@@ -1,4 +1,4 @@
-from pyxform.xform_instance_parser import parse_xform_instance
+from xform_instance_parser import parse_xform_instance
 
 
 class SurveyInstance(object):

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -1,9 +1,9 @@
 import os.path
 
-from pyxform.errors import PyXFormError
-from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
-from pyxform.survey_element import SurveyElement
-from pyxform.utils import basestring, node, unicode
+from errors import PyXFormError
+from question_type_dictionary import QUESTION_TYPE_DICT
+from survey_element import SurveyElement
+from utils import basestring, node, unicode
 
 
 class Question(SurveyElement):

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -1,4 +1,4 @@
-from pyxform.xls2json import QuestionTypesReader, print_pyobj_to_json
+from xls2json import QuestionTypesReader, print_pyobj_to_json
 
 FILE_MEDIA_TYPES = ",".join([
     "text/plain",

--- a/pyxform/section.py
+++ b/pyxform/section.py
@@ -1,6 +1,6 @@
-from pyxform.question import SurveyElement
-from pyxform.utils import node
-from pyxform.errors import PyXFormError
+from question import SurveyElement
+from utils import node
+from errors import PyXFormError
 
 
 class Section(SurveyElement):

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -6,14 +6,14 @@ import xml.etree.ElementTree as ETree
 from collections import defaultdict
 from datetime import datetime
 
-from pyxform import constants
-from pyxform.errors import PyXFormError
-from pyxform.instance import SurveyInstance
-from pyxform.odk_validate import check_xform
-from pyxform.question import Question
-from pyxform.section import Section
-from pyxform.survey_element import SurveyElement
-from pyxform.utils import PatchedText, basestring, node, unicode
+import constants
+from errors import PyXFormError
+from instance import SurveyInstance
+from odk_validate import check_xform
+from question import Question
+from section import Section
+from survey_element import SurveyElement
+from utils import PatchedText, basestring, node, unicode
 
 nsmap = {
     u"xmlns": u"http://www.w3.org/2002/xforms",
@@ -440,7 +440,7 @@ class Survey(Section):
         return unicode(self)
 
     def __unicode__(self):
-        return "<pyxform.survey.Survey instance at %s>" % hex(id(self))
+        return "<survey.Survey instance at %s>" % hex(id(self))
 
     def _setup_xpath_dictionary(self):
         self._xpath = {}

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -1,8 +1,8 @@
 import json
-from pyxform.utils import is_valid_xml_tag, node, unicode
-from pyxform.xls2json import print_pyobj_to_json
-from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
-from pyxform.errors import PyXFormError
+from utils import is_valid_xml_tag, node, unicode
+from xls2json import print_pyobj_to_json
+from question_type_dictionary import QUESTION_TYPE_DICT
+from errors import PyXFormError
 
 
 def _overlay(over, under):

--- a/pyxform/xform_instance_parser.py
+++ b/pyxform/xform_instance_parser.py
@@ -5,7 +5,7 @@
 
 from xml.dom import minidom
 import re
-from pyxform.utils import unicode
+from utils import unicode
 
 XFORM_ID_STRING = u"_xform_id_string"
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -7,10 +7,10 @@ import re
 import sys
 import codecs
 import os
-from pyxform import constants, aliases
-from pyxform.errors import PyXFormError
-from pyxform.xls2json_backends import xls_to_dict, csv_to_dict
-from pyxform.utils import is_valid_xml_tag, unicode, basestring
+import constants, aliases
+from errors import PyXFormError
+from xls2json_backends import xls_to_dict, csv_to_dict
+from utils import is_valid_xml_tag, unicode, basestring
 
 SMART_QUOTES = {
     '\u2018': "'",

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -7,7 +7,7 @@ import re
 import sys
 import codecs
 import os
-import constants, aliases
+from . import constants, aliases
 from errors import PyXFormError
 from xls2json_backends import xls_to_dict, csv_to_dict
 from utils import is_valid_xml_tag, unicode, basestring

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -7,7 +7,7 @@ import re
 import sys
 import codecs
 import os
-from . import constants, aliases
+import constants, aliases
 from errors import PyXFormError
 from xls2json_backends import xls_to_dict, csv_to_dict
 from utils import is_valid_xml_tag, unicode, basestring

--- a/pyxform/xls2json_backends.py
+++ b/pyxform/xls2json_backends.py
@@ -5,7 +5,7 @@ import xlrd
 from xlrd import XLRDError
 import unicodecsv as csv
 from io import BytesIO
-import constants
+from . import constants
 import re
 import datetime
 from errors import PyXFormError

--- a/pyxform/xls2json_backends.py
+++ b/pyxform/xls2json_backends.py
@@ -5,7 +5,7 @@ import xlrd
 from xlrd import XLRDError
 import unicodecsv as csv
 from io import BytesIO
-from . import constants
+import constants
 import re
 import datetime
 from errors import PyXFormError

--- a/pyxform/xls2json_backends.py
+++ b/pyxform/xls2json_backends.py
@@ -5,11 +5,11 @@ import xlrd
 from xlrd import XLRDError
 import unicodecsv as csv
 from io import BytesIO
-from pyxform import constants
+import constants
 import re
 import datetime
-from pyxform.errors import PyXFormError
-from pyxform.utils import unicode, basestring, unichr
+from errors import PyXFormError
+from utils import unicode, basestring, unichr
 from functools import reduce
 from collections import OrderedDict
 

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -4,8 +4,8 @@ import argparse
 import json
 import os
 
-from pyxform import builder, xls2json
-from pyxform.utils import has_external_choices, sheet_to_csv
+import builder, xls2json
+from utils import has_external_choices, sheet_to_csv
 """
 xls2xform converts properly formatted Excel documents into XForms for
 use with ODK Collect.

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import os
 
-from . import builder, xls2json
+import .builder, .xls2json
 from utils import has_external_choices, sheet_to_csv
 """
 xls2xform converts properly formatted Excel documents into XForms for

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import os
 
-import builder, xls2json
+import .builder, .xls2json
 from utils import has_external_choices, sheet_to_csv
 """
 xls2xform converts properly formatted Excel documents into XForms for

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import os
 
-import .builder, .xls2json
+import builder, xls2json
 from utils import has_external_choices, sheet_to_csv
 """
 xls2xform converts properly formatted Excel documents into XForms for

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import os
 
-import .builder, .xls2json
+from . import builder, xls2json
 from utils import has_external_choices, sheet_to_csv
 """
 xls2xform converts properly formatted Excel documents into XForms for


### PR DESCRIPTION
Hi there,

I advised a friend to use PyXform to convert xlsforms to xml locally for testing, and when she cloned the repo and attempted to use the xls2xform.py script, the following error resulted:

```Traceback (most recent call last):
  File "xls2xform.py", line 7, in <module>
    from pyxform import builder, xls2json
ImportError: No module named pyxform
```

This was on OSX. I pulled the latest code to my Ubuntu 16.04 machine, and found the same result: any attempt to run xls2xform, with or without arguments, generates this ImportError.

Looking through the code, it appears that a number of modules call for an import from the module pyxform. I'm not sure why it's been done this way; it appears to make it impossible to use the script directly from the command line in either OSX or Ubuntu, but perhaps there's another use-case for which this import structure works, or is necessary.

In any case, I've removed all import statements directly referencing the pyxform module, and it now works on both my Ubuntu machine and my friend's Mac.

After making these changes in my fork, calling:

```
python xls2xform path/to/infile.xlsx path/to/outfile.xml
```

Results in a success message and a working output file in the specified folder.

However, I have no idea if this somehow compromises other uses of the script! I haven't tested it on a Windows machine (I would think that Python is Python, but I don't know this, so safer not to asume). Furthermore, I don't know that in some embedded application this import structure isn't somehow necessary.

If this doesn't break things for others, it certainly helps those of us who use the script standalone from OSX or Linux command line to develop and test forms, and we'd be grateful if you'd merge it. If it breaks things for other people, no worries, we'll continue forking as necessary.

If it's necessary to keep the import calls to pyxform, I'd appreciate knowing why this is; perhaps I can try to learn what's necessary to make the changes that accommodate both that need and my desire to have a working command-line script to convert forms locally.

Thanks, as always, for creating and maintaining this extraordinary project, which I use on a daily basis for humanitarian and development work.

Ivan


 
