### PR TITLE
Upgrade xlrd

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 nose==1.3.7
 FormEncode==1.3
 modilabs-python-utils==0.1.5
-xlrd==1.0.0
+xlrd==1.1.0
 unittest2==1.1.0
 unicodecsv==0.14.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description='A Python package to create XForms for ODK Collect.',
     long_description=open('README.rst', 'rt').read(),
     install_requires=[
-        'xlrd==1.0.0',
+        'xlrd==1.1.0',
         'unicodecsv==0.14.1',
         'formencode',
         'unittest2',


### PR DESCRIPTION
xlrd changelog is at https://xlrd.readthedocs.io/en/latest/changes.html.

To test his change, I ran `nosetests` and got this output.

 ```
$ nosetests
........................................................................usage: nosetests [-h] [--json] [--skip_validate] path_to_XLSForm output_path
nosetests: error: too few arguments
..........................................................
----------------------------------------------------------------------
Ran 130 tests in 16.332s

OK 
```

I think this is a safe change, but I don't know pyxform that well. It'd be prudent for the maintainers (or maybe @sheppard) to consider the implications of this change before merging.