### PR TITLE
Upgrade from xlrd 1.0.0 to 1.1.0

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 nose==1.3.7
 FormEncode==1.3
 modilabs-python-utils==0.1.5
-xlrd==1.0.0
+xlrd==1.1.0
 unittest2==1.1.0
 unicodecsv==0.14.1


### PR DESCRIPTION
This fixes version conflicts with other packages which rely on the latest release of xlrd, such as wq/wq#27