### PR TITLE
Workarounds for PyInstaller on Windows

### DIFF
--- a/pyxform/odk_validate/__init__.py
+++ b/pyxform/odk_validate/__init__.py
@@ -60,7 +60,7 @@ def _java_installed():
     stderr = None
     java_regex = re.compile("java version")
     try:
-        stderr = run_popen_with_timeout(["java", "-version"], 100)[3]
+        stderr = run_popen_with_timeout(["java", "-version"], 100)[3].strip().decode('utf-8')
     except:
         pass
     


### PR DESCRIPTION
I use pyxform inside a cross-platform app (https://github.com/opendatakit/xlsform-offline) that is packaged by PyInstaller. In the past, I maintained my own fork of pyxform, but I figured I'd send this patch upstream so I don't have to maintain my fork. The changes are...

1. `subprocess.Popen` will open a command window when run from a PyInstaller-packaged app with the `--noconsole` option. There is code at https://github.com/pyinstaller/pyinstaller/wiki/Recipe-subprocess which is based on a GPL project, so I used code that I had from a few years back that does the same thing.

2. The `_java_installed` implementation spawns all sorts of windows when in a PyInstaller-packaged app. I've changed it to a call that doesn't spawn windows.

I tested this by installing my branch and running `xls2xform.exe` on a Windows 10 machine using this form ([validate-error.xlsx](https://github.com/XLSForm/pyxform/files/1561371/validate-error.xlsx)) with a validation problem. I confirmed that validation happened when Java was in the path. I confirmed that I got a `pyxform odk validate dependency: java not found` error when Java was not in the path. I also confirmed the above behavior on a macOS machine.
