### PR TITLE
Feature/external instance #107

### DIFF
--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -92,6 +92,10 @@ class SurveyElementBuilder(object):
             d = self._sections[section_name]
             full_survey = self.create_survey_element_from_dict(d)
             return full_survey.children
+        elif d[u"type"] == u"data-xml":
+            # TODO: Build up an array of names (preventing duplicates)
+            # and make that accessible in survey.py
+            print 'found data-xml item with name: '+d[u"name"] 
         else:
             return self._create_question_from_dict(
                 d, copy_json_dict(QUESTION_TYPE_DICT), self._add_none_option)

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -93,7 +93,7 @@ class SurveyElementBuilder(object):
             d = self._sections[section_name]
             full_survey = self.create_survey_element_from_dict(d)
             return full_survey.children
-        elif d[u"type"] == u"xml-data":
+        elif d[u"type"] == u"xml-external":
             return ExternalInstance(**d)
         else:
             return self._create_question_from_dict(

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -3,6 +3,7 @@ import os
 
 from pyxform import file_utils, utils
 from pyxform.errors import PyXFormError
+from pyxform.external_instance import ExternalInstance
 from pyxform.question import (InputQuestion, MultipleChoiceQuestion,
                               OsmUploadQuestion, Question, RangeQuestion,
                               TriggerQuestion, UploadQuestion)
@@ -92,10 +93,8 @@ class SurveyElementBuilder(object):
             d = self._sections[section_name]
             full_survey = self.create_survey_element_from_dict(d)
             return full_survey.children
-        elif d[u"type"] == u"data-xml":
-            # TODO: Build up an array of names (preventing duplicates)
-            # and make that accessible in survey.py
-            print 'found data-xml item with name: '+d[u"name"] 
+        elif d[u"type"] == u"xml-data":
+            return ExternalInstance(**d)
         else:
             return self._create_question_from_dict(
                 d, copy_json_dict(QUESTION_TYPE_DICT), self._add_none_option)

--- a/pyxform/external_instance.py
+++ b/pyxform/external_instance.py
@@ -4,15 +4,6 @@ from pyxform.utils import node
 
 class ExternalInstance(SurveyElement):
 
-    def xml_instance(self):
-        """
-        Get the XML representation of the external instance element.
-        """
-        return node(
-            "instance",
-            id=self[u"name"],
-            src="jr://file/{}.xml".format(self[u"name"]))
-
     def xml_control(self):
         """
         No-op since there is no associated form control to place under <body/>.

--- a/pyxform/external_instance.py
+++ b/pyxform/external_instance.py
@@ -1,0 +1,22 @@
+from pyxform.survey_element import SurveyElement
+from pyxform.utils import node
+
+
+class ExternalInstance(SurveyElement):
+
+    def xml_instance(self):
+        """
+        Get the XML representation of the external instance element.
+        """
+        return node(
+            "instance",
+            id=self[u"name"],
+            src="jr://file/{}.xml".format(self[u"name"]))
+
+    def xml_control(self):
+        """
+        No-op since there is no associated form control to place under <body/>.
+
+        Exists here because there's a soft abstractmethod in SurveyElement.
+        """
+        pass

--- a/pyxform/instance_info.py
+++ b/pyxform/instance_info.py
@@ -1,0 +1,11 @@
+
+
+class InstanceInfo(object):
+    """Standardise Instance details relevant during XML generation."""
+
+    def __init__(self, type, context, name, unique_id, instance):
+        self.type = type
+        self.context = context
+        self.name = name
+        self.unique_id = unique_id
+        self.instance = instance

--- a/pyxform/instance_info.py
+++ b/pyxform/instance_info.py
@@ -3,9 +3,8 @@
 class InstanceInfo(object):
     """Standardise Instance details relevant during XML generation."""
 
-    def __init__(self, type, context, name, unique_id, instance):
+    def __init__(self, type, context, name, instance):
         self.type = type
         self.context = context
         self.name = name
-        self.unique_id = unique_id
         self.instance = instance

--- a/pyxform/instance_info.py
+++ b/pyxform/instance_info.py
@@ -3,8 +3,9 @@
 class InstanceInfo(object):
     """Standardise Instance details relevant during XML generation."""
 
-    def __init__(self, type, context, name, instance):
+    def __init__(self, type, context, name, src, instance):
         self.type = type
         self.context = context
         self.name = name
+        self.src = src
         self.instance = instance

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -857,7 +857,7 @@ QUESTION_TYPE_DICT = \
                 "type": "binary"
             }
         },
-        "xml-data": {
+        "xml-external": {
             # Only effect is to add an external instance.
         }
     }

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -857,5 +857,7 @@ QUESTION_TYPE_DICT = \
                 "type": "binary"
             }
         },
-        "data-xml": {}
+        "xml-data": {
+            # Only effect is to add an external instance.
+        }
     }

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -856,5 +856,6 @@ QUESTION_TYPE_DICT = \
             "bind": {
                 "type": "binary"
             }
-        }
+        },
+        "data-xml": {}
     }

--- a/pyxform/section.py
+++ b/pyxform/section.py
@@ -1,3 +1,4 @@
+from pyxform.external_instance import ExternalInstance
 from pyxform.question import SurveyElement
 from pyxform.utils import node
 from pyxform.errors import PyXFormError
@@ -38,6 +39,8 @@ class Section(SurveyElement):
             if child.get(u"flat"):
                 for grandchild in child.xml_instance_array():
                     result.appendChild(grandchild)
+            elif isinstance(child, ExternalInstance):
+                continue
             else:
                 result.appendChild(child.xml_instance())
         return result

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -450,7 +450,7 @@ class Survey(Section):
         return '<?xml version="1.0"?>\n' + inline_output
 
     def __repr__(self):
-        return unicode(self)
+        return self.__unicode__()
 
     def __unicode__(self):
         return "<pyxform.survey.Survey instance at %s>" % hex(id(self))

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -261,6 +261,15 @@ class Survey(Section):
           list_name in the choices sheet. This is done to allow users to re-use
           external sources without duplicate instances being generated in the
           XForm document. However, it does require careful in form design.
+
+        There are two other things currently supported by pyxform that involve
+        external files and are not explicitly handled here, but may be relevant
+        to future efforts to harmonise / simplify external data workflows:
+
+        - `search` appearance/function: works a lot like pulldata but the csv
+          isn't made explicit in the form.
+        - `select_one_external`: implicitly relies on a `itemsets.csv` file and
+          uses XPath-like expressions for querying.
         """
         instances = []
         for i in self.iter_descendants():

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -61,6 +61,8 @@ class Survey(Section):
     def validate(self):
         if self.id_string in [None, 'None']:
             raise PyXFormError('Survey cannot have an empty id_string')
+        # TODO: don't raise error if data-xml has no label
+        # TODO: check for duplicate names of data-xml items
         super(Survey, self).validate()
         self._validate_uniqueness_of_section_names()
 
@@ -138,6 +140,13 @@ class Survey(Section):
             yield node("instance", node("root", *instance_element_list),
                        id=list_name)
 
+    def _generate_remote_instances(self):
+        # TODO: loop through all data-xml items:
+        # TODO: prevent duplicates, see _generate_pulldata_instances, though
+        # it would be more robust to check existing instances in the model so far.
+        name = 'test1'
+        yield node("instance", id=name, src="jr://file/{}.xml".format(name))
+
     def _generate_pulldata_instances(self):
         pulldata = []
         for i in self.iter_descendants():
@@ -184,6 +193,7 @@ class Survey(Section):
             model_children.append(self.itext())
         model_children += [node("instance", self.xml_instance())]
         model_children += list(self._generate_static_instances())
+        model_children += list(self._generate_remote_instances())
         model_children += list(self._generate_pulldata_instances())
         model_children += list(self._generate_from_file_instances())
         model_children += self.xml_bindings()

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -262,14 +262,14 @@ class Survey(Section):
 
         Instance names used for the id attribute are generated as follows:
 
-        - xml-data: item name value (for type==xml-data)
+        - xml-external: item name value (for type==xml-external)
         - pulldata: first arg to calculation->pulldata()
         - select from file: file name arg to type->itemset
         - choices: list_name (for type==select_*)
 
         Validation and business rules for output of instances:
 
-        - xml-data item name must be unique across the XForm and the form is
+        - xml-external item name must be unique across the XForm and the form is
           considered invalid if there is a duplicate name. This differs from
           other item types which allow duplicates if not in the same group.
         - for all instance sources, if the same instance name is encountered,

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -358,7 +358,7 @@ class SurveyElement(dict):
         The control depends on what type of question we're asking, it
         doesn't make sense to implement here in the base class.
         """
-        raise Exception("Control not implemented")
+        raise NotImplementedError("Control not implemented")
 
 
 def hashable(v):

--- a/pyxform/tests/test_expected_output/pull_data.xml
+++ b/pyxform/tests/test_expected_output/pull_data.xml
@@ -12,7 +12,14 @@
           </meta>
         </pull_data>
       </instance>
-      <instance id="fruits" src="jr://file-csv/fruits.csv"/>
+      <instance id="fruits" src="jr://file-csv/fruits.csv">
+        <root>
+          <item>
+            <name>_</name>
+            <label>_</label>
+          </item>
+        </root>
+      </instance>
       <bind calculate="pulldata('fruits', 'name','name', 'mango')" nodeset="/pull_data/fruit" type="string"/>
       <bind nodeset="/pull_data/note_fruite" readonly="true()" type="string"/>
       <bind calculate="concat('uuid:', uuid())" nodeset="/pull_data/meta/instanceID" readonly="true()" type="string"/>

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -240,7 +240,9 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
                 "Expected valid survey but compilation failed. "
                 "Try correcting the error with 'debug=True', "
                 "setting 'errored=True', "
-                "and or optionally 'error__contains=[...]'")
+                "and or optionally 'error__contains=[...]'"
+                "\nError(s): " + "\n".join(errors)
+            )
         elif survey and expecting_invalid_survey:
             raise PyxformTestError("Expected survey to be invalid.")
 

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -12,8 +12,8 @@ from unittest import TestCase
 from pyxform.builder import create_survey_element_from_dict
 from pyxform.errors import PyXFormError
 from pyxform.odk_validate import ODKValidateError, check_xform
-from pyxform.survey import nsmap
 from pyxform.tests_v1.test_utils.md_table import md_table_to_ss_structure
+from pyxform.utils import NSMAP
 from pyxform.xls2json import workbook_to_json
 
 
@@ -152,7 +152,9 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
             root = ETree.fromstring(xml.encode('utf-8'))
 
             # Ensure all namespaces are present, even if unused
-            root.attrib.update(**nsmap)
+            final_nsmap = NSMAP.copy()
+            final_nsmap.update(survey.get_nsmap())
+            root.attrib.update(final_nsmap)
 
             xml_nodes['xml'] = root
 

--- a/pyxform/tests_v1/test_xmldata.py
+++ b/pyxform/tests_v1/test_xmldata.py
@@ -1,0 +1,191 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+from pyxform.tests_v1.pyxform_test_case import PyxformTestError
+try:
+    from unittest import skip
+except ImportError:
+    from unittest2 import skip
+
+
+class ExternalInstanceTests(PyxformTestCase):
+
+    def test_external_single_ok(self):
+        """Simplest possible example to include an external instance."""
+        self.assertPyxformXform(
+            md="""
+            | survey |             |           |                  |
+            |        | type        | name      | label            |
+            |        | xml-data    | mydata    |                  |
+            """,
+            model__contains=[
+                '<instance id="mydata" src="jr://file/mydata.xml"/>'
+            ]
+        )
+
+    def test_external_two_in_section_duplicate_raises(self):
+        """Duplicate external instances in the same section raises an error."""
+        with self.assertRaises(PyxformTestError) as ctx:
+            self.assertPyxformXform(
+                md="""
+                | survey |             |           |                  |
+                |        | type        | name      | label            |
+                |        | xml-data    | mydata    |                  |
+                |        | xml-data    | mydata    |                  |
+                """,
+                model__contains=[])
+        # This is caught first by existing validation rule.
+        self.assertIn("There are two survey elements named 'mydata'",
+                      repr(ctx.exception))
+
+    def test_external_two_in_section_unique_ok(self):
+        """Two unique external instances in the same section is OK."""
+        self.assertPyxformXform(
+            md="""
+            | survey |             |           |                  |
+            |        | type        | name      | label            |
+            |        | xml-data    | mydata    |                  |
+            |        | xml-data    | mydata2   |                  |
+            """,
+            model__contains=[
+                '<instance id="mydata" src="jr://file/mydata.xml"/>',
+                '<instance id="mydata2" src="jr://file/mydata2.xml"/>'
+            ]
+        )
+
+    def test_external_multi_group_duplicate_raises(self):
+        """Duplicate external instances anywhere raises an error."""
+        with self.assertRaises(PyxformTestError) as ctx:
+            self.assertPyxformXform(
+                md="""
+                | survey |             |         |                  |
+                |        | type        | name    | label            |
+                |        | xml-data    | mydata  |                  |
+                |        | begin group | g1      |                  |
+                |        | xml-data    | mydata  |                  |
+                |        | end group   | g1      |                  |
+                |        | begin group | g2      |                  |
+                |        | xml-data    | mydata  |                  |
+                |        | end group   | g2      |                  |
+                """,
+                model__contains=[])
+        self.assertIn("Instance names must be unique", repr(ctx.exception))
+
+    def test_external_multi_group_duplicate_raises_helpfully(self):
+        """Duplicate external instances anywhere raises a helpful error."""
+        with self.assertRaises(PyxformTestError) as ctx:
+            self.assertPyxformXform(
+                md="""
+                | survey |             |         |                  |
+                |        | type        | name    | label            |
+                |        | xml-data    | mydata  |                  |
+                |        | begin group | g1      |                  |
+                |        | xml-data    | mydata  |                  |
+                |        | end group   | g1      |                  |
+                |        | begin group | g2      |                  |
+                |        | xml-data    | mydata2 |                  |
+                |        | end group   | g2      |                  |
+                |        | begin group | g3      |                  |
+                |        | xml-data    | mydata3 |                  |
+                |        | end group   | g3      |                  |
+                """,
+                model__contains=[])
+        self.assertIn("The name 'mydata' was found 2 time(s)",
+                      repr(ctx.exception))
+
+    def test_external_multi_group_unique_ok(self):
+        """Unique external instances anywhere is OK."""
+        self.assertPyxformXform(
+            md="""
+            | survey |             |         |                  |
+            |        | type        | name    | label            |
+            |        | xml-data    | mydata  |                  |
+            |        | begin group | g1      |                  |
+            |        | xml-data    | mydata1 |                  |
+            |        | end group   | g1      |                  |
+            |        | begin group | g2      |                  |
+            |        | xml-data    | mydata2 |                  |
+            |        | end group   | g2      |                  |
+            |        | begin group | g3      |                  |
+            |        | xml-data    | mydata3 |                  |
+            |        | end group   | g3      |                  |
+            """,
+            model__contains=[
+                '<instance id="mydata" src="jr://file/mydata.xml"/>',
+                '<instance id="mydata1" src="jr://file/mydata1.xml"/>',
+                '<instance id="mydata2" src="jr://file/mydata2.xml"/>',
+                '<instance id="mydata3" src="jr://file/mydata3.xml"/>'
+            ]
+        )
+
+    def test_instance_names_other_sources_duplicate_raises(self):
+        """Duplicate instances with other sources present raises an error."""
+        with self.assertRaises(PyxformTestError) as ctx:
+            self.assertPyxformXform(
+                md="""
+                | survey |                                      |      |       |
+                |        | type                                 | name | label | calculation  |
+                |        | begin group                          | g1   |       |              |
+                |        | xml-data                             | city |       |              |
+                |        | end group                            | g1   |       |              |
+                |        | xml-data                             | city |       |              |
+                |        | begin group                          | g2   |       |              |
+                |        | select_one_from_file cities.csv      | city | City  |              |
+                |        | end group                            | g2   |       |              |
+                |        | begin group                          | g3   |       |              |
+                |        | select_multiple_from_file cities.csv | city | City  |              |
+                |        | end group                            | g3   |       |              |
+                |        | begin group                          | g4   |       |              |
+                |        | calculate                            | city | City  | pulldata('fruits', 'name', 'name', 'mango') |
+                |        | end group                            | g4   |       |              |
+                """,
+                model__contains=[])
+        self.assertIn("The name 'city' was found 2 time(s)",
+                      repr(ctx.exception))
+
+    def test_instance_names_other_sources_unique_ok(self):
+        """Unique instances with other sources present are OK."""
+        self.assertPyxformXform(
+            md="""
+            | survey |                                      |       |       |
+            |        | type                                 | name  | label | calculation  |
+            |        | begin group                          | g1    |       |              |
+            |        | xml-data                             | city1 |       |              |
+            |        | end group                            | g1    |       |              |
+            |        | begin group                          | g2    |       |              |
+            |        | select_one_from_file cities.csv      | city2 | City2 |              |
+            |        | end group                            | g2    |       |              |
+            |        | begin group                          | g3    |       |              |
+            |        | select_multiple_from_file cities.csv | city3 | City3 |              |
+            |        | end group                            | g3    |       |              |
+            |        | begin group                          | g4    |       |              |
+            |        | calculate                            | city4 | City4 | pulldata('fruits', 'name', 'name', 'mango') |
+            |        | end group                            | g4    |       |              |
+            """,
+            model__contains=[
+                '<instance id="city1" src="jr://file/city1.xml"/>',
+"""
+      <instance id="cities" src="jr://file-csv/cities.csv">
+        <root>
+          <item>
+            <name>_</name>
+            <label>_</label>
+          </item>
+        </root>
+      </instance>
+""",
+                '<instance id="fruits" src="jr://file-csv/fruits.csv"/>'
+            ]
+        )
+
+    @skip("Usage scenarios TBA but it might look something like this.")
+    def test_external_usage_scenario(self):
+        self.assertPyxformXform(
+            md="""
+            | survey |             |           |                  | 
+            |        | type        | name      | label            | bind::type  |  calculation  
+            |        | calculate   | external1 |                  | External    |  oc-item(event1(1), form2, item3(1))
+            |        | note        | ext_note  | The external value is ${external_1} |     |
+            """,
+            model__contains=[
+                # TODO: not sure what
+                ])
+

--- a/pyxform/tests_v1/test_xmldata.py
+++ b/pyxform/tests_v1/test_xmldata.py
@@ -13,9 +13,9 @@ class ExternalInstanceTests(PyxformTestCase):
         """Simplest possible example to include an external instance."""
         self.assertPyxformXform(
             md="""
-            | survey |             |           |                  |
-            |        | type        | name      | label            |
-            |        | xml-data    | mydata    |                  |
+            | survey |              |        |       |
+            |        | type         | name   | label |
+            |        | xml-external | mydata |       |
             """,
             model__contains=[
                 '<instance id="mydata" src="jr://file/mydata.xml">'
@@ -28,10 +28,10 @@ class ExternalInstanceTests(PyxformTestCase):
         with self.assertRaises(PyxformTestError) as ctx:
             self.assertPyxformXform(
                 md="""
-                | survey |             |           |                  |
-                |        | type        | name      | label            |
-                |        | xml-data    | mydata    |                  |
-                |        | xml-data    | mydata    |                  |
+                | survey |              |        |       |
+                |        | type         | name   | label |
+                |        | xml-external | mydata |       |
+                |        | xml-external | mydata |       |
                 """,
                 model__contains=[])
         # This is caught first by existing validation rule.
@@ -42,10 +42,10 @@ class ExternalInstanceTests(PyxformTestCase):
         """Two unique external instances in the same section is OK."""
         self.assertPyxformXform(
             md="""
-            | survey |             |           |                  |
-            |        | type        | name      | label            |
-            |        | xml-data    | mydata    |                  |
-            |        | xml-data    | mydata2   |                  |
+            | survey |              |         |       |
+            |        | type         | name    | label |
+            |        | xml-external | mydata  |       |
+            |        | xml-external | mydata2 |       |
             """,
             model__contains=[
                 '<instance id="mydata" src="jr://file/mydata.xml">',
@@ -59,15 +59,15 @@ class ExternalInstanceTests(PyxformTestCase):
         with self.assertRaises(PyxformTestError) as ctx:
             self.assertPyxformXform(
                 md="""
-                | survey |             |         |                  |
-                |        | type        | name    | label            |
-                |        | xml-data    | mydata  |                  |
-                |        | begin group | g1      |                  |
-                |        | xml-data    | mydata  |                  |
-                |        | end group   | g1      |                  |
-                |        | begin group | g2      |                  |
-                |        | xml-data    | mydata  |                  |
-                |        | end group   | g2      |                  |
+                | survey |              |        |       |
+                |        | type         | name   | label |
+                |        | xml-external | mydata |       |
+                |        | begin group  | g1     |       |
+                |        | xml-external | mydata |       |
+                |        | end group    | g1     |       |
+                |        | begin group  | g2     |       |
+                |        | xml-external | mydata |       |
+                |        | end group    | g2     |       |
                 """,
                 model__contains=[])
         self.assertIn("Instance names must be unique", repr(ctx.exception))
@@ -78,21 +78,21 @@ class ExternalInstanceTests(PyxformTestCase):
         """Unique external instances anywhere is OK."""
         self.assertPyxformXform(
             md="""
-            | survey |             |         |                  |
-            |        | type        | name    | label            |
-            |        | xml-data    | mydata  |                  |
-            |        | begin group | g1      |                  |
-            |        | xml-data    | mydata1 |                  |
-            |        | note        | note1   | It's note-able   |
-            |        | end group   | g1      |                  |
-            |        | begin group | g2      |                  |
-            |        | note        | note2   | It's note-able   |
-            |        | xml-data    | mydata2 |                  |
-            |        | end group   | g2      |                  |
-            |        | begin group | g3      |                  |
-            |        | note        | note3   | It's note-able   |
-            |        | xml-data    | mydata3 |                  |
-            |        | end group   | g3      |                  |
+            | survey |              |         |                |
+            |        | type         | name    | label          |
+            |        | xml-external | mydata  |                |
+            |        | begin group  | g1      |                |
+            |        | xml-external | mydata1 |                |
+            |        | note         | note1   | It's note-able |
+            |        | end group    | g1      |                |
+            |        | begin group  | g2      |                |
+            |        | note         | note2   | It's note-able |
+            |        | xml-external | mydata2 |                |
+            |        | end group    | g2      |                |
+            |        | begin group  | g3      |                |
+            |        | note         | note3   | It's note-able |
+            |        | xml-external | mydata3 |                |
+            |        | end group    | g3      |                |
             """,
             model__contains=[
                 '<instance id="mydata" src="jr://file/mydata.xml">',
@@ -111,9 +111,9 @@ class ExternalInstanceTests(PyxformTestCase):
                 | survey |                                      |      |       |
                 |        | type                                 | name | label | calculation  |
                 |        | begin group                          | g1   |       |              |
-                |        | xml-data                             | city |       |              |
+                |        | xml-external                         | city |       |              |
                 |        | end group                            | g1   |       |              |
-                |        | xml-data                             | city |       |              |
+                |        | xml-external                         | city |       |              |
                 |        | begin group                          | g2   |       |              |
                 |        | select_one_from_file cities.csv      | city | City  |              |
                 |        | end group                            | g2   |       |              |
@@ -135,7 +135,7 @@ class ExternalInstanceTests(PyxformTestCase):
             | survey  |                                      |       |       |              |
             |         | type                                 | name  | label | calculation  | choice_filter |
             |         | begin group                          | g1    |       | | |
-            |         | xml-data                             | city1 |       | | |
+            |         | xml-external                         | city1 |       | | |
             |         | note                                 | note1 | Note  | | |
             |         | end group                            | g1    |       | | |
             |         | begin group                          | g2    |       | | |
@@ -209,12 +209,12 @@ class ExternalInstanceTests(PyxformTestCase):
         )
 
     def test_cannot__use_different_src_same_id__external_then_pulldata(self):
-        """Duplicate instance from pulldata after xml-data raises an error."""
+        """Duplicate instance from pulldata after xml-external raises an error."""
         md = """
             | survey |                                      |        |       |              |
             |        | type                                 | name   | label | calculation  |
             |        | begin group                          | g1     |       |              |
-            |        | xml-data                             | fruits |       |              |
+            |        | xml-external                         | fruits |       |              |
             |        | calculate                            | f_csv  | City  | pulldata('fruits', 'name', 'name', 'mango') |
             |        | note                                 | note   | Fruity! ${f_csv} |   |
             |        | end group                            | g1     |       |              |
@@ -231,13 +231,13 @@ class ExternalInstanceTests(PyxformTestCase):
         )
 
     def test_cannot__use_different_src_same_id__pulldata_then_external(self):
-        """Duplicate instance from xml-data after pulldata raises an error."""
+        """Duplicate instance from xml-external after pulldata raises an error."""
         md = """
             | survey |                                      |        |       |              |
             |        | type                                 | name   | label | calculation  |
             |        | begin group                          | g1     |       |              |
             |        | calculate                            | f_csv  | City  | pulldata('fruits', 'name', 'name', 'mango') |
-            |        | xml-data                             | fruits |       |              |
+            |        | xml-external                         | fruits |       |              |
             |        | note                                 | note   | Fruity! ${f_csv} |   |
             |        | end group                            | g1     |       |              |
             """
@@ -316,7 +316,7 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | select_one_from_file pain_locations.xml      | pweek  | Location of worst pain this week.  |
             |        | select_one_from_file pain_locations.xml      | pmonth | Location of worst pain this month. |
             |        | select_one_from_file pain_locations.xml      | pyear  | Location of worst pain this year.  |
-            |        | xml-data                                     | pain_locations  | |
+            |        | xml-external                                 | pain_locations  | |
             """
         expected = \
 """
@@ -338,7 +338,7 @@ class ExternalInstanceTests(PyxformTestCase):
         md = """
             | survey |                                              |        |        |
             |        | type                                         | name   | label  | 
-            |        | xml-data                                     | pain_locations  | |
+            |        | xml-external                                 | pain_locations  | |
             |        | select_multiple_from_file pain_locations.xml | plocs  | Locations of pain this week.       |
             |        | select_one_from_file pain_locations.xml      | pweek  | Location of worst pain this week.  |
             |        | select_one_from_file pain_locations.xml      | pmonth | Location of worst pain this month. |

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -25,7 +25,15 @@ TAG_CHAR = r"[a-zA-Z:_0-9\-.]"
 XFORM_TAG_REGEXP = "%(start)s%(char)s*" % {
     "start": TAG_START_CHAR,
     "char": TAG_CHAR
-    }
+}
+NSMAP = {
+    u"xmlns": u"http://www.w3.org/2002/xforms",
+    u"xmlns:h": u"http://www.w3.org/1999/xhtml",
+    u"xmlns:ev": u"http://www.w3.org/2001/xml-events",
+    u"xmlns:xsd": u"http://www.w3.org/2001/XMLSchema",
+    u"xmlns:jr": u"http://openrosa.org/javarosa",
+    u"xmlns:orx": u"http://openrosa.org/xforms"
+}
 
 
 class DetachableElement(Element):

--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -6,8 +6,7 @@ import codecs
 import xml.etree.ElementTree as ETree
 from operator import itemgetter
 from pyxform import builder
-from pyxform.utils import basestring
-from pyxform.survey import nsmap
+from pyxform.utils import basestring, NSMAP
 
 
 # {{{ http://code.activestate.com/recipes/573463/ (r7)
@@ -181,7 +180,7 @@ class XFormToDict:
 
     def get_dict(self):
         json_str = json.dumps(self._dict)
-        for uri in nsmap.values():
+        for uri in NSMAP.values():
             json_str = json_str.replace('{%s}' % uri, '')
         return json.loads(json_str)
 


### PR DESCRIPTION
PR for #107. More or less the same as pulldata and select_one_from_file etc. in terms of adding a supplementary instance to the form model, but this just does the instance part without any effects elsewhere on the form (no controls, bindings, etc.).

Includes some tidy up of the other functions that generate instances to make it possible to validate across all of them e.g. to check that duplicates aren't being added. Also I think this may qualify as a bug fix but for example if a user has a form using the same select from file e.g. `select_one_from_file cities.csv` with item1 and item2, then 2 identical copies of the instance would be added - now only one is added.

Includes some other minor cleanups:

- Survey's `__repr__` calling `unicode(self)` caused a recursion crash, now uses `__unicode__` instead
- Exception that was acting like a NotImplementedError is now one
- PyxformTestCase didn't show why the compilation failed but now it does
