### PR TITLE
Add OpenJDK support

### DIFF
--- a/pyxform/odk_validate/__init__.py
+++ b/pyxform/odk_validate/__init__.py
@@ -58,7 +58,7 @@ def run_popen_with_timeout(command, timeout):
 
 def _java_installed():
     stderr = None
-    java_regex = re.compile("java version")
+    java_regex = re.compile("(java|openjdk) version")
     try:
         stderr = run_popen_with_timeout(["java", "-version"], 100)[3].strip().decode('utf-8')
     except:


### PR DESCRIPTION
Fixes the issue raised at https://github.com/XLSForm/pyxform/pull/166#issuecomment-354714933.

Tested the regex by putting the expression and test string at https://pythex.org. Also tested it by running this and getting three yeses.

```python
import re

test_1 = "java version 1.8.0_152"
test_2 = "openjdk version 9"
test_3 = "openjdk version 9 java version 1.8.0_152"

java_regex = re.compile("(java|openjdk) version")
if java_regex.match(test_1):
    print test_1, 'yes'
if java_regex.match(test_2):
    print test_2, 'yes'
if java_regex.match(test_3):
    print test_3, 'yes'
```
