### PR TITLE
Handle Validate errors with unicode

### DIFF
--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -207,7 +207,7 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
                                        "'odk_validate_error__contains'" +
                                        " was empty:" + unicode(e))
             for v_err in odk_validate_error__contains:
-                self.assertContains(unicode(e), v_err,
+                self.assertContains(e.args[0].decode('utf-8'), v_err,
                                     msg_prefix='odk_validate_error__contains')
         else:
             survey = True

--- a/pyxform/tests_v1/test_validate_unicode_exception.py
+++ b/pyxform/tests_v1/test_validate_unicode_exception.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+class ValidateUnicodeException(PyxformTestCase):
+    """
+    Validation errors may include non-ASCII characters. In particular, ODK Validate
+    uses ͎ (small arrow) to indicate where a problem starts.
+    """
+    def test_validate_unicode_exception(self):
+        self.assertPyxformXform(
+            md="""
+            | survey  |           |       |       |                |
+            |         | type      | name  | label | calculation    |
+            |         | calculate | bad   | bad   | $(myField)='1' |
+            """,
+            run_odk_validate=True,
+            odk_validate_error__contains=[
+                u"Invalid calculate for the bind attached to \"${bad}\" : Couldn't understand the expression starting at this point:",
+            ])

--- a/pyxform/validators/odk_validate/__init__.py
+++ b/pyxform/validators/odk_validate/__init__.py
@@ -73,7 +73,7 @@ def check_xform(path_to_xform):
     else:
         if returncode > 0:  # Error invalid
             raise ODKValidateError(
-                'ODK Validate Errors:\n' + ErrorCleaner.odk_validate(stderr))
+                b'ODK Validate Errors:\n' + ErrorCleaner.odk_validate(stderr).encode('utf-8'))
         elif returncode == 0:
             if stderr:
                 warnings.append('ODK Validate Warnings:\n' + stderr)


### PR DESCRIPTION
Closes #72 

The test did not fail originally because the issue was with displaying the error. It seems like it's still good to have a test for it but I'm not sure if it's actually useful.

I manually verified that https://docs.google.com/spreadsheets/d/1gBJVFqbW0vK7B3cpVmZMPEdJ34ulf7PWiQAynxCo7Dk/edit#gid=0 originally failed and now works with these changes applied.
