### PR TITLE
Fix appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - ps: pip install --disable-pip-version-check --user --upgrade pip
+  - ps: python -m pip install -U pip
 
   # We need wheel installed to build wheels
   - ps: pip install wheel


### PR DESCRIPTION
I realized the Appveyor was breaking in https://github.com/XLSForm/pyxform/pull/195 and wanted to send in a PR to fix.

According to https://pip.pypa.io/en/stable/installing/#id10, the best way to upgrade pip on windows is now `python -m pip install -U pip`. This change is discussed at https://github.com/pypa/pip/issues/1299.