### PR TITLE
Support guidance hints

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -28,6 +28,7 @@ AUTO_DELETE = u"auto_delete"
 DEFAULT_LANGUAGE = u"default_language"
 LABEL = u"label"
 HINT = u"hint"
+GUIDANCE_HINT = u"guidance_hint"
 STYLE = u"style"
 ATTRIBUTE = u"attribute"
 

--- a/pyxform/json_form_schema.json
+++ b/pyxform/json_form_schema.json
@@ -127,6 +127,16 @@
 							"description" : "A key value pair where the key is a language, and the value is the content in that language."
 						}
 					},
+					"guidance_hint" :
+					{
+						"type" : ["string", "object"],
+						"description" : "Either a guidance hint string used for training or a mapping of languages to localized versions of the hint",
+						"additionalProperties":
+						{
+							"type" : "string",
+							"description" : "A key value pair where the key is a language, and the value is the content in that language."
+						}						
+					},
 					"media" :
 					{
 						"type" : "object",

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -41,7 +41,7 @@ class InputQuestion(Question):
     """
     def xml_control(self):
         control_dict = self.control
-        label_and_hint = self.xml_label_and_hint()
+        label_and_hint = self.xml_label_and_hints()
         survey = self.get_root()
         # Resolve field references in attributes
         for key, value in control_dict.items():
@@ -50,7 +50,7 @@ class InputQuestion(Question):
 
         result = node(**control_dict)
         if label_and_hint:
-            for element in self.xml_label_and_hint():
+            for element in self.xml_label_and_hints():
                 result.appendChild(element)
 
         # Input types are used for selects with external choices sheets.
@@ -75,7 +75,7 @@ class TriggerQuestion(Question):
         control_dict['ref'] = self.get_xpath()
         return node(
             u"trigger",
-            *self.xml_label_and_hint(),
+            *self.xml_label_and_hints(),
             **control_dict
             )
 
@@ -90,7 +90,7 @@ class UploadQuestion(Question):
         control_dict['mediatype'] = self._get_media_type()
         return node(
             u"upload",
-            *self.xml_label_and_hint(),
+            *self.xml_label_and_hints(),
             **control_dict
             )
 
@@ -148,7 +148,7 @@ class MultipleChoiceQuestion(Question):
         control_dict['ref'] = self.get_xpath()
 
         result = node(**control_dict)
-        for element in self.xml_label_and_hint():
+        for element in self.xml_label_and_hints():
             result.appendChild(element)
         # itemset are only supposed to be strings,
         # check to prevent the rare dicts that show up
@@ -246,7 +246,7 @@ class OsmUploadQuestion(UploadQuestion):
         control_dict['mediatype'] = self._get_media_type()
         result = node(
             u"upload",
-            *self.xml_label_and_hint(),
+            *self.xml_label_and_hints(),
             **control_dict
             )
 
@@ -263,7 +263,7 @@ class RangeQuestion(Question):
     """
     def xml_control(self):
         control_dict = self.control
-        label_and_hint = self.xml_label_and_hint()
+        label_and_hint = self.xml_label_and_hints()
         survey = self.get_root()
         # Resolve field references in attributes
         for key, value in control_dict.items():
@@ -273,7 +273,7 @@ class RangeQuestion(Question):
         control_dict.update(params)
         result = node(**control_dict)
         if label_and_hint:
-            for element in self.xml_label_and_hint():
+            for element in self.xml_label_and_hints():
                 result.appendChild(element)
 
         return result

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -28,6 +28,7 @@ class SurveyElement(dict):
         u"sms_option": unicode,
         u"label": unicode,
         u"hint": unicode,
+        u"guidance_hint": unicode,
         u"default": unicode,
         u"type": unicode,
         u"appearance": unicode,
@@ -243,7 +244,7 @@ class SurveyElement(dict):
                         'text': text
                     }
 
-        for display_element in [u'label', u'hint']:
+        for display_element in [u'label', u'hint', u'guidance_hint']:
             label_or_hint = self[display_element]
 
             if display_element is u'label' \
@@ -296,18 +297,31 @@ class SurveyElement(dict):
                 self.hint)
             return node(u"hint", hint, toParseString=output_inserted)
 
-    def xml_label_and_hint(self):
+    def xml_guidance_hint(self):
+        if isinstance(self.guidance_hint, dict):
+            path = self._translation_path("guidance_hint")
+            return node(u"guidance_hint", ref="jr:itext('%s')" % path, form="guidance")
+        else:
+            guidance_hint, output_inserted = self.get_root().insert_output_values(
+                self.guidance_hint)
+            return node(u"hint", guidance_hint, toParseString=output_inserted, form="guidance")
+
+
+    def xml_label_and_hints(self):
         """
-        Return a list containing one node for the label and if there
-        is a hint one node for the hint.
+        Return a list containing one node for the label, if there
+        is a hint one node for the hint and if there is a guidance hint,
+        one node for the guidance hint (used for training or for printing).
         """
         result = []
         if self.label or self.media:
             result.append(self.xml_label())
         if self.hint:
             result.append(self.xml_hint())
+        if self.guidance_hint:
+            result.append(self.xml_guidance_hint())
 
-        if len(result) == 0:
+        if len(result) == 0 or (len(result) == 1 and self.guidance_hint):
             msg = "The survey element named '%s' " \
                   "has no label or hint." % self.name
             raise PyXFormError(msg)

--- a/pyxform/tests_v1/test_guidance_hint.py
+++ b/pyxform/tests_v1/test_guidance_hint.py
@@ -1,0 +1,45 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class GuidanceHintTest(PyxformTestCase):
+    def test_single_language_guidance(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |           |                              |
+            |        | type   |   name   | label | hint      | guidance_hint                |
+            |        | string |   name   | Name  | your name | as shown on birth certificate|
+            """,
+            xml__contains=[
+                '<hint>your name</hint>',
+                '<hint form="guidance">as shown on birth certificate</hint>'],
+        )
+
+    def test_multi_language_guidance(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |           |                              |                                     |
+            |        | type   |   name   | label | hint      | guidance_hint::English (en)  | guidance_hint::French (fr)          |
+            |        | string |   name   | Name  | your name | as shown on birth certificate| comme sur le certificat de naissance|
+            """,
+            xml__contains=[
+                '<translation lang="French (fr)">',
+                '<value>comme sur le certificat de naissance</value>',
+                '<translation lang="English (en)">',
+                '<value>as shown on birth certificate</value>',
+                '<guidance_hint form=\"guidance\" ref=\"jr:itext(\'/data/name:guidance_hint\')\"/>'],
+        )
+
+    def test_guidance_hint_only(self):
+        self.assertPyxformXform(
+            name="data",
+            errored=True,
+            md="""
+            | survey |        |          |                              |
+            |        | type   |   name   | guidance_hint                |
+            |        | string |   name   | as shown on birth certificate|
+            """,
+            error__contains=[
+                'The survey element named \'name\' has no label or hint.'],
+        )

--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -385,6 +385,9 @@ class XFormToDictBuilder:
                     question[_k] = _v
             else:
                 question[k] = v
+        if 'guidance_hint' in obj:
+            k, v = self._get_label(obj['guidance_hint'], 'guidance_hint')
+            question[k] = v
         if 'autoplay' in obj or 'appearance' in obj \
                 or 'count' in obj or 'rows' in obj:
             question['control'] = {}


### PR DESCRIPTION
Closes #142

I considered calling `xml_guidance_hint` directly from `question` but ultimately found it cleaner to include all hint variants in `xml_label_and_hints`.