### PR TITLE
Add max-pixels parameter for images

### DIFF
--- a/pyxform/tests_v1/test_max_pixels.py
+++ b/pyxform/tests_v1/test_max_pixels.py
@@ -1,0 +1,44 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+class MaxPixelsTest(PyxformTestCase):
+    def test_integer_max_pixels(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                |
+            |        | type   | name     | label | parameters     |
+            |        | image  | my_image | Image | max-pixels=640 |
+            """,
+            xml__contains=[
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/data/my_image" type="binary" orx:max-pixels="640"/>'
+                ]
+        )
+
+    def test_string_max_pixels(self):
+        self.assertPyxformXform(
+            name="data",
+            errored=True,
+            md="""
+            | survey |        |          |       |                |
+            |        | type   | name     | label | parameters     |
+            |        | image  | my_image | Image | max-pixels=foo |
+            """,
+            error__contains=[
+                "Parameter max-pixels must have an integer value."
+                ]
+        )
+
+    def test_string_extra_params(self):
+        self.assertPyxformXform(
+            name="data",
+            errored=True,
+            md="""
+            | survey |        |          |       |                        |
+            |        | type   | name     | label | parameters             |
+            |        | image  | my_image | Image | max-pixels=640 foo=bar |
+            """,
+            error__contains=[
+                "Accepted parameters are 'max-pixels': 'foo' is an invalid parameter."
+                ]
+        )

--- a/pyxform/tests_v1/test_randomize_itemsets.py
+++ b/pyxform/tests_v1/test_randomize_itemsets.py
@@ -120,7 +120,7 @@ class RandomizeItemsetsTest(PyxformTestCase):
 
             """,
             error__contains=[
-                "Selects accept parameters 'randomize' and 'seed': 'step' is an invalid parameter."
+                "Accepted parameters are 'randomize, seed': 'step' is an invalid parameter."
                 ]
         )
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -892,6 +892,21 @@ def workbook_to_json(
             parent_children_array.append(new_dict)
             continue
 
+        if question_type == 'photo':
+            new_dict = row.copy()
+            parameters = get_parameters(row.get('parameters', ''), ['max-pixels'])
+
+            if 'max-pixels' in parameters.keys():
+                try:
+                    int(parameters['max-pixels'])
+                except:
+                    raise PyXFormError("Parameter max-pixels must have an integer value.")
+
+                new_dict['bind'] = new_dict.get('bind', {})
+                new_dict['bind'].update({'orx:max-pixels': parameters['max-pixels']})
+            parent_children_array.append(new_dict)
+            continue
+
         # TODO: Consider adding some question_type validation here.
 
         # Put the row in the json dict as is:

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -264,32 +264,18 @@ def process_range_question_type(row):
     Raises PyXFormError when invalid range parameters are used.
     """
     new_dict = row.copy()
-    parameters = _parameters(new_dict.get('parameters', ''))
+    parameters = get_parameters(new_dict.get('parameters', ''), ['start', 'end', 'step'])
     parameters_map = {'start': 'start', 'end': 'end', 'step': 'step'}
     defaults = {'start': '1', 'end': '10', 'step': '1'}
-    params = {}
-
-    for param in parameters:
-        if '=' not in param:
-            raise PyXFormError("Expecting parameters to be in the form of "
-                               "'start=X end=X step=X'.")
-        k, v = param.split('=')[:2]
-        key = parameters_map.get(k.lower().strip())
-        if key:
-            params[key] = v.strip()
-        else:
-            raise PyXFormError(
-                "Range has the parameters 'start', 'end' and"
-                " 'step': '%s' is an invalid parameter." % k)
 
     # set defaults
     for key in parameters_map.values():
-        if key not in params:
-            params[key] = defaults[key]
+        if key not in parameters:
+            parameters[key] = defaults[key]
 
     try:
         has_float = any(
-            [float(x) and '.' in str(x) for x in params.values()])
+            [float(x) and '.' in str(x) for x in parameters.values()])
     except ValueError:
         raise PyXFormError("Range parameters 'start', "
                            "'end' or 'step' must all be numbers.")
@@ -299,7 +285,7 @@ def process_range_question_type(row):
             new_dict['bind'] = new_dict.get('bind', {})
             new_dict['bind'].update({'type': 'decimal'})
 
-    new_dict['parameters'] = params
+    new_dict['parameters'] = parameters
 
     return new_dict
 
@@ -816,37 +802,23 @@ def workbook_to_json(
                 new_json_dict[constants.TYPE] = select_type
 
                 # Look at parameters column for randomization parameters
-                parameters = _parameters(row.get('parameters', ''))
-                allowed_params = ['randomize', 'seed']
+                parameters = get_parameters(row.get('parameters', ''), ['randomize', 'seed'])
 
-                params = {}
-                for param in parameters:
-                    if '=' not in param:
-                        raise PyXFormError("Expecting parameters to be in the form of"
-                            "'randomize=true seed=324.2'.")
-                    k, v = param.split('=')[:2]
-                    key = k.lower().strip()
-                    if key in allowed_params:
-                        params[key] = v.lower().strip()
-                    else:
-                        raise PyXFormError("Selects accept parameters "
-                            "'randomize' and 'seed': '%s' is an invalid parameter." % key)
+                if "randomize" in parameters.keys():
+                    if parameters["randomize"] != "true" and parameters["randomize"] != "false":
+                        raise PyXFormError("randomize must be set to true or false: "
+                            "'%s' is an invalid value" % parameters["randomize"])
 
-                    if "randomize" in params.keys():
-                        if params["randomize"] != "true" and params["randomize"] != "false":
-                            raise PyXFormError("randomize must be set to true or false: "
-                                "'%s' is an invalid value" % params["randomize"])
-
-                        if "seed" in params.keys():
-                            try:
-                                float(params["seed"])
-                            except ValueError:
-                                raise PyXFormError("seed value must be a number.")
-                    elif "seed" in params.keys():
-                        raise PyXFormError("Parameters must include randomize=true to use a seed.")
+                    if "seed" in parameters.keys():
+                        try:
+                            float(parameters["seed"])
+                        except ValueError:
+                            raise PyXFormError("seed value must be a number.")
+                elif "seed" in parameters.keys():
+                    raise PyXFormError("Parameters must include randomize=true to use a seed.")
 
 
-                new_json_dict['parameters'] = params
+                new_json_dict['parameters'] = parameters
 
                 if row.get('choice_filter'):
                     if select_type == 'select one external':
@@ -854,9 +826,8 @@ def workbook_to_json(
                     else:
                         new_json_dict['itemset'] = list_name
                         json_dict['choices'] = choices
-                elif "randomize" in params.keys() and params["randomize"] == "true":
+                elif "randomize" in parameters.keys() and parameters["randomize"] == "true":
                         new_json_dict['itemset'] = list_name
-                        new_json_dict['randomize'] = True
                         json_dict['choices'] = choices
                 elif file_extension in ['.csv', '.xml']:
                     new_json_dict['itemset'] = list_name
@@ -1040,14 +1011,27 @@ def organize_by_values(dict_list, key):
             result[val] = dicty_copy
     return result
 
-def _parameters(parameters):
-    parts = parameters.split(';')
+def get_parameters(raw_parameters, allowed_parameters):
+    parts = raw_parameters.split(';')
     if len(parts) == 1:
-        parts = parameters.split(',')
+        parts = raw_parameters.split(',')
     if len(parts) == 1:
-        parts = parameters.split()
+        parts = raw_parameters.split()
 
-    return parts
+    params = {}
+    for param in parts:
+        if '=' not in param:
+            raise PyXFormError("Expecting parameters to be in the form of "
+                            "'parameter1=value parameter2=value'.")
+        k, v = param.split('=')[:2]
+        key = k.lower().strip()
+        if key in allowed_parameters:
+            params[key] = v.lower().strip()
+        else:
+            raise PyXFormError("Accepted parameters are "
+                "'%s': '%s' is an invalid parameter." % (", ".join(allowed_parameters),  key))
+
+    return params
 
 
 class SpreadsheetReader(object):


### PR DESCRIPTION
Closes #137

Let's hope I didn't do anything too crazy this time!

a1e24ed pulls out code common to types that can have values in the parameters column as we had discussed in a prior PR.

Instead of passing on the `max-pixels` value in `parameters` I went straight to adding it to the `bind` dictionary.

One thing that confuses me is that in the happy case test the order of the bind attributes isn't what I expected: https://github.com/XLSForm/pyxform/compare/master...lognaturel:pyxform-137?expand=1#diff-86152448d7cce73f07b4cd294f930633R14. In fact, when I set debug=True, `orx:max-pixel` comes before `type` to give `<bind nodeset="/data/my_image" orx:max-pixels="640" type="binary"/>`. I don't think this is a symptom of a deeper problem but would be good to get a double check.

The very astute will notice an unrelated change at https://github.com/XLSForm/pyxform/compare/master...lognaturel:pyxform-137?expand=1#diff-b29aeb282b118614b8333cdfc19f700dL859. I noticed that it wasn't used so I snuck that in as part of the extraction.