### PR TITLE
Add support for guidance hints

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -304,7 +304,7 @@ class SurveyElement(dict):
             return node(u"label", label, toParseString=output_inserted)
 
     def xml_hint(self):
-        if isinstance(type(self.hint), dict) or self.guidance_hint:
+        if isinstance(self.hint, dict) or self.guidance_hint:
             path = self._translation_path("hint")
             return node(u"hint", ref="jr:itext('%s')" % path)
         else:

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -28,6 +28,7 @@ class SurveyElement(dict):
         u"sms_option": unicode,
         u"label": unicode,
         u"hint": unicode,
+        u"guidance_hint": unicode,
         u"default": unicode,
         u"type": unicode,
         u"appearance": unicode,
@@ -243,13 +244,28 @@ class SurveyElement(dict):
                         'text': text
                     }
 
-        for display_element in [u'label', u'hint']:
+        for display_element in [u'label', u'hint', u'guidance_hint']:
             label_or_hint = self[display_element]
 
             if display_element is u'label' \
                     and self.needs_itext_ref() \
                     and type(label_or_hint) is not dict \
                     and label_or_hint:
+                label_or_hint = {default_language: label_or_hint}
+
+            # always use itext for guidance hints because that's
+            # how they're defined - https://opendatakit.github.io/xforms-spec/#languages
+            if display_element is u'guidance_hint' \
+                    and not(isinstance(label_or_hint, dict)) \
+                    and len(label_or_hint) > 0:
+                label_or_hint = {default_language: label_or_hint}
+
+            # always use itext for hint if there's a guidance hint
+            if display_element is u'hint' \
+                    and not(isinstance(label_or_hint, dict)) \
+                    and len(label_or_hint) > 0 \
+                    and "guidance_hint" in self.keys() \
+                    and len(self["guidance_hint"]) > 0:
                 label_or_hint = {default_language: label_or_hint}
 
             if type(label_or_hint) is dict:
@@ -288,7 +304,7 @@ class SurveyElement(dict):
             return node(u"label", label, toParseString=output_inserted)
 
     def xml_hint(self):
-        if type(self.hint) == dict:
+        if isinstance(type(self.hint), dict) or self.guidance_hint:
             path = self._translation_path("hint")
             return node(u"hint", ref="jr:itext('%s')" % path)
         else:
@@ -304,10 +320,10 @@ class SurveyElement(dict):
         result = []
         if self.label or self.media:
             result.append(self.xml_label())
-        if self.hint:
+        if self.hint or self.guidance_hint:
             result.append(self.xml_hint())
 
-        if len(result) == 0:
+        if len(result) == 0 or self.guidance_hint and len(result) == 1:
             msg = "The survey element named '%s' " \
                   "has no label or hint." % self.name
             raise PyXFormError(msg)

--- a/pyxform/tests_v1/test_guidance_hint.py
+++ b/pyxform/tests_v1/test_guidance_hint.py
@@ -1,0 +1,88 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class GuidanceHintTest(PyxformTestCase):
+    def test_hint_only(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |           |
+            |        | type   |   name   | label | hint      |
+            |        | string |   name   | Name  | your name |
+            """,
+            xml__contains=[
+                '<hint>your name</hint>'
+            ]
+        )
+
+    def test_guidance_hint_and_label(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                              |
+            |        | type   |   name   | label | guidance_hint                |
+            |        | string |   name   | Name  | as shown on birth certificate|
+            """,
+            xml__contains=[
+                '<hint ref="jr:itext(\'/data/name:hint\')"/>',
+                '<value form=\"guidance\">as shown on birth certificate</value>',
+                '<hint ref="jr:itext(\'/data/name:hint\')"/>'
+            ]
+        )
+
+    def test_hint_and_guidance_one_language(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |           |                              |
+            |        | type   |   name   | label | hint      | guidance_hint                |
+            |        | string |   name   | Name  | your name | as shown on birth certificate|
+            """,
+            xml__contains=[
+                '<hint ref="jr:itext(\'/data/name:hint\')"/>',
+                '<value>your name</value>',
+                '<value form=\"guidance\">as shown on birth certificate</value>'],
+        )
+
+    def test_multi_language_guidance(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |           |                              |                                     |
+            |        | type   |   name   | label | hint      | guidance_hint                | guidance_hint::French (fr)          |
+            |        | string |   name   | Name  | your name | as shown on birth certificate| comme sur le certificat de naissance|
+            """,
+            xml__contains=[
+                '<translation lang="French (fr)">',
+                '<value form=\"guidance\">comme sur le certificat de naissance</value>',
+                '<translation default="true()" lang="default">',
+                '<value form=\"guidance\">as shown on birth certificate</value>',
+                '<hint ref="jr:itext(\'/data/name:hint\')"/>'],
+        )
+
+    def test_guidance_hint_only(self):
+        self.assertPyxformXform(
+            name="data",
+            errored=True,
+            md="""
+            | survey |        |          |                              |
+            |        | type   |   name   | guidance_hint                |
+            |        | string |   name   | as shown on birth certificate|
+            """,
+            error__contains=[
+                'The survey element named \'name\' has no label or hint.'],
+        )
+
+
+    def test_multi_language_guidance_only(self):
+        self.assertPyxformXform(
+            name="data",
+            errored=True,
+            md="""
+            | survey |        |          |                              |                                     |
+            |        | type   |   name   | guidance_hint                | guidance_hint::French (fr)          |
+            |        | string |   name   | as shown on birth certificate| comme sur le certificat de naissance|
+            """,
+            error__contains=[
+                'The survey element named \'name\' has no label or hint.'],
+        )

--- a/pyxform/tests_v1/test_guidance_hint.py
+++ b/pyxform/tests_v1/test_guidance_hint.py
@@ -86,3 +86,18 @@ class GuidanceHintTest(PyxformTestCase):
             error__contains=[
                 'The survey element named \'name\' has no label or hint.'],
         )
+
+    def test_multi_language_hint(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |                      |                    |
+            |        | type   |   name   | hint                 | hint::French (fr)  |
+            |        | string |   name   | default language hint| French hint        |
+            """,
+            xml__contains=[
+                "<hint ref=\"jr:itext('/data/name:hint')\"/>",
+                "<value>French hint</value>",
+                "<value>default language hint</value>"
+                ],
+        )


### PR DESCRIPTION
Closes #142 

Second time's a charm? 😇

See below for some sample output. There are additional cases in the tests -- any I forgot?

The json representation has a `guidance_hint` element separate from `hint`. I collapse them for the XML representation in `_setup_translations`. That's the part I was least sure about.

Other than that there are some shenanigans to make sure an `itext` is always used when there's a `guidance_hint`, even if there's a single language. That's in `survey_element` and it's a little messy.

CC @jd-alexander

## Guidance hint only
```xml
<?xml version="1.0"?>
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <h:head>
    <h:title>pyxform_autotesttitle</h:title>
    <model>
      <itext>
        <translation default="true()" lang="default">
          <text id="/data/name:hint">
            <value form="guidance">as shown on birth certificate</value>
          </text>
        </translation>
      </itext>
      <instance>
        <data id="pyxform_autotest_id_string">
          <name/>
          <meta>
            <instanceID/>
          </meta>
        </data>
      </instance>
      <bind nodeset="/data/name" type="string"/>
      <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
    </model>
  </h:head>
  <h:body>
    <input ref="/data/name">
      <label>Name</label>
      <hint ref="jr:itext('/data/name:hint')"/>
    </input>
  </h:body>
</h:html>
```

## Regular hint and guidance hint, multiple languages

```xml
<?xml version="1.0"?>
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <h:head>
    <h:title>pyxform_autotesttitle</h:title>
    <model>
      <itext>
        <translation default="true()" lang="default">
          <text id="/data/name:hint">
            <value>your name</value>
            <value form="guidance">as shown on birth certificate</value>
          </text>
        </translation>
        <translation lang="French (fr)">
          <text id="/data/name:hint">
            <value form="guidance">comme sur le certificat de naissance</value>
            <value>-</value>
          </text>
        </translation>
      </itext>
      <instance>
        <data id="pyxform_autotest_id_string">
          <name/>
          <meta>
            <instanceID/>
          </meta>
        </data>
      </instance>
      <bind nodeset="/data/name" type="string"/>
      <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
    </model>
  </h:head>
  <h:body>
    <input ref="/data/name">
      <label>Name</label>
      <hint ref="jr:itext('/data/name:hint')"/>
    </input>
  </h:body>
</h:html>
```