### PR TITLE
[WIP] Always output a first instance for repeats

### DIFF
--- a/pyxform/section.py
+++ b/pyxform/section.py
@@ -44,6 +44,11 @@ class Section(SurveyElement):
                 continue
             else:
                 result.appendChild(child.xml_instance())
+
+                # If this is a repeat, also insert a template to handle defaults
+                if isinstance(child, RepeatingSection):
+                    result.appendChild(child.template_instance())
+
         return result
 
     def xml_instance_array(self):
@@ -102,12 +107,9 @@ class RepeatingSection(Section):
         return node(u"group", repeat_node, ref=self.get_xpath(),
                     **self.control)
 
-    # I'm anal about matching function signatures when overriding a function,
-    # but there's no reason for kwargs to be an argument
-    def xml_instance(self, **kwargs):
-        kwargs = {"jr:template": ""}  # It might make more sense to add this
-        #                               as a child on initialization
 
+    def template_instance(self):
+        kwargs = {"jr:template": ""}
         return super(RepeatingSection, self).xml_instance(**kwargs)
 
 

--- a/pyxform/tests_v1/test_repeats.py
+++ b/pyxform/tests_v1/test_repeats.py
@@ -1,0 +1,119 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+# Verify that a repeat results in both a single repeat instance and a
+# repeat template. This means clients always show one repeat and
+# can optionally have a template.
+class RepeatTests(PyxformTestCase):
+    def test_repeat_first_instance(self):
+        self.assertPyxformXform(
+            md="""
+            | Survey |              |         |               |
+            |        | type         | name    | label         |
+            |        | begin repeat | repeat  | My Repeat     |
+            |        | integer      | age     | the age       |
+            |        | end repeat   | repeat  |               |
+            """,
+            xml__contains=[
+                """<repeat>
+            <age/>
+          </repeat>
+          <repeat jr:template="">
+            <age/>
+          </repeat>
+          """],
+        )
+
+    def test_repeat_first_instance_default(self):
+        self.assertPyxformXform(
+            md="""
+            | Survey |              |         |               |         |
+            |        | type         | name    | label         | default |
+            |        | begin repeat | repeat  | My Repeat     |         |
+            |        | integer      | age     | the age       | 23      |
+            |        | end repeat   | repeat  |               |         |
+            """,
+            xml__contains=[
+                """<repeat>
+            <age>23</age>
+          </repeat>
+          <repeat jr:template="">
+            <age>23</age>
+          </repeat>
+          """],
+        )
+
+    def test_repeat_first_instance_default_count(self):
+        self.assertPyxformXform(
+            debug=True,
+            md="""
+            | Survey |              |         |               |         |              |
+            |        | type         | name    | label         | default | repeat_count |
+            |        | begin repeat | repeat  | My Repeat     |         | 3            |
+            |        | integer      | age     | the age       | 23      |              |
+            |        | end repeat   | repeat  |               |         |              |
+            """,
+            xml__contains=[
+                """<repeat>
+            <age>23</age>
+          </repeat>
+          <repeat </age>
+          </repeat>
+          """],
+        )
+
+    def test_repeat_first_instance_group_default(self):
+        self.assertPyxformXform(
+            md="""
+            | Survey |              |         |               |         |
+            |        | type         | name    | label         | default |
+            |        | begin repeat | repeat  | My Repeat     |         |
+            |        | begin group  | group   | My group      |         |
+            |        | integer      | age     | the age       | 23      |
+            |        | end group    | group   |               |         |
+            |        | end repeat   | repeat  |               |         |
+            """,
+            xml__contains=[
+                """<repeat>
+            <group>
+              <age>23</age>
+            </group>
+          </repeat>
+          <repeat jr:template="">
+            <group>
+              <age>23</age>
+            </group>
+          </repeat>
+          """],
+        )
+
+    def test_nested_repeat_first_instance_defaults(self):
+        self.assertPyxformXform(
+            debug=True,
+            md="""
+            | Survey |              |         |               |         |
+            |        | type         | name    | label         | default |
+            |        | begin repeat | repeat  | My Repeat     |         |
+            |        | begin repeat | repeat2 |               |         |
+            |        | integer      | age     | the age       | 23      |
+            |        | end repeat   | repeat2 |               |         |
+            |        | end repeat   | repeat  |               |         |
+            """,
+            xml__contains=[
+                """<repeat>
+            <repeat2>
+              <age>23</age>
+            </repeat2>
+            <repeat2 jr:template="">
+              <age>23</age>
+            </repeat2>
+          </repeat>
+          <repeat jr:template="">
+            <repeat2>
+              <age>23</age>
+            </repeat2>
+            <repeat2 jr:template="">
+              <age>23</age>
+            </repeat2>
+          </repeat>
+          """],
+        )


### PR DESCRIPTION
- [ ] remove count test? https://github.com/XLSForm/pyxform/pull/210#discussion_r199865425
- [ ] figure out what the nested case should actually look like https://github.com/XLSForm/pyxform/pull/210#discussion_r199863454
- [ ] fix tests that now fail 

I'm a little unclear on what should happen with nested repeats. The test at `test_nested_repeat_first_instance_defaults` shows what I expect to work though it is a little odd. It doesn't work in Collect and I haven't dug deeper to figure out why yet. @MartijnR, is Enketo happy with that?

(<i>Sidenote: is `instance` the most overloaded word ever or what?!</i>)