### PR TITLE
Add support for prefix, delimiter and tag for SMS

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -43,6 +43,10 @@ settings_header = {
     u"sms_allow_media": constants.SMS_ALLOW_MEDIA,
     u"sms_date_format": constants.SMS_DATE_FORMAT,
     u"sms_datetime_format": constants.SMS_DATETIME_FORMAT,
+
+    u"prefix": constants.COMPACT_PREFIX,
+    u"delimiter": constants.COMPACT_DELIMITER,
+
     u"set form id": constants.ID_STRING,
     u"public_key": constants.PUBLIC_KEY,
     u"submission_url": constants.SUBMISSION_URL,
@@ -61,6 +65,7 @@ survey_header = {
     u"SMS Date Format": constants.SMS_DATE_FORMAT,
     u"SMS DateTime Format": constants.SMS_DATETIME_FORMAT,
     u"SMS Response": constants.SMS_RESPONSE,
+    u"compact_tag": u"instance::odk:tag", # used for compact representation
     u"Type": u"type",
     u"List_name": u"list_name",
     # u"repeat_count": u"jr:count",  duplicate key

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -20,6 +20,12 @@ SMS_ALLOW_MEDIA = u"sms_allow_media"
 SMS_DATE_FORMAT = u"sms_date_format"
 SMS_DATETIME_FORMAT = u"sms_datetime_format"
 SMS_RESPONSE = u"sms_response"
+
+# compact representation (https://opendatakit.github.io/xforms-spec/#compact-record-representation-(for-sms))
+COMPACT_PREFIX = u"prefix"
+COMPACT_DELIMITER = u"delimiter"
+COMPACT_TAG = u"compact_tag"
+
 VERSION = u"version"
 PUBLIC_KEY = u"public_key"
 SUBMISSION_URL = u"submission_url"

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -24,6 +24,7 @@ class Question(SurveyElement):
         attributes.update(self.get(u'instance', {}))
         for key, value in attributes.items():
             attributes[key] = survey.insert_xpaths(value)
+
         if self.get(u"default"):
             return node(
                 self.name, unicode(self.get(u"default")), **attributes

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -44,6 +44,10 @@ class Survey(Section):
             u"sms_date_format": unicode,
             u"sms_datetime_format": unicode,
             u"sms_response": unicode,
+
+            constants.COMPACT_PREFIX: unicode,
+            constants.COMPACT_DELIMITER: unicode,
+
             u"file_name": unicode,
             u"default_language": unicode,
             u"_translations": dict,
@@ -375,6 +379,12 @@ class Survey(Section):
 
         if self.version:
             result.setAttribute(u"version", self.version)
+
+        if self.prefix:
+            result.setAttribute(u"odk:prefix", self.prefix)
+
+        if self.delimiter:
+            result.setAttribute(u"odk:delimiter", self.delimiter)
 
         return result
 

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -1,4 +1,5 @@
 import json
+from pyxform import constants
 from pyxform.utils import is_valid_xml_tag, node, unicode
 from pyxform.xls2json import print_pyobj_to_json
 from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
@@ -24,6 +25,7 @@ class SurveyElement(dict):
     # describes this survey element
     FIELDS = {
         u"name": unicode,
+        constants.COMPACT_TAG: unicode, # used for compact (sms) representation
         u"sms_field": unicode,
         u"sms_option": unicode,
         u"label": unicode,

--- a/pyxform/tests_v1/test_sms.py
+++ b/pyxform/tests_v1/test_sms.py
@@ -1,0 +1,69 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class SMSTest(PyxformTestCase):
+    def test_prefix_only(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |           |          |       |           |
+            |          | type      |   name   | label | hint      |
+            |          | string    |   name   | Name  | your name |
+            | settings |           |          |       |           |
+            |          | prefix    |          |       |           |
+            |          | sms_test  |          |       |           |
+            """,
+            xml__contains=[
+                'odk:prefix="sms_test"'
+            ]
+        )
+
+    def test_delimiter_only(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |           |          |       |           |
+            |          | type      |   name   | label | hint      |
+            |          | string    |   name   | Name  | your name |
+            | settings |           |          |       |           |
+            |          | delimiter |          |       |           |
+            |          | ~         |          |       |           |
+            """,
+            xml__contains=[
+                'odk:delimiter="~"'
+            ]
+        )
+
+    def test_prefix_and_delimiter(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |           |          |       |           |
+            |          | type      |   name   | label | hint      |
+            |          | string    |   name   | Name  | your name |
+            | settings |           |          |       |           |
+            |          | delimiter | prefix   |       |           |
+            |          | *         | sms_test2|       |           |
+            """,
+            xml__contains=[
+                'odk:delimiter="*"',
+                'odk:prefix="sms_test2"'
+            ]
+        )
+
+    def test_sms_tag(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |           |          |             |       |           |         |
+            |          | type      |   name   | compact_tag | label | hint      | default |
+            |          | string    |   name   | n           | Name  | your name |         |
+            |          | int       |   age    | +a          | Age   | your age  | 7       |
+            |          | string    | fruit    |             | Fruit | fav fruit |         |
+            """,
+            xml__contains=[
+                '<name odk:tag="n"/>',
+                '<age odk:tag="+a">7</age>',
+                '<fruit/>'
+            ]
+        )


### PR DESCRIPTION
See https://opendatakit.github.io/xforms-spec/#compact-record-representation-(for-sms) for the XForms spec.

Turns out that `tag` is already an alias for `name` in pyxform columns so I used `short_tag` instead. I would love to deprecate some of the aliases at some point but that's a separate conversation.

One thing that's not totally explicit in the XForms spec is whether `odk:tag` only applies to questions. I believe that to be the case because it would be a mess otherwise (we don't have any notion of closing a tag) but @jd-alexander, @yanokwa can one of you please confirm?

**EDIT:** actually, I did write "Questions that have a tag attribute..." but now I can't remember whether we explicitly discussed this.