### PR TITLE
Silence warnings to prevent breaking the build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,9 @@ install:
   - ps: python -m pip install -U pip setuptools
 
   # We need wheel installed to build wheels
-  - ps: pip install wheel
+  - ps: pip install -q -q wheel
 
-  - ps: pip install -q -r requirements.pip
+  - ps: pip install -q -q -r requirements.pip
 
 build: off
 


### PR DESCRIPTION
This might look like a bad idea since errors won't break the build, but we will only lose errors that break installing wheel and the requirements. The former is fine, but the latter might mean we don't have the correct version of the requirements if the Windows images already have those packages installed. Seems like a pretty minor risk. 