### PR TITLE
Ensure parameters are typed properly

### DIFF
--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -96,13 +96,13 @@ class AuditTest(PyxformTestCase):
         self.assertPyxformXform(
             name="meta_audit",
             md="""
-            | survey |        |          |                                                                         |
-            |        | type   |   name   | parameters                                                              |
-            |        | audit  |   audit  | location-priority=balanced, location-min-interval=1, location-max-age=2 |
+            | survey |        |          |                                                                            |
+            |        | type   |   name   | parameters                                                                 |
+            |        | audit  |   audit  | location-priority=balanced, location-min-interval=60, location-max-age=300 |
             """,
             xml__contains=[
                 '<meta>',
                 '<audit/>',
                 '</meta>',
-                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:location-max-age="2" odk:location-min-interval="1" odk:location-priority="balanced"/>'],
+                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:location-max-age="300" odk:location-min-interval="60" odk:location-priority="balanced"/>'],
         )

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -582,8 +582,8 @@ def workbook_to_json(
                                 "Parameter " + constants.LOCATION_MAX_AGE +
                                 " must be greater  than or equal to zero.")
 
-                    if parameters[constants.LOCATION_MAX_AGE] < \
-                        parameters[constants.LOCATION_MIN_INTERVAL]:
+                    if int(parameters[constants.LOCATION_MAX_AGE]) < \
+                        int(parameters[constants.LOCATION_MIN_INTERVAL]):
                         raise PyXFormError(
                             "Parameter " + constants.LOCATION_MAX_AGE +
                             " must be greater than or equal to " +


### PR DESCRIPTION
* Wrap parameters in`int()` to make the comparisons valid
* Use large and realistic numbers in the test