### PR TITLE
Clear Invalid Filename Error Message

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -1,11 +1,12 @@
 import json
 import re
+
 from pyxform import constants
+from pyxform.errors import PyXFormError
+from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
 from pyxform.utils import is_valid_xml_tag, node, unicode, \
     INVALID_XFORM_TAG_REGEXP
 from pyxform.xls2json import print_pyobj_to_json
-from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
-from pyxform.errors import PyXFormError
 
 try:
     from functools import lru_cache
@@ -137,15 +138,9 @@ class SurveyElement(dict):
 
     def validate(self):
         if not is_valid_xml_tag(self.name):
-            try:
-                invalid_char = re.search(INVALID_XFORM_TAG_REGEXP, self.name)
-                msg = "Invalid name. Remove '{}' from '{}'".format(
-                    invalid_char.group(0), self.name)
-            except AttributeError:
-                msg = "The name '{}' is an invalid xml tag. Names must begin" \
-                      " with a letter, colon, or underscore, subsequent " \
-                      "characters can include numbers, dashes, " \
-                      "and periods.".format(self.name)
+            invalid_char = re.search(INVALID_XFORM_TAG_REGEXP, self.name)
+            msg = "Invalid name. Remove '{}' from '{}'".format(
+                invalid_char.group(0), self.name)
             raise PyXFormError(msg)
 
     # TODO: Make sure renaming this doesn't cause any problems

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -1,7 +1,8 @@
 import json
-
+import re
 from pyxform import constants
-from pyxform.utils import is_valid_xml_tag, node, unicode
+from pyxform.utils import is_valid_xml_tag, node, unicode, \
+    INVALID_XFORM_TAG_REGEXP
 from pyxform.xls2json import print_pyobj_to_json
 from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
 from pyxform.errors import PyXFormError
@@ -136,9 +137,15 @@ class SurveyElement(dict):
 
     def validate(self):
         if not is_valid_xml_tag(self.name):
-            msg = "The name '%s' is an invalid xml tag. Names must begin with" \
-                  " a letter, colon, or underscore, subsequent characters can" \
-                  " include numbers, dashes, and periods." % self.name
+            try:
+                invalid_char = re.search(INVALID_XFORM_TAG_REGEXP, self.name)
+                msg = "Invalid name. Remove '{}' from '{}'".format(
+                    invalid_char.group(0), self.name)
+            except AttributeError:
+                msg = "The name '{}' is an invalid xml tag. Names must begin" \
+                      " with a letter, colon, or underscore, subsequent " \
+                      "characters can include numbers, dashes, " \
+                      "and periods.".format(self.name)
             raise PyXFormError(msg)
 
     # TODO: Make sure renaming this doesn't cause any problems

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -1,5 +1,6 @@
-import json
 import re
+
+import json
 
 from pyxform import constants
 from pyxform.errors import PyXFormError
@@ -139,8 +140,11 @@ class SurveyElement(dict):
     def validate(self):
         if not is_valid_xml_tag(self.name):
             invalid_char = re.search(INVALID_XFORM_TAG_REGEXP, self.name)
-            msg = "Invalid name. Remove '{}' from '{}'".format(
-                invalid_char.group(0), self.name)
+            msg = "The name '{}' is an invalid XML tag, it contains an " \
+                  "invalid character '{}'. Names must begin with a letter, " \
+                  "colon, or underscore, subsequent characters can include " \
+                  "numbers, dashes, and periods".format(
+                self.name, invalid_char.group(0))
             raise PyXFormError(msg)
 
     # TODO: Make sure renaming this doesn't cause any problems

--- a/pyxform/tests_v1/test_sheet_columns.py
+++ b/pyxform/tests_v1/test_sheet_columns.py
@@ -130,10 +130,11 @@ class InvalidChoiceSheetColumnsTests(PyxformTestCase):
             ])
 
     def test_clear_filename_error_message(self):
-        """
-        Test clear filename
-        """
-
+        """Test clear filename error message"""
+        error_message = "The name 'bad@filename' is an invalid XML tag, it " \
+                        "contains an invalid character '@'. Names must begin" \
+                        " with a letter, colon, or underscore, subsequent " \
+                        "characters can include numbers, dashes, and periods"
         self.assertPyxformXform(
             name='bad@filename',
             ss_structure=self._simple_choice_ss([
@@ -144,7 +145,7 @@ class InvalidChoiceSheetColumnsTests(PyxformTestCase):
                     'name': 'c2',
                     'label': 'choice 2'}]),
             errored=True,
-            error__contains=["Invalid name. Remove '@' from 'bad@filename'"]
+            error__contains=[error_message]
             )
 
 

--- a/pyxform/tests_v1/test_sheet_columns.py
+++ b/pyxform/tests_v1/test_sheet_columns.py
@@ -129,6 +129,24 @@ class InvalidChoiceSheetColumnsTests(PyxformTestCase):
                 'list name',
             ])
 
+    def test_clear_filename_error_message(self):
+        """
+        Test clear filename
+        """
+
+        self.assertPyxformXform(
+            name='bad@filename',
+            ss_structure=self._simple_choice_ss([
+                {'list_name': 'l1',
+                    'name': 'c1',
+                    'label': 'choice 1'},
+                {'list_name': 'l1',
+                    'name': 'c2',
+                    'label': 'choice 2'}]),
+            errored=True,
+            error__contains=["Invalid name. Remove '@' from 'bad@filename'"]
+            )
+
 
 class AliasesTests(PyxformTestCase):
     """

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -33,7 +33,7 @@ XFORM_TAG_REGEXP = "%(start)s%(char)s*" % {
     "char": TAG_CHAR
 }
 
-INVALID_XFORM_TAG_REGEXP = r"[^a-zA-Z:_][^a-zA-Z:_0-9\\-.]*"
+INVALID_XFORM_TAG_REGEXP = r"[^a-zA-Z:_][^a-zA-Z:_0-9\-.]*"
 
 NSMAP = {
     u"xmlns": u"http://www.w3.org/2002/xforms",

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -32,6 +32,9 @@ XFORM_TAG_REGEXP = "%(start)s%(char)s*" % {
     "start": TAG_START_CHAR,
     "char": TAG_CHAR
 }
+
+INVALID_XFORM_TAG_REGEXP = r"[^a-zA-Z:_][^a-zA-Z:_0-9\\-.]*"
+
 NSMAP = {
     u"xmlns": u"http://www.w3.org/2002/xforms",
     u"xmlns:h": u"http://www.w3.org/1999/xhtml",


### PR DESCRIPTION
Provide a clear error message. State exact error, if a filename is invalid. 
Fixes #22