### PR TITLE
issue 157 - warn users when any language is missing a tranlsation and blanking fields

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -562,7 +562,6 @@ class Survey(Section):
         When translations are not provided "-" will be used.
         This disables any of the default_language fallback functionality.
         """
-
         if warnings is None:
             warnings = []
 

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -178,7 +178,7 @@ class Survey(Section):
 
         return NSMAP
 
-    def xml(self):
+    def xml(self, warnings=None):
         """
         calls necessary preparation methods, then returns the xml.
         """
@@ -432,13 +432,13 @@ class Survey(Section):
                 yield i.instance
             seen[i.name] = i
 
-    def xml_model(self):
+    def xml_model(self, warnings=None):
         """
         Generate the xform <model> element
         """
         self._setup_translations()
         self._setup_media()
-        self._add_empty_translations()
+        self._add_empty_translations(warnings)
 
         model_children = []
         if self._translations:
@@ -555,13 +555,16 @@ class Survey(Section):
                             choice_value,
                         )
 
-    def _add_empty_translations(self):
+    def _add_empty_translations(self, warnings=None):
         """
         Adds translations so that every itext element has the same elements \
         accross every language.
         When translations are not provided "-" will be used.
         This disables any of the default_language fallback functionality.
         """
+        if warnings is None:
+            warnings = []
+
         paths = {}
         for lang, translation in self._translations.items():
             for path, content in translation.items():
@@ -573,6 +576,13 @@ class Survey(Section):
                     self._translations[lang][path] = {}
                 for content_type in content_types:
                     if content_type not in self._translations[lang][path]:
+                        if lang == 'default':
+                            warnings.append('\tDefault language not set,' +
+                                            ' with no default translations for ' + content_type
+                                            + ' Please consider setting a `default_language` in your'
+                                            + ' settings tab to insure questions and options appear'
+                                            + ' as expected.'
+                                            )
                         self._translations[lang][path][content_type] = "-"
 
     def _setup_media(self):
@@ -712,10 +722,10 @@ class Survey(Section):
         """Returns a date string with the format of %Y_%m_%d."""
         return self._created.strftime("%Y_%m_%d")
 
-    def _to_ugly_xml(self):
-        return '<?xml version="1.0"?>' + self.xml().toxml()
+    def _to_ugly_xml(self, warnings=None):
+        return '<?xml version="1.0"?>' + self.xml(warnings).toxml()
 
-    def _to_pretty_xml(self):
+    def _to_pretty_xml(self, warnings=None):
         """
         I want the to_xml method to by default validate the xml we are
         producing.
@@ -837,6 +847,8 @@ class Survey(Section):
         Print the xForm to a file and optionally validate it as well by
         throwing exceptions and adding warnings to the warnings array.
         """
+        print('print xform to file')
+        print('i has warnigns!')
         if warnings is None:
             warnings = []
         if not path:
@@ -844,9 +856,9 @@ class Survey(Section):
         try:
             with codecs.open(path, mode="w", encoding="utf-8") as file_obj:
                 if pretty_print:
-                    file_obj.write(self._to_pretty_xml())
+                    file_obj.write(self._to_pretty_xml(warnings))
                 else:
-                    file_obj.write(self._to_ugly_xml())
+                    file_obj.write(self._to_ugly_xml(warnings))
         except Exception as error:
             if os.path.exists(path):
                 os.unlink(path)
@@ -896,9 +908,9 @@ class Survey(Section):
             if os.path.exists(tmp.name):
                 os.remove(tmp.name)
         if pretty_print:
-            return self._to_pretty_xml()
+            return self._to_pretty_xml(warnings)
 
-        return self._to_ugly_xml()
+        return self._to_ugly_xml(warnings)
 
     def instantiate(self):
         """

--- a/pyxform/tests_v1/test_language_warnings.py
+++ b/pyxform/tests_v1/test_language_warnings.py
@@ -72,6 +72,66 @@ class LanguageWarningTest(PyxformTestCase):
         )
         os.unlink(tmp.name)
 
+    def test_missing_translation_no_default_lang_media_has_no_language(self):
+        # form should test media tag w NO default language set.
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey  |                 |         |                     |             |
+            |         | type            | name    | label::English (en) | media::image|
+            |         | integer         | nums    | How many nums?      | opt1.jpg    |
+        """
+        )
+
+        warnings = []
+        tmp = tempfile.NamedTemporaryFile(suffix=".xml", delete=False)
+        tmp.close()
+        survey.print_xform_to_file(tmp.name, warnings=warnings)
+
+        # In this survey, when 'default' s selected the label of this question will be '-'.
+        # Also, when 'English (en)` is selected, the medial will be '-'
+        self.assertTrue(len(warnings) == 2)
+        os.unlink(tmp.name)
+
+    def test_missing_translation_media(self):
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey  |                 |         |                     |                    |                          |
+            |         | type            | name    | label::English (en) | label::French (fr) | media::image::French (fr)|
+            |         | integer         | nums    | How many nums?      | Combien noms?      | opt1.jpg                 |
+        """
+        )
+
+        warnings = []
+        tmp = tempfile.NamedTemporaryFile(suffix=".xml", delete=False)
+        tmp.close()
+        survey.print_xform_to_file(tmp.name, warnings=warnings)
+        self.assertTrue(len(warnings) == 1)
+        self.assertIn(
+            "Question missing translation: /pyxform_autotestname/nums", warnings[0]
+        )
+        self.assertIn("Column missing: image", warnings[0])
+        os.unlink(tmp.name)
+
+    def test_missing_translation_hint(self):
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey  |                 |         |                     |                    |                   |
+            |         | type            | name    | label::English (en) | label::French (fr) | hint::French (fr) |
+            |         | integer         | nums    | How many nums?      | Combien noms?      | noms est nombres  |
+        """
+        )
+
+        warnings = []
+        tmp = tempfile.NamedTemporaryFile(suffix=".xml", delete=False)
+        tmp.close()
+        survey.print_xform_to_file(tmp.name, warnings=warnings)
+        self.assertTrue(len(warnings) == 1)
+        self.assertIn(
+            "Question missing translation: /pyxform_autotestname/nums", warnings[0]
+        )
+        self.assertIn("Column missing: hint", warnings[0])
+        os.unlink(tmp.name)
+
     def test_default_language_only_should_not_warn(self):
         survey = self.md_to_pyxform_survey(
             """
@@ -82,7 +142,7 @@ class LanguageWarningTest(PyxformTestCase):
             |        | list_name       | name    | label  | fake          |
             |        | opts            | opt1    | Opt1   | 1             |
             |        | opts            | opt2    | Opt2   | 1             |
-            """
+        """
         )
 
         warnings = []


### PR DESCRIPTION
I was having trouble detecting media columns and the like early, and I realized the media column wasn't really the problem here, it was the unlabelled column.

So I dug for where the `-` was being literally added to the XML as an answer value and added the warning there.