### PR TITLE
Big-image support

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -92,6 +92,7 @@ survey_header = {
     "image": "media::image",
     "audio": "media::audio",
     "video": "media::video",
+    "big-image": "media::big-image",
     "count": "control::jr:count",
     "repeat_count": "control::jr:count",
     "jr:count": "control::jr:count",
@@ -113,6 +114,7 @@ list_header = {
     "image": "media::image",
     "audio": "media::audio",
     "video": "media::video",
+    "big-image": "media::big-image",
 }
 # Note that most of the type aliasing happens in all.xls
 _type = {

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -371,4 +371,13 @@ QUESTION_TYPE_DICT = {
     "xml-external": {
         # Only effect is to add an external instance.
     },
+    "big-image": {
+        "control": {
+            "tag": "upload",
+            "mediatype": "big-image/*"
+        },
+        "bind": {
+            "type": "binary"
+        }
+    }
 }

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -141,7 +141,7 @@ class SurveyElement(dict):
     ]
 
     # Supported media types for attaching to questions
-    SUPPORTED_MEDIA = ["image", "audio", "video"]
+    SUPPORTED_MEDIA = ["image", "audio", "video", "big-image"]
 
     def validate(self):
         if not is_valid_xml_tag(self.name):

--- a/pyxform/tests_v1/test_xmldata.py
+++ b/pyxform/tests_v1/test_xmldata.py
@@ -367,6 +367,39 @@ class ExternalInstanceTests(PyxformTestCase):
         xml = survey._to_pretty_xml()
         self.assertEqual(1, xml.count(expected))
 
+    def test_big_image_column(self):
+        """test Support for big-image itext value tag type """
+        md = """
+            | survey  |                |                 |                |       |                  |
+            |         | type           | name            | label          | image | media::big-image |
+            |         | select_one a_b | big-image-test  | big-image-test | y.jpg | y.jpg            |
+            | choices |                |           |        |           |                  |
+            |         | list_name      | name      | label  | image     | media::big-image |
+            |         | a_b            | a         |        | a.jpg     | c.jpg            |
+            |         | a_b            | b         |        | b.jpg     | d.jpg            |
+            """  # noqa
+        self.assertPyxformXform(
+            name="data",
+            md=md,
+            errored=False,
+            itext__contains=[
+                '<translation default="true()" lang="default">',
+                '<text id="/data/big-image-test/b:label">',
+                '<value form="image">jr://images/b.jpg</value>',
+                '<value form="big-image">jr://big-image/d.jpg</value>',
+                '</text>',
+                '<text id="/data/big-image-test/a:label">',
+                '<value form="image">jr://images/a.jpg</value>',
+                '<value form="big-image">jr://big-image/c.jpg</value>',
+                '</text>',
+                '<text id="/data/big-image-test:label">',
+                '<value form="image">jr://images/y.jpg</value>',
+                '<value form="big-image">jr://big-image/y.jpg</value>',
+                '<value>big-image-test</value>',
+                '</text>',
+                '</translation>',
+            ])
+
     def test_external_instance_pulldata_constraint(self):
         """
         Checks if instance node for pulldata function is added


### PR DESCRIPTION

Include support for `big-image` column header
Only three media types were supported initially, including `big-image` support ensures support for all media types specified here https://opendatakit.github.io/xforms-spec/#supported-media-types
fixes #34 