### PR TITLE
Underscores in name warning

### DIFF
--- a/pyxform/tests/bug_tests.py
+++ b/pyxform/tests/bug_tests.py
@@ -1,14 +1,16 @@
 """
 Some tests for the new (v0.9) spec is properly implemented.
 """
-import unittest2 as unittest
 import codecs
 import os
+
+import unittest2 as unittest
+
 import pyxform
+from pyxform.errors import PyXFormError
+from pyxform.tests.utils import XFormTestCase
 from pyxform.utils import has_external_choices
 from pyxform.xls2json import SurveyReader, parse_file_to_workbook_dict
-from pyxform.tests.utils import XFormTestCase
-from pyxform.errors import PyXFormError
 
 DIR = os.path.dirname(__file__)
 
@@ -193,7 +195,7 @@ class BadChoicesSheetHeaders(unittest.TestCase):
         warnings = []
         pyxform.xls2json.parse_file_to_json(path_to_excel_file,
                                             warnings=warnings)
-        self.assertEquals(len(warnings), 2,
+        self.assertEquals(len(warnings), 3,
                           "Found " + str(len(warnings)) + " warnings")
 
 

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -294,7 +294,8 @@ class BasicXls2JsonApiTests(TestCase):
         self.assertGreater(len(warnings), 0)
         warning = "Google Sheets submissions don't allow underscores in the " \
                   "column name. If you intend to use Google Sheets " \
-                  "submissions, replace hidden_test with hidden-test"
+                  "submissions, replace underscores with hyphens in the " \
+                  "following names: hidden_test"
         self.assertIn(warning, warnings)
 
 

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -1,13 +1,15 @@
 """
 Testing simple cases for Xls2Json
 """
-from unittest2 import TestCase
-from pyxform.xls2json import SurveyReader
-from pyxform.xls2json_backends import xls_to_dict, csv_to_dict
-from pyxform.tests import utils
-import os
-import json
 import codecs
+import os
+
+import json
+from unittest2 import TestCase
+
+from pyxform.tests import utils
+from pyxform.xls2json import SurveyReader, parse_file_to_json
+from pyxform.xls2json_backends import xls_to_dict, csv_to_dict
 
 
 # Nothing calls this AFAICT
@@ -282,6 +284,18 @@ class BasicXls2JsonApiTests(TestCase):
         ]
         self.assertEqual(
             choice_filter_survey.to_json_dict()[u"children"], expected_dict)
+
+    def test_underscore_warnings(self):
+        """Raise warnings incase there are underscores in column names"""
+        warnings = []
+        parse_file_to_json(
+            utils.path_to_text_fixture("hidden.xls"),
+            warnings=warnings)
+        self.assertGreater(len(warnings), 0)
+        warning = "Google Sheets submissions don't allow underscores in the " \
+                  "column name. If you intend to use Google Sheets " \
+                  "submissions, replace hidden_test with hidden-test"
+        self.assertIn(warning, warnings)
 
 
 class CsvReaderEquivalencyTest(TestCase):

--- a/pyxform/tests/xlsform_spec_test.py
+++ b/pyxform/tests/xlsform_spec_test.py
@@ -1,9 +1,11 @@
 """
 Some tests for the new (v0.9) spec is properly implemented.
 """
-import unittest2 as unittest
 import codecs
 import os
+
+import unittest2 as unittest
+
 import pyxform
 from pyxform.errors import PyXFormError
 from pyxform.tests.utils import XFormTestCase
@@ -96,7 +98,7 @@ class WarningsTest(unittest.TestCase):
         pyxform.xls2json.parse_file_to_json(
             path_to_excel_file, warnings=warnings)
         self.assertEquals(
-            len(warnings), 21, "Found " + str(len(warnings)) + " warnings")
+            len(warnings), 22, "Found " + str(len(warnings)) + " warnings")
 
 
 class CalculateWithoutCalculationTest(unittest.TestCase):

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -2,15 +2,18 @@
 A Python script to convert excel files into JSON.
 """
 from __future__ import print_function, unicode_literals
-import json
-import re
-import sys
+
 import codecs
 import os
+import re
+import sys
+
+import json
+
 from pyxform import constants, aliases
 from pyxform.errors import PyXFormError
-from pyxform.xls2json_backends import xls_to_dict, csv_to_dict
 from pyxform.utils import is_valid_xml_tag, unicode, basestring
+from pyxform.xls2json_backends import xls_to_dict, csv_to_dict
 
 SMART_QUOTES = {
     '\u2018': "'",
@@ -516,6 +519,13 @@ def workbook_to_json(
 
         # Get question type
         question_type = row.get(constants.TYPE)
+        question_name = row.get(constants.NAME, ' ')
+        if '_' in question_name:
+            warnings.append(
+                "Google Sheets submissions don't allow underscores in the "
+                "column name. If you intend to use Google Sheets submissions, "
+                "replace {} with {}".format(
+                    question_name, question_name.replace('_', '-')))
         if not question_type:
             # if name and label are also missing,
             # then its a comment row, and we skip it with warning

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -498,6 +498,8 @@ def workbook_to_json(
 
     # Rows from the survey sheet that should be nested in meta
     survey_meta = []
+    # Google Sheets submissions don't allow underscores in the column name
+    names_with_underscores = []
 
     for row in survey_sheet:
         row_number += 1
@@ -519,13 +521,10 @@ def workbook_to_json(
 
         # Get question type
         question_type = row.get(constants.TYPE)
-        question_name = row.get(constants.NAME, ' ')
-        if '_' in question_name:
-            warnings.append(
-                "Google Sheets submissions don't allow underscores in the "
-                "column name. If you intend to use Google Sheets submissions, "
-                "replace {} with {}".format(
-                    question_name, question_name.replace('_', '-')))
+        question_name = row.get(constants.NAME)
+
+        if question_name and '_' in question_name:
+            names_with_underscores.append(question_name)
         if not question_type:
             # if name and label are also missing,
             # then its a comment row, and we skip it with warning
@@ -1004,6 +1003,12 @@ def workbook_to_json(
         # Put the row in the json dict as is:
         parent_children_array.append(row)
 
+    if names_with_underscores:
+        warnings.append(
+            "Google Sheets submissions don't allow underscores in the "
+            "column name. If you intend to use Google Sheets submissions, "
+            "replace underscores with hyphens in the following names: "
+            "{}".format(', '.join(names_with_underscores)))
     if len(stack) != 1:
         raise PyXFormError("Unmatched begin statement: " + str(stack[-1][0]))
 


### PR DESCRIPTION
Google Sheets submissions don't allow underscores in the column name. 
Here, a warning will be raised upon form conversion in case items in the name column have underscores. 
fixes #270 