### PR TITLE
Only convert yes/no to true()/false() on whitelisted attributes

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -132,6 +132,14 @@ class SurveyElement(dict):
         "FALSE": "false()",
     }
 
+    CONVERTIBLE_BIND_ATTRIBUTES = [
+        "readonly",
+        "required",
+        "relevant",
+        "constraint",
+        "calculate",
+    ]
+
     # Supported media types for attaching to questions
     SUPPORTED_MEDIA = ["image", "audio", "video"]
 
@@ -377,7 +385,11 @@ class SurveyElement(dict):
             for k, v in bind_dict.items():
                 # I think all the binding conversions should be happening on
                 # the xls2json side.
-                if hashable(v) and v in self.binding_conversions:
+                if (
+                    hashable(v)
+                    and v in self.binding_conversions
+                    and k in self.CONVERTIBLE_BIND_ATTRIBUTES
+                ):
                     v = self.binding_conversions[v]
                 if k == "jr:constraintMsg" and type(v) is dict:
                     v = "jr:itext('%s')" % self._translation_path("jr:constraintMsg")

--- a/pyxform/tests_v1/test_bind_conversions.py
+++ b/pyxform/tests_v1/test_bind_conversions.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""
+BindConversionsTest - test bind conversions.
+"""
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class BindConversionsTest(PyxformTestCase):
+    """
+    BindConversionsTest - test bind conversions
+    """
+
+    def test_bind_readonly_conversion(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |       |      |       |          |
+            |        | type  | name | label | readonly |
+            |        | text  | text | text  | yes      |
+            """,
+            xml__contains=['<bind nodeset="/data/text" readonly="true()"'],
+        )
+
+    def test_bind_required_conversion(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |       |      |       |          |
+            |        | type  | name | label | required |
+            |        | text  | text | text  | FALSE    |
+            """,
+            xml__contains=['<bind nodeset="/data/text" required="false()"'],
+        )
+
+    def test_bind_constraint_conversion(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |       |      |       |                    |
+            |        | type  | name | label | constraint_message |
+            |        | text  | text | text  | yes                |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/text" type="string" jr:constraintMsg="yes"'
+            ],
+        )
+
+    def test_bind_custom_conversion(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |       |      |       |           |
+            |        | type  | name | label | bind::foo |
+            |        | text  | text | text  | bar       |
+            """,
+            xml__contains=['<bind foo="bar" nodeset="/data/text" type="string"'],
+        )


### PR DESCRIPTION
Fixes #226

The whitelist comes from the XForms 1.0 attributes that we list at https://opendatakit.github.io/xforms-spec/#bind-attributes. 

Note that I didn't include `saveIncomplete`. That's because Collect doesn't actually check the value. It just checks the presence of the attribute. I'll be updating the spec.

I also don't include attributes like `jr:requiredMsg`, and `odk:location-priority`. That's because they don't accept boolean values.