### PR TITLE
Add external instance if pulldata() is used in constraint, required, readonly, relevant expressions

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -93,10 +93,4 @@ LOCATION_MAX_AGE = "location-max-age"
 TRACK_CHANGES = "track-changes"
 
 # supported bind keywords for which external instances will be created for pulldata function
-EXTERNAL_INSTANCES = [
-    "calculate",
-    "constraint",
-    "readonly",
-    "required",
-    "relevant",
-]
+EXTERNAL_INSTANCES = ["calculate", "constraint", "readonly", "required", "relevant"]

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -91,3 +91,12 @@ LOCATION_PRIORITY = "location-priority"
 LOCATION_MIN_INTERVAL = "location-min-interval"
 LOCATION_MAX_AGE = "location-max-age"
 TRACK_CHANGES = "track-changes"
+
+# supported bind keywords for which external instances will be created for pulldata function
+EXTERNAL_INSTANCES = [
+    "calculate",
+    "constraint",
+    "readonly",
+    "required",
+    "relevant",
+]

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -286,7 +286,6 @@ class Survey(Section):
 
     @staticmethod
     def _generate_pulldata_instances(element):
-
         def get_pulldata_functions(element):
             """
             Returns a list of different pulldata(... function strings if
@@ -297,16 +296,15 @@ class Survey(Section):
             """
             functions_present = []
             for formula_name in constants.EXTERNAL_INSTANCES:
-                if unicode(element['bind'].get(formula_name)).startswith('pulldata('):
-                    functions_present.append(element['bind'][formula_name])
+                if unicode(element["bind"].get(formula_name)).startswith("pulldata("):
+                    functions_present.append(element["bind"][formula_name])
             return functions_present
 
         formulas = get_pulldata_functions(element)
         if len(formulas) > 0:
             formula_instances = []
             for formula in formulas:
-                pieces = formula.split('"') \
-                    if '"' in formula else formula.split("'")
+                pieces = formula.split('"') if '"' in formula else formula.split("'")
                 if len(pieces) > 1 and pieces[1]:
                     file_id = pieces[1]
                     uri = "jr://file-csv/{}.csv".format(file_id)
@@ -315,7 +313,7 @@ class Survey(Section):
                             type=u"pulldata",
                             context="[type: {t}, name: {n}]".format(
                                 t=element[u"parent"][u"type"],
-                                n=element[u"parent"][u"name"]
+                                n=element[u"parent"][u"name"],
                             ),
                             name=file_id,
                             src=uri,
@@ -323,8 +321,8 @@ class Survey(Section):
                                 "instance",
                                 Survey._get_dummy_instance(),
                                 id=file_id,
-                                src=uri
-                            )
+                                src=uri,
+                            ),
                         )
                     )
             return formula_instances

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -302,7 +302,7 @@ class Survey(Section):
             return functions_present
 
         formulas = get_pulldata_functions(element)
-        if len(formulas):
+        if len(formulas) > 0:
             formula_instances = []
             for formula in formulas:
                 pieces = formula.split('"') \

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -286,30 +286,48 @@ class Survey(Section):
 
     @staticmethod
     def _generate_pulldata_instances(element):
-        if "calculate" in element["bind"]:
-            calculate = element["bind"]["calculate"]
-            if calculate.startswith("pulldata("):
-                pieces = (
-                    calculate.split('"') if '"' in calculate else calculate.split("'")
-                )
+
+        def get_pulldata_functions(element):
+            """
+            Returns a list of different pulldata(... function strings if
+            pulldata function is defined at least once for any of:
+            calculate, constraint, readonly, required, relevant
+
+            :param: element (pyxform.survey.Survey):
+            """
+            functions_present = []
+            for formula_name in constants.EXTERNAL_INSTANCES:
+                if unicode(element['bind'].get(formula_name)).startswith('pulldata('):
+                    functions_present.append(element['bind'][formula_name])
+            return functions_present
+
+        formulas = get_pulldata_functions(element)
+        if len(formulas):
+            formula_instances = []
+            for formula in formulas:
+                pieces = formula.split('"') \
+                    if '"' in formula else formula.split("'")
                 if len(pieces) > 1 and pieces[1]:
                     file_id = pieces[1]
                     uri = "jr://file-csv/{}.csv".format(file_id)
-                    return InstanceInfo(
-                        type="pulldata",
-                        context="[type: {t}, name: {n}]".format(
-                            t=element["parent"]["type"], n=element["parent"]["name"]
-                        ),
-                        name=file_id,
-                        src=uri,
-                        instance=node(
-                            "instance",
-                            Survey._get_dummy_instance(),
-                            id=file_id,
+                    formula_instances.append(
+                        InstanceInfo(
+                            type=u"pulldata",
+                            context="[type: {t}, name: {n}]".format(
+                                t=element[u"parent"][u"type"],
+                                n=element[u"parent"][u"name"]
+                            ),
+                            name=file_id,
                             src=uri,
-                        ),
+                            instance=node(
+                                "instance",
+                                Survey._get_dummy_instance(),
+                                id=file_id,
+                                src=uri
+                            )
+                        )
                     )
-
+            return formula_instances
         return None
 
     @staticmethod
@@ -374,7 +392,9 @@ class Survey(Section):
             i_ext = self._generate_external_instances(element=i)
             i_pull = self._generate_pulldata_instances(element=i)
             i_file = self._generate_from_file_instances(element=i)
-            instances += [x for x in [i_ext, i_pull, i_file] if x is not None]
+            for x in [i_ext, i_pull, i_file]:
+                if x is not None:
+                    instances += x if isinstance(x, list) else [x]
 
         # Append last so the choice instance is excluded on a name clash.
         for name, value in self.choices.items():

--- a/pyxform/tests_v1/test_xmldata.py
+++ b/pyxform/tests_v1/test_xmldata.py
@@ -367,7 +367,7 @@ class ExternalInstanceTests(PyxformTestCase):
         xml = survey._to_pretty_xml()
         self.assertEqual(1, xml.count(expected))
 
-    def test_external_instance_pulldata_constraints(self):
+    def test_external_instance_pulldata_constraint(self):
         """
         Checks if instance node for pulldata function is added
         when pulldata occurs in column with constraint title
@@ -433,7 +433,6 @@ class ExternalInstanceTests(PyxformTestCase):
                                     node
                                 ],
                                 debug=True)
-
 
     def test_external_instance_pulldata(self):
         """

--- a/pyxform/tests_v1/test_xmldata.py
+++ b/pyxform/tests_v1/test_xmldata.py
@@ -378,10 +378,7 @@ class ExternalInstanceTests(PyxformTestCase):
         |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
         """
         node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
-        self.assertPyxformXform(md=md,
-                                xml__contains=[
-                                    node
-                                ])
+        self.assertPyxformXform(md=md, xml__contains=[node])
 
     def test_external_instance_pulldata_readonly(self):
         """
@@ -395,10 +392,7 @@ class ExternalInstanceTests(PyxformTestCase):
         """
         node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
 
-        self.assertPyxformXform(md=md,
-                                xml__contains=[
-                                    node
-                                ])
+        self.assertPyxformXform(md=md, xml__contains=[node])
 
     def test_external_instance_pulldata_required(self):
         """
@@ -411,11 +405,7 @@ class ExternalInstanceTests(PyxformTestCase):
         |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
         """
         node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
-        self.assertPyxformXform(md=md,
-                                xml__contains=[
-                                    node
-                                ],
-                                debug=True)
+        self.assertPyxformXform(md=md, xml__contains=[node], debug=True)
 
     def test_external_instance_pulldata_relevant(self):
         """
@@ -428,11 +418,7 @@ class ExternalInstanceTests(PyxformTestCase):
         |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
         """
         node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
-        self.assertPyxformXform(md=md,
-                                xml__contains=[
-                                    node
-                                ],
-                                debug=True)
+        self.assertPyxformXform(md=md, xml__contains=[node], debug=True)
 
     def test_external_instance_pulldata(self):
         """

--- a/pyxform/tests_v1/test_xmldata.py
+++ b/pyxform/tests_v1/test_xmldata.py
@@ -366,3 +366,107 @@ class ExternalInstanceTests(PyxformTestCase):
         survey = self.md_to_pyxform_survey(md_raw=md)
         xml = survey._to_pretty_xml()
         self.assertEqual(1, xml.count(expected))
+
+    def test_external_instance_pulldata_constraints(self):
+        """
+        Checks if instance node for pulldata function is added
+        when pulldata occurs in column with constraint title
+        """
+        md = """
+        | survey |        |         |                |                                                         |
+        |        | type   | name    | label          | constraint                                              |
+        |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
+        """
+        node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
+        self.assertPyxformXform(md=md,
+                                xml__contains=[
+                                    node
+                                ])
+
+    def test_external_instance_pulldata_readonly(self):
+        """
+        Checks if instance node for pulldata function is added
+        when pulldata occurs in column with readonly title
+        """
+        md = """
+        | survey |        |         |                |                                                         |
+        |        | type   | name    | label          | readonly                                                |
+        |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
+        """
+        node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
+
+        self.assertPyxformXform(md=md,
+                                xml__contains=[
+                                    node
+                                ])
+
+    def test_external_instance_pulldata_required(self):
+        """
+        Checks if instance node for pulldata function is added
+        when pulldata occurs in column with required title
+        """
+        md = """
+        | survey |        |         |                |                                                         |
+        |        | type   | name    | label          | required                                                |
+        |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
+        """
+        node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
+        self.assertPyxformXform(md=md,
+                                xml__contains=[
+                                    node
+                                ],
+                                debug=True)
+
+    def test_external_instance_pulldata_relevant(self):
+        """
+        Checks if instance node for pulldata function is added
+        when pulldata occurs in column with relevant title
+        """
+        md = """
+        | survey |        |         |                |                                                         |
+        |        | type   | name    | label          | relevant                                                |
+        |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
+        """
+        node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
+        self.assertPyxformXform(md=md,
+                                xml__contains=[
+                                    node
+                                ],
+                                debug=True)
+
+
+    def test_external_instance_pulldata(self):
+        """
+        Checks that only one instance node for pulldata is created
+        if pulldata function is present in at least one columns with
+        the titles: constraint, relevant, required, readonly
+        """
+        md = """
+        | survey |        |         |                |                                                         |                                                         |                                                         |
+        |        | type   | name    | label          | relevant                                                | required                                                | constraint                                              |
+        |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
+        """
+        node = """<instance id="ID" src="jr://file-csv/ID.csv">"""
+        survey = self.md_to_pyxform_survey(md_raw=md)
+        xml = survey._to_pretty_xml()
+        self.assertEqual(1, xml.count(node))
+
+    def test_external_instances_multiple_diff_pulldatas(self):
+        """
+        Checks that all instances for pulldata that needs creation
+        are created
+        The situation is if pulldata is present in 2 or more
+        columns but pulling data from different csv files
+        """
+        md = """
+        | survey |        |         |                |                                                        |                                                             |
+        |        | type   | name    | label          | relevant                                               | required                                                    |
+        |        | text   | Part_ID | Participant ID | pulldata('fruits', 'name', 'name_key', 'mango')        | pulldata('OtherID', 'ParticipantID', ParticipantIDValue',.) |
+        """
+        node1 = '<instance id="fruits" src="jr://file-csv/fruits.csv">'
+        node2 = '<instance id="OtherID" src="jr://file-csv/OtherID.csv">'
+
+        survey = self.md_to_pyxform_survey(md_raw=md)
+        xml = survey._to_pretty_xml()
+        self.assertEqual(1, xml.count(node1))
+        self.assertEqual(1, xml.count(node2))


### PR DESCRIPTION
Add external instance if pulldata() is used in constraint, required, readonly, relevant expressions
- required
- constraint
- readonly
- relevant

- functionality of the same for: calculate was retained.