### PR TITLE
Remove Python 3.4 CI because it's EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,6 @@ jobs:
     <<: *build-template
     docker:
       - image: circleci/python:3.5
-  py-3.4:
-    <<: *build-template
-    docker:
-      - image: circleci/python:3.4
   py-2.7:
     <<: *build-template
     docker:
@@ -75,5 +71,4 @@ workflows:
       - py-3.7
       - py-3.6
       - py-3.5
-      - py-3.4
       - py-2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,10 @@ environment:
     # isn't covered by this document) at the time of writing.
 
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"


### PR DESCRIPTION
Python 3.4 was EOL 2019-03-18. https://devguide.python.org/devcycle/#end-of-life-branches.

Conveniently this also fixes the broken CircleCI builds with py-3.4 and makes the checks faster :)