### PR TITLE
Use uid preload for stable instanceIDs

### DIFF
--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -148,7 +148,7 @@ class BuilderTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",
@@ -190,7 +190,7 @@ class BuilderTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",
@@ -305,7 +305,7 @@ class BuilderTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",
@@ -433,7 +433,7 @@ class BuilderTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",
@@ -478,7 +478,7 @@ class BuilderTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -147,10 +147,7 @@ class BuilderTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }
@@ -189,10 +186,7 @@ class BuilderTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }
@@ -304,10 +298,7 @@ class BuilderTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }
@@ -432,10 +423,7 @@ class BuilderTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }
@@ -477,10 +465,7 @@ class BuilderTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }

--- a/pyxform/tests/example_xls/instance_xmlns_test.xml
+++ b/pyxform/tests/example_xls/instance_xmlns_test.xml
@@ -11,7 +11,7 @@
         </instance_xmlns_test>
       </instance>
       <bind nodeset="/instance_xmlns_test/yes_or_no" type="select1"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/instance_xmlns_test/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/instance_xmlns_test/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/example_xls/spec_test_expected_output.xml
+++ b/pyxform/tests/example_xls/spec_test_expected_output.xml
@@ -669,7 +669,7 @@
       <bind nodeset="/xlsform_spec_test/everything/phonenumber_test_output" readonly="true()" type="string"/>
       <bind nodeset="/xlsform_spec_test/everything/_1" type="string"/>
       <bind nodeset="/xlsform_spec_test/everything/FALSE" type="string"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/xlsform_spec_test/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/xlsform_spec_test/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/example_xls/widgets.xml
+++ b/pyxform/tests/example_xls/widgets.xml
@@ -145,7 +145,7 @@
       <bind nodeset="/widgets/happy_sad_table/reserved_name_for_field_list_labels_39" type="select"/>
       <bind nodeset="/widgets/happy_sad_table/happy_sad_brian" type="select"/>
       <bind nodeset="/widgets/happy_sad_table/happy_sad_michael" type="select"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/widgets/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/widgets/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/group_test.py
+++ b/pyxform/tests/group_test.py
@@ -46,10 +46,7 @@ class GroupTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }

--- a/pyxform/tests/group_test.py
+++ b/pyxform/tests/group_test.py
@@ -47,7 +47,7 @@ class GroupTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",

--- a/pyxform/tests/loop_tests.py
+++ b/pyxform/tests/loop_tests.py
@@ -79,7 +79,7 @@ class LoopTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",

--- a/pyxform/tests/loop_tests.py
+++ b/pyxform/tests/loop_tests.py
@@ -78,10 +78,7 @@ class LoopTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }

--- a/pyxform/tests/settings_test.py
+++ b/pyxform/tests/settings_test.py
@@ -45,7 +45,7 @@ class SettingsTests(TestCase):
                     "children": [
                         {
                             "bind": {
-                                "calculate": "concat('uuid:', uuid())",
+                                "jr:preload": "uid",
                                 "readonly": "true()",
                             },
                             "name": "instanceID",

--- a/pyxform/tests/settings_test.py
+++ b/pyxform/tests/settings_test.py
@@ -44,10 +44,7 @@ class SettingsTests(TestCase):
                 {
                     "children": [
                         {
-                            "bind": {
-                                "jr:preload": "uid",
-                                "readonly": "true()",
-                            },
+                            "bind": {"jr:preload": "uid", "readonly": "true()"},
                             "name": "instanceID",
                             "type": "calculate",
                         }

--- a/pyxform/tests/test_expected_output/attribute_columns_test.xml
+++ b/pyxform/tests/test_expected_output/attribute_columns_test.xml
@@ -727,7 +727,7 @@
       <bind nodeset="/attribute_columns_test/everything/_1" type="string"/>
       <bind nodeset="/attribute_columns_test/everything/FALSE" type="string"/>
       <bind jr:noAppErrorString="Sorry, app does not exist." nodeset="/attribute_columns_test/launch" type="int"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/attribute_columns_test/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/attribute_columns_test/meta/instanceID" readonly="true()" type="string"/>
       <bind calculate=" /attribute_columns_test/everything/my_name " nodeset="/attribute_columns_test/meta/instanceName" type="string"/>
     </model>
   </h:head>

--- a/pyxform/tests/test_expected_output/cascades_old.xml
+++ b/pyxform/tests/test_expected_output/cascades_old.xml
@@ -2800,7 +2800,7 @@
       <bind nodeset="/cascades_old/sectionC/sectionC5/q50_wm_minor_repairs" required="true()" type="select1"/>
       <bind nodeset="/cascades_old/sectionC/sectionC5/q51_wm_repair_supplies" required="true()" type="select1"/>
       <bind nodeset="/cascades_old/sectionC/sectionC6/q52_add_comments" required="false()" type="string"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/cascades_old/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/cascades_old/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/cascading_select_test.xml
+++ b/pyxform/tests/test_expected_output/cascading_select_test.xml
@@ -150,7 +150,7 @@
       <bind nodeset="/cascading_select_test/mylga_zone" type="select1"/>
       <bind nodeset="/cascading_select_test/mylga_state" type="select1"/>
       <bind nodeset="/cascading_select_test/mylga" type="select1"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/cascading_select_test/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/cascading_select_test/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/default_time_demo.xml
+++ b/pyxform/tests/test_expected_output/default_time_demo.xml
@@ -12,7 +12,7 @@
         </default_time_demo>
       </instance>
       <bind nodeset="/default_time_demo/start_time" type="time"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/default_time_demo/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/default_time_demo/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/flat_xlsform_test.xml
+++ b/pyxform/tests/test_expected_output/flat_xlsform_test.xml
@@ -704,7 +704,7 @@
       <bind nodeset="/flat_xlsform_test/_1" relevant="not(selected( /flat_xlsform_test/skip_to_end , 'yes'))" type="string"/>
       <bind nodeset="/flat_xlsform_test/FALSE" relevant="not(selected( /flat_xlsform_test/skip_to_end , 'yes'))" type="string"/>
       <bind jr:noAppErrorString="Sorry, app does not exist." nodeset="/flat_xlsform_test/launch" type="int"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/flat_xlsform_test/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/flat_xlsform_test/meta/instanceID" readonly="true()" type="string"/>
       <bind calculate=" /flat_xlsform_test/my_name " nodeset="/flat_xlsform_test/meta/instanceName" type="string"/>
     </model>
   </h:head>

--- a/pyxform/tests/test_expected_output/new_cascading_select.xml
+++ b/pyxform/tests/test_expected_output/new_cascading_select.xml
@@ -150,7 +150,7 @@
       <bind nodeset="/new_cascading_select/state" type="select1"/>
       <bind nodeset="/new_cascading_select/county" type="select1"/>
       <bind nodeset="/new_cascading_select/city" type="select1"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/new_cascading_select/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/new_cascading_select/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/old_cascades.xml
+++ b/pyxform/tests/test_expected_output/old_cascades.xml
@@ -150,7 +150,7 @@
       <bind nodeset="/old_cascades/state_states" type="select1"/>
       <bind nodeset="/old_cascades/state_counties" type="select1"/>
       <bind nodeset="/old_cascades/state" type="select1"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/old_cascades/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/old_cascades/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/or_other.xml
+++ b/pyxform/tests/test_expected_output/or_other.xml
@@ -64,7 +64,7 @@
       <bind nodeset="/or_other/fav_color" type="select1"/>
       <bind nodeset="/or_other/fav_color_other" relevant="selected(../fav_color, 'other')" type="string"/>
       <bind nodeset="/or_other/fav_pastel" type="select1"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/or_other/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/or_other/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/pull_data.xml
+++ b/pyxform/tests/test_expected_output/pull_data.xml
@@ -22,7 +22,7 @@
       </instance>
       <bind calculate="pulldata('fruits', 'name','name', 'mango')" nodeset="/pull_data/fruit" type="string"/>
       <bind nodeset="/pull_data/note_fruite" readonly="true()" type="string"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/pull_data/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/pull_data/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/repeat_date_test.xml
+++ b/pyxform/tests/test_expected_output/repeat_date_test.xml
@@ -24,7 +24,7 @@
       <bind nodeset="/repeat_date_test/repeat_test/table_list_3" type="select1"/>
       <bind nodeset="/repeat_date_test/repeat_test/table_list_4" type="select1"/>
       <bind nodeset="/repeat_date_test/generated_note_name_8" readonly="true()" type="string"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/repeat_date_test/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/repeat_date_test/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/search_and_select.xml
+++ b/pyxform/tests/test_expected_output/search_and_select.xml
@@ -14,7 +14,7 @@
       </instance>
       <bind nodeset="/search_and_select/fruit" type="select1"/>
       <bind nodeset="/search_and_select/note_fruit" readonly="true()" type="string"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/search_and_select/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/search_and_select/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/select_one_external.xml
+++ b/pyxform/tests/test_expected_output/select_one_external.xml
@@ -16,7 +16,7 @@
       <bind nodeset="/select_one_external/state" type="select1"/>
       <bind nodeset="/select_one_external/county" type="string"/>
       <bind nodeset="/select_one_external/city" type="string"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/select_one_external/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/select_one_external/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/simple_loop.json
+++ b/pyxform/tests/test_expected_output/simple_loop.json
@@ -46,7 +46,7 @@
                 {
                     "bind": {
                         "readonly": "true()", 
-                        "calculate": "concat('uuid:', uuid())"
+                        "jr:preload": "uid"
                     }, 
                     "type": "calculate", 
                     "name": "instanceID"

--- a/pyxform/tests/test_expected_output/table-list.xml
+++ b/pyxform/tests/test_expected_output/table-list.xml
@@ -54,7 +54,7 @@
       <bind nodeset="/table-list/happy_sad_table/reserved_name_for_field_list_labels_8" type="select"/>
       <bind nodeset="/table-list/happy_sad_table/happy_sad_brian" type="select"/>
       <bind nodeset="/table-list/happy_sad_table/happy_sad_michael" type="select"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/table-list/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/table-list/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/widgets.xml
+++ b/pyxform/tests/test_expected_output/widgets.xml
@@ -145,7 +145,7 @@
       <bind nodeset="/widgets/happy_sad_table/reserved_name_for_field_list_labels_39" type="select"/>
       <bind nodeset="/widgets/happy_sad_table/happy_sad_brian" type="select"/>
       <bind nodeset="/widgets/happy_sad_table/happy_sad_michael" type="select"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/widgets/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/widgets/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/xlsform_spec_test.xml
+++ b/pyxform/tests/test_expected_output/xlsform_spec_test.xml
@@ -726,7 +726,7 @@
       <bind nodeset="/xlsform_spec_test/everything/_1" type="string"/>
       <bind nodeset="/xlsform_spec_test/everything/FALSE" type="string"/>
       <bind jr:noAppErrorString="Sorry, app does not exist." nodeset="/xlsform_spec_test/launch" type="int"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/xlsform_spec_test/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/xlsform_spec_test/meta/instanceID" readonly="true()" type="string"/>
       <bind calculate=" /xlsform_spec_test/everything/my_name " nodeset="/xlsform_spec_test/meta/instanceName" type="string"/>
     </model>
   </h:head>

--- a/pyxform/tests/test_expected_output/xml_escaping.xml
+++ b/pyxform/tests/test_expected_output/xml_escaping.xml
@@ -16,7 +16,7 @@
       <bind calculate="2" nodeset="/xml_escaping/a" type="string"/>
       <bind calculate="1" nodeset="/xml_escaping/b" type="string"/>
       <bind nodeset="/xml_escaping/table_list_3" type="select1"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/xml_escaping/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/xml_escaping/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/test_expected_output/yes_or_no_question.json
+++ b/pyxform/tests/test_expected_output/yes_or_no_question.json
@@ -38,7 +38,7 @@
                 {
                     "bind": {
                         "readonly": "true()", 
-                        "calculate": "concat('uuid:', uuid())"
+                        "jr:preload": "uid"
                     }, 
                     "type": "calculate", 
                     "name": "instanceID"

--- a/pyxform/tests/test_output/cascades_old.xml
+++ b/pyxform/tests/test_output/cascades_old.xml
@@ -2800,7 +2800,7 @@
       <bind nodeset="/cascades_old/sectionC/sectionC5/q50_wm_minor_repairs" required="true()" type="select1"/>
       <bind nodeset="/cascades_old/sectionC/sectionC5/q51_wm_repair_supplies" required="true()" type="select1"/>
       <bind nodeset="/cascades_old/sectionC/sectionC6/q52_add_comments" required="false()" type="string"/>
-      <bind calculate="concat('uuid:', uuid())" nodeset="/cascades_old/meta/instanceID" readonly="true()" type="string"/>
+      <bind jr:preload="uid" nodeset="/cascades_old/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
   <h:body>

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -54,10 +54,7 @@ class BasicXls2JsonApiTests(TestCase):
             {
                 "children": [
                     {
-                        "bind": {
-                            "jr:preload": "uid",
-                            "readonly": "true()",
-                        },
+                        "bind": {"jr:preload": "uid", "readonly": "true()"},
                         "name": "instanceID",
                         "type": "calculate",
                     }
@@ -77,10 +74,7 @@ class BasicXls2JsonApiTests(TestCase):
             {
                 "children": [
                     {
-                        "bind": {
-                            "jr:preload": "uid",
-                            "readonly": "true()",
-                        },
+                        "bind": {"jr:preload": "uid", "readonly": "true()"},
                         "name": "instanceID",
                         "type": "calculate",
                     }
@@ -110,10 +104,7 @@ class BasicXls2JsonApiTests(TestCase):
             {
                 "children": [
                     {
-                        "bind": {
-                            "jr:preload": "uid",
-                            "readonly": "true()",
-                        },
+                        "bind": {"jr:preload": "uid", "readonly": "true()"},
                         "name": "instanceID",
                         "type": "calculate",
                     }
@@ -203,10 +194,7 @@ class BasicXls2JsonApiTests(TestCase):
                 "name": "meta",
                 "children": [
                     {
-                        "bind": {
-                            "readonly": "true()",
-                            "jr:preload": "uid",
-                        },
+                        "bind": {"readonly": "true()", "jr:preload": "uid"},
                         "type": "calculate",
                         "name": "instanceID",
                     }

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -55,7 +55,7 @@ class BasicXls2JsonApiTests(TestCase):
                 "children": [
                     {
                         "bind": {
-                            "calculate": "concat('uuid:', uuid())",
+                            "jr:preload": "uid",
                             "readonly": "true()",
                         },
                         "name": "instanceID",
@@ -78,7 +78,7 @@ class BasicXls2JsonApiTests(TestCase):
                 "children": [
                     {
                         "bind": {
-                            "calculate": "concat('uuid:', uuid())",
+                            "jr:preload": "uid",
                             "readonly": "true()",
                         },
                         "name": "instanceID",
@@ -111,7 +111,7 @@ class BasicXls2JsonApiTests(TestCase):
                 "children": [
                     {
                         "bind": {
-                            "calculate": "concat('uuid:', uuid())",
+                            "jr:preload": "uid",
                             "readonly": "true()",
                         },
                         "name": "instanceID",
@@ -205,7 +205,7 @@ class BasicXls2JsonApiTests(TestCase):
                     {
                         "bind": {
                             "readonly": "true()",
-                            "calculate": "concat('uuid:', uuid())",
+                            "jr:preload": "uid",
                         },
                         "type": "calculate",
                         "name": "instanceID",

--- a/pyxform/tests/xml_tests.py
+++ b/pyxform/tests/xml_tests.py
@@ -51,7 +51,7 @@ class XMLTests(utils.XFormTestCase):
         </yes_or_no_question>
       </instance>
       <bind nodeset="/yes_or_no_question/good_day" type="select1"/>
-      <bind calculate="concat('uuid:', uuid())"
+      <bind jr:preload="uid"
         nodeset="/yes_or_no_question/meta/instanceID"
         readonly="true()" type="string"/>
     </model>

--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -511,6 +511,10 @@ class XFormToDictBuilder:
                             rs["bind"] = {}
                         rs["bind"][k] = v
                         continue
+                    if k == "preload" and v == "uid":
+                        if "bind" not in rs:
+                            rs["bind"] = {}
+                        rs["bind"]["jr:preload"] = v
                     rs[k] = v
                 if "preloadParams" in rs and "preload" in rs:
                     rs["type"] = rs["preloadParams"]

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1172,7 +1172,7 @@ def workbook_to_json(
                 "name": "instanceID",
                 "bind": {
                     "readonly": "true()",
-                    "calculate": settings.get("instance_id", "concat('uuid:', uuid())"),
+                    "jr:preload": settings.get("instance_id", "uid"),
                 },
                 "type": "calculate",
             }


### PR DESCRIPTION
Related to https://github.com/opendatakit/build/issues/228
Closes https://github.com/XLSForm/pyxform/issues/94

Not sure if the code at 8659eaa961933f898cea6462cf11fc8add5482e9 is in the best place, so I defer to @ukanga (or @lognaturel if she has a moment).

I didn't add a test since uuids() are in most of the existing tests.

Test failures are all CI issues.