### PR TITLE
include changes related to form encryption.

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -451,15 +451,14 @@ class Survey(Section):
             submission_attrs = dict()
             if self.submission_url:
                 submission_attrs["action"] = self.submission_url
+                submission_attrs["method"] = "post"
             if self.public_key:
                 submission_attrs["base64RsaPublicKey"] = self.public_key
             if self.auto_send:
                 submission_attrs["orx:auto-send"] = self.auto_send
             if self.auto_delete:
                 submission_attrs["orx:auto-delete"] = self.auto_delete
-            submission_node = node(
-                "submission", method="form-data-post", **submission_attrs
-            )
+            submission_node = node("submission", **submission_attrs)
             model_children.insert(0, submission_node)
 
         return node("model", *model_children)

--- a/pyxform/tests/test_expected_output/flat_xlsform_test.xml
+++ b/pyxform/tests/test_expected_output/flat_xlsform_test.xml
@@ -3,7 +3,7 @@
   <h:head>
     <h:title>Flat test</h:title>
     <model>
-      <submission action="https://example-odk-aggregate.appspot.com/submission" base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo93+Dgn3iDleC9XMTDH7ez1MOm/BOt287DgkldNkdvrtdC4oUegx3N8Say9tq47k2EOzeLYkezVnKdtserx+g/+R6pDIOS66bwbH+HoslDEUaZRZ47EipSGC1JhtOp/nQGQCsdVc5q/fPvw8d2rLLi+PQUZPBOiBxUo9h/CFc41hl/quUELmylSdL4O06OAP8OCEDA+tl0C2Ik+uCYMDJLD4m7YVbkV7jJXjtILj+GW+noLriFMRsgg7WKQe2j9fw5+v46nzhokOnDnHh+yGwQMfs/B0jfFAgXllLNjIPlXQf2UVzuxEax6wLCyqUXMIjCPSNfnzDRgFB4Qw3QbJCwIDAQAB" method="form-data-post"/>
+      <submission action="https://example-odk-aggregate.appspot.com/submission" base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo93+Dgn3iDleC9XMTDH7ez1MOm/BOt287DgkldNkdvrtdC4oUegx3N8Say9tq47k2EOzeLYkezVnKdtserx+g/+R6pDIOS66bwbH+HoslDEUaZRZ47EipSGC1JhtOp/nQGQCsdVc5q/fPvw8d2rLLi+PQUZPBOiBxUo9h/CFc41hl/quUELmylSdL4O06OAP8OCEDA+tl0C2Ik+uCYMDJLD4m7YVbkV7jJXjtILj+GW+noLriFMRsgg7WKQe2j9fw5+v46nzhokOnDnHh+yGwQMfs/B0jfFAgXllLNjIPlXQf2UVzuxEax6wLCyqUXMIjCPSNfnzDRgFB4Qw3QbJCwIDAQAB" method="post"/>
       <itext>
         <translation default="true()" lang="default">
           <text id="/flat_xlsform_test/deviceid_test_output:label">

--- a/pyxform/tests/test_expected_output/xlsform_spec_test.xml
+++ b/pyxform/tests/test_expected_output/xlsform_spec_test.xml
@@ -3,7 +3,7 @@
   <h:head>
     <h:title>Spec test</h:title>
     <model>
-      <submission action="https://example-odk-aggregate.appspot.com/submission" base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo93+Dgn3iDleC9XMTDH7ez1MOm/BOt287DgkldNkdvrtdC4oUegx3N8Say9tq47k2EOzeLYkezVnKdtserx+g/+R6pDIOS66bwbH+HoslDEUaZRZ47EipSGC1JhtOp/nQGQCsdVc5q/fPvw8d2rLLi+PQUZPBOiBxUo9h/CFc41hl/quUELmylSdL4O06OAP8OCEDA+tl0C2Ik+uCYMDJLD4m7YVbkV7jJXjtILj+GW+noLriFMRsgg7WKQe2j9fw5+v46nzhokOnDnHh+yGwQMfs/B0jfFAgXllLNjIPlXQf2UVzuxEax6wLCyqUXMIjCPSNfnzDRgFB4Qw3QbJCwIDAQAB" method="form-data-post"/>
+      <submission action="https://example-odk-aggregate.appspot.com/submission" base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo93+Dgn3iDleC9XMTDH7ez1MOm/BOt287DgkldNkdvrtdC4oUegx3N8Say9tq47k2EOzeLYkezVnKdtserx+g/+R6pDIOS66bwbH+HoslDEUaZRZ47EipSGC1JhtOp/nQGQCsdVc5q/fPvw8d2rLLi+PQUZPBOiBxUo9h/CFc41hl/quUELmylSdL4O06OAP8OCEDA+tl0C2Ik+uCYMDJLD4m7YVbkV7jJXjtILj+GW+noLriFMRsgg7WKQe2j9fw5+v46nzhokOnDnHh+yGwQMfs/B0jfFAgXllLNjIPlXQf2UVzuxEax6wLCyqUXMIjCPSNfnzDRgFB4Qw3QbJCwIDAQAB" method="post"/>
       <itext>
         <translation default="true()" lang="default">
           <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label">

--- a/pyxform/tests_v1/test_settings_auto_send_delete.py
+++ b/pyxform/tests_v1/test_settings_auto_send_delete.py
@@ -19,9 +19,7 @@ class SettingsAutoSendDelete(PyxformTestCase):
             |          | true         |           |           |
             """,
             debug=True,
-            xml__contains=[
-                '<submission method="form-data-post" orx:auto-send="true"/>'
-            ],
+            xml__contains=['<submission orx:auto-send="true"/>'],
         )
 
     def test_settings_auto_delete_true(self):
@@ -37,9 +35,7 @@ class SettingsAutoSendDelete(PyxformTestCase):
             |          | true         |           |           |
             """,
             debug=True,
-            xml__contains=[
-                '<submission method="form-data-post" orx:auto-delete="true"/>'
-            ],
+            xml__contains=['<submission orx:auto-delete="true"/>'],
         )
 
     def test_settings_auto_send_delete_false(self):
@@ -56,6 +52,48 @@ class SettingsAutoSendDelete(PyxformTestCase):
             """,
             debug=True,
             xml__contains=[
-                '<submission method="form-data-post" orx:auto-delete="false" orx:auto-send="false"/>'
+                '<submission orx:auto-delete="false" orx:auto-send="false"/>'
+            ],
+        )
+
+    def test_settings_without_submission_url_does_not_generate_method_attribute(self):
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |              |           |           |
+            |          | type         | name      | label     |
+            |          | text         | name      | Name      |
+            | settings |                                                                    |           |           |
+            |          | public_key                                                         | auto_send |           |
+            |          | MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwOHPJWD9zc8JPBZj/UtC   | false     |           |
+            |          | dHiY7I4HWt61UG1XRaGvvwUkC/y8P5Kk6dRnf3yMTBHQoisT2vU2ODWVaU5elndk   |           |           |
+            |          | hiKiWdhufp1d86FWGYz/i+VOmdoV+0zoyPzk+vTEG8bpiY7/UcDYY0CsrRmaMei1   |           |           |
+            |          | 15xZwQpSMpayqMjemvwGDyhy2B3Yize4yaxyLFG53wMrHEczzsYz8FuRfuKUleE/   |           |           |
+            |          | 6jFc3uXZET4LJ7S76n1XU+bE+mhhoZ+tVERgaVH38l0SZljBITwHeqQ9WQckkmDf   |           |           |
+            |          | bRHBG7TQm+Afnx0s5E2bGIT5jB5cj9YaX6BqZSeodpafQjpXEJg6uufxF1Ni3Btv   |           |           |
+            |          |  4wIDAQAB                                                          |           |           |
+            """,
+            debug=True,
+            xml__contains=[
+                '<submission base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwOHPJWD9zc8JPBZj/UtC" orx:auto-send="false"/>'
+            ],
+        )
+
+    def test_settings_with_submission_url_generates_method_attribute(self):
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |              |           |           |
+            |          | type         | name      | label     |
+            |          | text         | name      | Name      |
+            | settings |                                                       |           |           |
+            |          | submission_url                                        | auto_send |           |
+            |          | https://odk.ona.io/random_person/submission           | false     |           |
+            """,
+            debug=True,
+            xml__contains=[
+                '<submission action="https://odk.ona.io/random_person/submission" method="post" orx:auto-send="false"/>'
             ],
         )


### PR DESCRIPTION
This would change the method from form-data-post to post and only include the method if the submission_url is defined in the settings file

Fixes #215