### PR TITLE
Warn users where repeated or complex logic is found.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -184,7 +184,7 @@ latex_documents = [
         u"pyxform Documentation",
         u"Columbia University, Modi Research Group",
         "manual",
-    ),
+    )
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -96,3 +96,9 @@ TRACK_CHANGES_REASONS = "track-changes-reasons"
 
 # supported bind keywords for which external instances will be created for pulldata function
 EXTERNAL_INSTANCES = ["calculate", "constraint", "readonly", "required", "relevant"]
+
+# if variables inside a complex relevant logic expression exceed this number,
+# show a warning
+COMPLEX_RELEVANT_VARIABLES_MAX_THRESHOLD = 20
+
+row_format_string = "[row : %s]"

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -68,13 +68,13 @@ class PyxformMarkdown(object):
         sheets = {}
         for sheet, contents in md_table_to_ss_structure(md):
             sheets[sheet] = list_to_dicts(contents)
-
         return self._ss_structure_to_pyxform_survey(sheets, kwargs)
 
     @staticmethod
     def _ss_structure_to_pyxform_survey(ss_structure, kwargs):
         # using existing methods from the builder
-        imported_survey_json = workbook_to_json(ss_structure)
+        warnings = kwargs.get('warnings', None)
+        imported_survey_json = workbook_to_json(ss_structure, warnings=warnings)
         # ideally, when all these tests are working, this would be
         # refactored as well
         survey = create_survey_element_from_dict(imported_survey_json)

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -73,7 +73,7 @@ class PyxformMarkdown(object):
     @staticmethod
     def _ss_structure_to_pyxform_survey(ss_structure, kwargs):
         # using existing methods from the builder
-        warnings = kwargs.get('warnings', None)
+        warnings = kwargs.get("warnings", None)
         imported_survey_json = workbook_to_json(ss_structure, warnings=warnings)
         # ideally, when all these tests are working, this would be
         # refactored as well

--- a/pyxform/tests_v1/test_repeated_complex_relevancies.py
+++ b/pyxform/tests_v1/test_repeated_complex_relevancies.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+from pyxform.xls2json import relevance_checker
+
+class RelevanceTest(TestCase):
+
+    def test_relevance_checker_works_repeat_relevancies(self):
+        """relevance_checker correctly flags repeated relevancies"""
+        errors = []
+        hashes = {}
+        errors_list = relevance_checker('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 6, hashes)
+        errors.extend(errors_list)
+        errors_list = relevance_checker('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 10, hashes)
+        errors.extend(errors_list)
+        errors_list = relevance_checker('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 39, hashes)
+        errors.extend(errors_list)
+        expected_error_message = """11, 40: Duplicate relevancies detected.
+        In future, its best to store repeated logic in calculate 
+        and referring to that calculate."""
+        self.assertListEqual([expected_error_message], errors_list)
+
+    def test_relevance_checker_works_complex_relevancies(self):
+        """relevance_checker correctly flags repeated relevancies"""
+        errors = []
+        hashes = {}
+        errors_list = relevance_checker(
+            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ', 6, hashes)
+        expected_error_message = """7: Possible complex or long logical expression detected .
+        This mat cause stack overflows during form submission."""
+        errors.extend(errors_list)
+        self.assertListEqual([expected_error_message], errors)
+
+    def test_relevance_checker_both_conmplex_and_repeated(self):
+        """relevance-checker function correctly checks for both
+        complex and repeated logical expressions"""
+        errors = []
+        hashes = {}
+        errors_list = relevance_checker(
+            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
+            6, hashes)
+        errors.extend(errors_list)
+        errors_list = relevance_checker(
+            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
+         10, hashes)
+        errors.extend(errors_list)
+        errors_list = relevance_checker(
+            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
+             39, hashes)
+        errors.extend(errors_list)
+        expected_error_message1 = """11, 40: Duplicate relevancies detected.
+                In future, its best to store repeated logic in calculate 
+                and referring to that calculate."""
+        expected_error_message2 = """11, 40: Possible complex or long logical expression detected .
+                This may cause stack overflows during form submission."""
+        self.assertTrue(expected_error_message1 in errors)
+        self.assertTrue(expected_error_message2 in errors)

--- a/pyxform/tests_v1/test_repeated_complex_relevancies.py
+++ b/pyxform/tests_v1/test_repeated_complex_relevancies.py
@@ -1,17 +1,29 @@
 from unittest import TestCase
 from pyxform.xls2json import expression_is_repeated, expression_is_complex
 
-class RelevanceTest(TestCase):
 
+class RelevanceTest(TestCase):
     def test_relevance_checker_works_repeat_relevancies(self):
         """expression_is_repeated correctly flags repeated relevancies"""
         errors = []
         hashes = {}
-        errors_list = expression_is_repeated('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 6, hashes)
+        errors_list = expression_is_repeated(
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
+            6,
+            hashes,
+        )
         errors.extend(errors_list)
-        errors_list = expression_is_repeated('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 10, hashes)
+        errors_list = expression_is_repeated(
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
+            10,
+            hashes,
+        )
         errors.extend(errors_list)
-        errors_list = expression_is_repeated('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 39, hashes)
+        errors_list = expression_is_repeated(
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
+            39,
+            hashes,
+        )
         errors.extend(errors_list)
         expected_error_message = """11, 40: Duplicate relevancies detected.
         In future, its best to store repeated logic in calculate 
@@ -23,7 +35,10 @@ class RelevanceTest(TestCase):
         errors = []
         hashes = {}
         errors_list = expression_is_complex(
-            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ', 6, hashes)
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
+            6,
+            hashes,
+        )
         expected_error_message = """7: Possible complex or long logical expression detected .
         This mat cause stack overflows during form submission."""
         errors.extend(errors_list)
@@ -35,20 +50,28 @@ class RelevanceTest(TestCase):
         errors = []
         hashes = {}
         errors_list = expression_is_repeated(
-            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
-            6, hashes)
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
+            6,
+            hashes,
+        )
         errors.extend(errors_list)
         errors_list = expression_is_complex(
-            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
-            6, hashes)
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
+            6,
+            hashes,
+        )
         errors.extend(errors_list)
         errors_list = expression_is_repeated(
-            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
-         10, hashes)
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
+            10,
+            hashes,
+        )
         errors.extend(errors_list)
         errors_list = expression_is_complex(
-            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
-             39, hashes)
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
+            39,
+            hashes,
+        )
         errors.extend(errors_list)
         expected_error_message1 = """11: Duplicate relevancies detected.
                 In future, its best to store repeated logic in calculate 
@@ -57,4 +80,3 @@ class RelevanceTest(TestCase):
                 This may cause stack overflows during form submission."""
         self.assertTrue(expected_error_message1 in errors)
         self.assertTrue(expected_error_message2 in errors)
-

--- a/pyxform/tests_v1/test_repeated_complex_relevancies.py
+++ b/pyxform/tests_v1/test_repeated_complex_relevancies.py
@@ -1,17 +1,17 @@
 from unittest import TestCase
-from pyxform.xls2json import relevance_checker
+from pyxform.xls2json import expression_is_repeated, expression_is_complex
 
 class RelevanceTest(TestCase):
 
     def test_relevance_checker_works_repeat_relevancies(self):
-        """relevance_checker correctly flags repeated relevancies"""
+        """expression_is_repeated correctly flags repeated relevancies"""
         errors = []
         hashes = {}
-        errors_list = relevance_checker('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 6, hashes)
+        errors_list = expression_is_repeated('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 6, hashes)
         errors.extend(errors_list)
-        errors_list = relevance_checker('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 10, hashes)
+        errors_list = expression_is_repeated('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 10, hashes)
         errors.extend(errors_list)
-        errors_list = relevance_checker('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 39, hashes)
+        errors_list = expression_is_repeated('${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11', 39, hashes)
         errors.extend(errors_list)
         expected_error_message = """11, 40: Duplicate relevancies detected.
         In future, its best to store repeated logic in calculate 
@@ -19,37 +19,42 @@ class RelevanceTest(TestCase):
         self.assertListEqual([expected_error_message], errors_list)
 
     def test_relevance_checker_works_complex_relevancies(self):
-        """relevance_checker correctly flags repeated relevancies"""
+        """expression_is_repeated correctly flags repeated relevancies"""
         errors = []
         hashes = {}
-        errors_list = relevance_checker(
+        errors_list = expression_is_complex(
             '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ', 6, hashes)
         expected_error_message = """7: Possible complex or long logical expression detected .
         This mat cause stack overflows during form submission."""
         errors.extend(errors_list)
         self.assertListEqual([expected_error_message], errors)
 
-    def test_relevance_checker_both_conmplex_and_repeated(self):
+    def test_relevance_checker_both_complex_and_repeated(self):
         """relevance-checker function correctly checks for both
         complex and repeated logical expressions"""
         errors = []
         hashes = {}
-        errors_list = relevance_checker(
+        errors_list = expression_is_repeated(
             '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
             6, hashes)
         errors.extend(errors_list)
-        errors_list = relevance_checker(
+        errors_list = expression_is_complex(
+            '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
+            6, hashes)
+        errors.extend(errors_list)
+        errors_list = expression_is_repeated(
             '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
          10, hashes)
         errors.extend(errors_list)
-        errors_list = relevance_checker(
+        errors_list = expression_is_complex(
             '${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ',
              39, hashes)
         errors.extend(errors_list)
-        expected_error_message1 = """11, 40: Duplicate relevancies detected.
+        expected_error_message1 = """11: Duplicate relevancies detected.
                 In future, its best to store repeated logic in calculate 
                 and referring to that calculate."""
-        expected_error_message2 = """11, 40: Possible complex or long logical expression detected .
+        expected_error_message2 = """7, 40: Possible complex or long logical expression detected .
                 This may cause stack overflows during form submission."""
         self.assertTrue(expected_error_message1 in errors)
         self.assertTrue(expected_error_message2 in errors)
+

--- a/pyxform/tests_v1/test_util.py
+++ b/pyxform/tests_v1/test_util.py
@@ -1,82 +1,83 @@
 from unittest import TestCase
 from pyxform.utils import expression_is_repeated, expression_is_complex
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 
 
-class RelevanceTest(TestCase):
+class RelevanceTest(PyxformTestCase):
     def test_relevance_checker_works_repeat_relevancies(self):
         """expression_is_repeated correctly flags repeated relevancies"""
-        errors = []
         hashes = {}
-        errors_list = expression_is_repeated(
+        response = expression_is_repeated(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
+            hashes,
             6,
-            hashes,
         )
-        errors.extend(errors_list)
-        errors_list = expression_is_repeated(
+        self.assertEqual('', response)
+
+        response = expression_is_repeated(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
+            hashes,
             10,
-            hashes,
         )
-        errors.extend(errors_list)
-        errors_list = expression_is_repeated(
+        self.assertEqual('[row : 10] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate.', response)
+
+        response = expression_is_repeated(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
-            39,
             hashes,
+            39,
         )
-        errors.extend(errors_list)
-        expected_error_message = """11, 40: Duplicate relevancies detected.
-        In future, its best to store repeated logic in calculate 
-        and referring to that calculate."""
-        self.assertListEqual([expected_error_message], errors_list)
+        self.assertEqual('[row : 39] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate.', response)
+
+
 
     def test_relevance_checker_works_complex_relevancies(self):
         """expression_is_repeated correctly flags repeated relevancies"""
-        errors = []
-        hashes = {}
-        errors_list = expression_is_complex(
+        response = expression_is_complex(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
-            6,
-            hashes,
-        )
-        expected_error_message = """7: Possible complex or long logical expression detected .
-        This may cause stack overflows during form submission."""
-        errors.extend(errors_list)
-        self.assertListEqual([expected_error_message], errors)
+         7)
+        self.assertEqual('[row : 7] Possible complex or long logical expression detected,  This may cause stack overflows during form submission.', response)
 
-    def test_relevance_checker_both_complex_and_repeated(self):
-        """relevance-checker function correctly checks for both
-        complex and repeated logical expressions"""
-        errors = []
-        hashes = {}
-        errors_list = expression_is_repeated(
-            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
-            6,
-            hashes,
+        response = expression_is_complex(
+            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 ",
+         5)
+        self.assertEqual('', response)
+
+    def test_generates_warning_for_repeated_relevance_logic(self):
+        """
+        Checks that warnings are generated and appended correctly, when
+        parsing an xml
+        """
+        md = """
+            | survey |                 |                  |                     |                      |
+            |        | type            | name             | label               | relevant             |
+            |        | select_one      | likes-pizza      | Do you like Pizza?  |                      |
+            |        | select_multiple | favorite-topping | favourite topppings | ${likes-pizza}='yes' |
+            |        | text            | favorite-shop    | favourite Shop      | ${likes-pizza}='yes' |
+        """
+        warnings = []
+        self.md_to_pyxform_survey(md_raw=md, kwargs={"warnings": warnings})
+        expected_warning_message = (
+            "[row : 4] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate."
         )
-        errors.extend(errors_list)
-        errors_list = expression_is_complex(
-            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
-            6,
-            hashes,
-        )
-        errors.extend(errors_list)
-        errors_list = expression_is_repeated(
-            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
-            10,
-            hashes,
-        )
-        errors.extend(errors_list)
-        errors_list = expression_is_complex(
-            "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
-            39,
-            hashes,
-        )
-        errors.extend(errors_list)
-        expected_error_message1 = """11: Duplicate relevancies detected.
-                In future, its best to store repeated logic in calculate 
-                and referring to that calculate."""
-        expected_error_message2 = """7, 40: Possible complex or long logical expression detected .
-                This may cause stack overflows during form submission."""
-        self.assertTrue(expected_error_message1 in errors)
-        self.assertTrue(expected_error_message2 in errors)
+
+        self.assertIn(expected_warning_message, warnings)
+
+    def test_generates_warning_for_complex_relevance_logic(self):
+        """
+        Checks that a warning was generated for complex relevance expressions
+        when parsing xls
+        """
+        md = """
+                   | survey |            |               |                      |           |
+                   |        | type       | name          | label                | relevant  |
+                   |        | select_one | B1_1StoveType | past stove           |           |
+                   |        | select_one | B1_2StoveType | present stove        |           |
+                   |        | select_one | B1_3StoveType | future stove         |           |
+                   |        | select_one | B1_4StoveType | possible future stove|           |
+                   |        | select_one | stove_prize   | your prize           | ${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 " | 
+               """
+        warnings = []
+        self.md_to_pyxform_survey(md_raw=md, kwargs={"warnings": warnings})
+        expected_warning_message = '[row : 6] Possible complex or long logical expression detected,  This may cause stack overflows during form submission.'
+
+        self.assertIn( expected_warning_message, warnings)

--- a/pyxform/tests_v1/test_util.py
+++ b/pyxform/tests_v1/test_util.py
@@ -12,35 +12,44 @@ class RelevanceTest(PyxformTestCase):
             hashes,
             6,
         )
-        self.assertEqual('', response)
+        self.assertEqual("", response)
 
         response = expression_is_repeated(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
             hashes,
             10,
         )
-        self.assertEqual('[row : 10] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate.', response)
+        self.assertEqual(
+            "[row : 10] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate.",
+            response,
+        )
 
         response = expression_is_repeated(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11",
             hashes,
             39,
         )
-        self.assertEqual('[row : 39] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate.', response)
-
-
+        self.assertEqual(
+            "[row : 39] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate.",
+            response,
+        )
 
     def test_relevance_checker_works_complex_relevancies(self):
         """expression_is_repeated correctly flags repeated relevancies"""
         response = expression_is_complex(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 or ${B1_1StoveType}=16 or ${B1_1StoveType}=17 or ${B1_1StoveType}=18 or ${B1_1StoveType}=19 or ${B1_1StoveType}=20 or ${B1_1StoveType}=21 or ${B1_1StoveType}=22 or ${B1_2StoveType}=23 or ${B1_2StoveType}=9 or ${B1_2StoveType}=10 or ${B1_2StoveType}=11 or ${B1_2StoveType}=12 or ${B1_2StoveType}=13 or ${B1_2StoveType}=14 or ${B1_2StoveType}=15 or ${B1_2StoveType}=16 or ${B1_2StoveType}=17 or ${B1_2StoveType}=18 or ${B1_2StoveType}=19 or ${B1_2StoveType}=20 or ${B1_2StoveType}=21 or ${B1_2StoveType}=22 or ${B1_3StoveType}=23 or ${B1_3StoveType}=9 or ${B1_3StoveType}=10 or ${B1_3StoveType}=11 or ${B1_3StoveType}=12 or ${B1_3StoveType}=13 or ${B1_3StoveType}=14 or ${B1_3StoveType}=15 or ${B1_3StoveType}=16 or ${B1_3StoveType}=17 or ${B1_3StoveType}=18 or ${B1_3StoveType}=19 or ${B1_3StoveType}=20 or ${B1_3StoveType}=21 or ${B1_3StoveType}=22 or ${B1_4StoveType}=23 or ${B1_4StoveType}=9 or ${B1_4StoveType}=10 or ${B1_4StoveType}=11 or ${B1_4StoveType}=12 or ${B1_4StoveType}=13 or ${B1_4StoveType}=14 or ${B1_4StoveType}=15 or ${B1_4StoveType}=16 or ${B1_4StoveType}=17 or ${B1_4StoveType}=18 or ${B1_4StoveType}=19 or ${B1_4StoveType}=20 or ${B1_4StoveType}=21 or ${B1_4StoveType}=22 ",
-         7)
-        self.assertEqual('[row : 7] Possible complex or long logical expression detected,  This may cause stack overflows during form submission.', response)
+            7,
+        )
+        self.assertEqual(
+            "[row : 7] Possible complex or long logical expression detected,  This may cause stack overflows during form submission.",
+            response,
+        )
 
         response = expression_is_complex(
             "${B1_1StoveType}=23 or ${B1_1StoveType}=9 or ${B1_1StoveType}=10 or ${B1_1StoveType}=11 or ${B1_1StoveType}=12 or ${B1_1StoveType}=13 or ${B1_1StoveType}=14 or ${B1_1StoveType}=15 ",
-         5)
-        self.assertEqual('', response)
+            5,
+        )
+        self.assertEqual("", response)
 
     def test_generates_warning_for_repeated_relevance_logic(self):
         """
@@ -56,9 +65,7 @@ class RelevanceTest(PyxformTestCase):
         """
         warnings = []
         self.md_to_pyxform_survey(md_raw=md, kwargs={"warnings": warnings})
-        expected_warning_message = (
-            "[row : 4] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate."
-        )
+        expected_warning_message = "[row : 4] Duplicate expression detected. In future, it is best to store repeated logic in calculate and referring to that calculate."
 
         self.assertIn(expected_warning_message, warnings)
 
@@ -78,6 +85,6 @@ class RelevanceTest(PyxformTestCase):
                """
         warnings = []
         self.md_to_pyxform_survey(md_raw=md, kwargs={"warnings": warnings})
-        expected_warning_message = '[row : 6] Possible complex or long logical expression detected,  This may cause stack overflows during form submission.'
+        expected_warning_message = "[row : 6] Possible complex or long logical expression detected,  This may cause stack overflows during form submission."
 
-        self.assertIn( expected_warning_message, warnings)
+        self.assertIn(expected_warning_message, warnings)

--- a/pyxform/tests_v1/test_util.py
+++ b/pyxform/tests_v1/test_util.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from pyxform.xls2json import expression_is_repeated, expression_is_complex
+from pyxform.utils import expression_is_repeated, expression_is_complex
 
 
 class RelevanceTest(TestCase):
@@ -40,7 +40,7 @@ class RelevanceTest(TestCase):
             hashes,
         )
         expected_error_message = """7: Possible complex or long logical expression detected .
-        This mat cause stack overflows during form submission."""
+        This may cause stack overflows during form submission."""
         errors.extend(errors_list)
         self.assertListEqual([expected_error_message], errors)
 

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -8,10 +8,11 @@ import json
 import os
 import re
 from xml.dom.minidom import Element, Text, parseString
-from hashlib import md5
 
 import unicodecsv as csv
 import xlrd
+
+from pyxform.constants import COMPLEX_RELEVANT_VARIABLES_MAX_THRESHOLD, row_format_string
 
 try:
     from json.decoder import JSONDecodeError

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -12,7 +12,10 @@ from xml.dom.minidom import Element, Text, parseString
 import unicodecsv as csv
 import xlrd
 
-from pyxform.constants import COMPLEX_RELEVANT_VARIABLES_MAX_THRESHOLD, row_format_string
+from pyxform.constants import (
+    COMPLEX_RELEVANT_VARIABLES_MAX_THRESHOLD,
+    row_format_string,
+)
 
 try:
     from json.decoder import JSONDecodeError
@@ -292,7 +295,7 @@ def expression_is_repeated(expression, expression_hash_map, row_number):
         )
     else:
         expression_hash_map[expression] = row_number
-        return ''
+        return ""
 
 
 def expression_is_complex(expression, row_number):
@@ -313,4 +316,4 @@ def expression_is_complex(expression, row_number):
             + " Possible complex or long logical expression detected, "
             + " This may cause stack overflows during form submission."
         )
-    return ''
+    return ""

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -276,6 +276,7 @@ def default_is_dynamic(element_default, element_type=None):
                 expression.append(expression_element)
     return contains_dynamic
 
+
 def expression_is_repeated(expression, expression_hash_map, row_number):
     """
     Checks If a logical expression repeated

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -329,6 +329,18 @@ def expression_is_repeated(expression, index, expression_hash_map):
     return warnings_list
 
 
+def expression_is_complex(expression, index):
+    """
+    A heuristic that attempts to check if an expression can be considered complex
+
+    expression (str) - text representing expression to be tested
+    index (int) - attempt at giving the location of the error location
+    return (str) - a warning message where one is necessary
+    """
+    warning_list = []
+    # will match a function syntax i.e. function name and the parenthesis
+    function_regex = r'(?:(\s?[a-z_0-9]+\s?\()|(\)))'
+
 
 def workbook_to_json(
     workbook_dict,

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -13,7 +13,7 @@ import subprocess
 from collections import Counter
 
 
-from hashlib import md5 # why md5
+from hashlib import md5  # why md5
 
 from pyxform import aliases, constants
 from pyxform.errors import PyXFormError
@@ -313,7 +313,9 @@ def expression_is_repeated(expression, index, expression_hash_map):
     return (list) the warning message in a list or an empty list if no warning
     """
     warnings_list = []
-    actual_row = index + 1  # this is assuming that order of rows is maintained to this point
+    actual_row = (
+        index + 1
+    )  # this is assuming that order of rows is maintained to this point
     this_expression_hash = md5(expression.encode()).hexdigest()
     if this_expression_hash in expression_hash_map.keys():
         # get list of locations where expression has been seen before
@@ -321,7 +323,9 @@ def expression_is_repeated(expression, index, expression_hash_map):
         row_indices.append(actual_row)
         warning_message = """%s: Duplicate relevancies detected.
         In future, its best to store repeated logic in calculate 
-        and referring to that calculate.""" % (", ".join(map(str, row_indices[1:])))
+        and referring to that calculate.""" % (
+            ", ".join(map(str, row_indices[1:]))
+        )
         warnings_list.append(warning_message)
     else:
         expression_hash_map[this_expression_hash] = [actual_row]
@@ -339,7 +343,7 @@ def expression_is_complex(expression, index):
     """
     warning_list = []
     # will match a function syntax i.e. function name and the parenthesis
-    function_regex = r'(?:(\s?[a-z_0-9]+\s?\()|(\)))'
+    function_regex = r"(?:(\s?[a-z_0-9]+\s?\()|(\)))"
 
 
 def workbook_to_json(
@@ -378,7 +382,9 @@ def workbook_to_json(
         if is_valid:
             break
         if "relevant" in [z.lower() for z in row]:
-            warning_list = expression_is_repeated(row['relevant'], index, expression_hash_map)
+            warning_list = expression_is_repeated(
+                row["relevant"], index, expression_hash_map
+            )
             warnings.extend(warning_list)
     if not is_valid:
         raise PyXFormError(

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -306,6 +306,7 @@ def process_range_question_type(row):
 
     return new_dict
 
+
 def workbook_to_json(
     workbook_dict,
     form_name=None,
@@ -631,8 +632,8 @@ def workbook_to_json(
             continue
 
         # check for repeated or complex relevancies
-        if "relevant" in row.get('bind', {}):
-            expression = row.get('bind').get('relevant')
+        if "relevant" in row.get("bind", {}):
+            expression = row.get("bind").get("relevant")
             repeated_expression_warning = expression_is_repeated(
                 expression, repeated_expressions_map, row_number
             )

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -604,6 +604,8 @@ def workbook_to_json(
 
     repeat_behavior_warning_added = False
     dynamic_default_warning_added = False
+    repeated_expressions_map = {}
+
     for row in survey_sheet:
         row_number += 1
         if stack[-1] is not None:
@@ -627,6 +629,18 @@ def workbook_to_json(
         # skip empty rows
         if len(row) == 0:
             continue
+
+        # check for repeated or complex relevancies
+        if "relevant" in row.get('bind', {}):
+            expression = row.get('bind').get('relevant')
+            repeated_expression_warning = expression_is_repeated(
+                expression, repeated_expressions_map, row_number
+            )
+            complex_expression_warning = expression_is_complex(expression, row_number)
+            if repeated_expression_warning:
+                warnings.append(repeated_expression_warning)
+            if complex_expression_warning:
+                warnings.append(complex_expression_warning)
 
         # Get question type
         question_type = row.get(constants.TYPE)

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -302,17 +302,18 @@ def process_range_question_type(row):
     return new_dict
 
 
-def relevance_checker(expression, index, expression_hash_map):
+def expression_is_repeated(expression, index, expression_hash_map):
     """
     Checks If a logical expression is complex or repeated
 
-    expression (str) - text representing relevance text to tested
+    expression (str) - text representing expression to be tested
     index (int) - attempt at giving the location of the error location
     expression_hash_map (dict) - store hashes for error messages as keys and index
         as values
+    return (list) the warning message in a list or an empty list if no warning
     """
     warnings_list = []
-    actual_row = index + 1 # this is assuming that order of rows is maintained to this point
+    actual_row = index + 1  # this is assuming that order of rows is maintained to this point
     this_expression_hash = md5(expression.encode()).hexdigest()
     if this_expression_hash in expression_hash_map.keys():
         # get list of locations where expression has been seen before
@@ -326,8 +327,6 @@ def relevance_checker(expression, index, expression_hash_map):
         expression_hash_map[this_expression_hash] = [actual_row]
 
     return warnings_list
-
-
 
 
 
@@ -367,7 +366,7 @@ def workbook_to_json(
         if is_valid:
             break
         if "relevant" in [z.lower() for z in row]:
-            warning_list = relevance_checker(row['relevant'], index, expression_hash_map)
+            warning_list = expression_is_repeated(row['relevant'], index, expression_hash_map)
             warnings.extend(warning_list)
     if not is_valid:
         raise PyXFormError(

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -14,8 +14,16 @@ from collections import Counter
 
 from pyxform import aliases, constants
 from pyxform.errors import PyXFormError
-from pyxform.utils import basestring, is_valid_xml_tag, unicode, default_is_dynamic, expression_is_repeated
+from pyxform.utils import (
+    basestring,
+    is_valid_xml_tag,
+    unicode,
+    default_is_dynamic,
+    expression_is_repeated,
+    expression_is_complex,
+)
 from pyxform.xls2json_backends import csv_to_dict, xls_to_dict
+from pyxform.constants import row_format_string
 
 SMART_QUOTES = {"\u2018": "'", "\u2019": "'", "\u201c": '"', "\u201d": '"'}
 
@@ -328,22 +336,14 @@ def workbook_to_json(
         warnings = []
     is_valid = False
     workbook_dict = {x.lower(): y for x, y in workbook_dict.items()}
-    expression_hash_map = {}
-    for index, row in enumerate(workbook_dict.get(constants.SURVEY, [])):
+    for row in workbook_dict.get(constants.SURVEY, []):
         is_valid = "type" in [z.lower() for z in row]
         if is_valid:
             break
-        if "relevant" in [z.lower() for z in row]:
-            warning_list = expression_is_repeated(
-                row["relevant"], index, expression_hash_map
-            )
-            warnings.extend(warning_list)
     if not is_valid:
         raise PyXFormError(
             "The survey sheet is either empty or missing important " "column headers."
         )
-
-    row_format_string = "[row : %s]"
 
     # Make sure the passed in vars are unicode
     form_name = unicode(form_name)


### PR DESCRIPTION
closes #102 

- Adds 2 utils functions:
  -  a function that checks for repeated relevance expressions
  - a function that checks for complex relevance expressions

Complex_expression checker function implements a naive algorithm based on the number of variables in the expression that are operated on by `or|and` logical operators.