### PR TITLE
Pretty Print is false by default when converting from the command line

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -870,11 +870,11 @@ class Survey(Section):
                     + "Learn more: http://xlsform.org#multiple-language-support"
                 )
 
-    def to_xml(self, validate=True, pretty_print=False, warnings=None, enketo=False):
+    def to_xml(self, validate=True, pretty_print=True, warnings=None, enketo=False):
         """
         Generates the XForm XML.
         validate is True by default - pass the XForm XML through ODK Validator.
-        pretty_print is False by default - formats the XML for readability.
+        pretty_print is True by default - formats the XML for readability.
         warnings - if a list is passed it stores all warnings generated
         enketo - pass the XForm XML though Enketo Validator.
 

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -870,11 +870,11 @@ class Survey(Section):
                     + "Learn more: http://xlsform.org#multiple-language-support"
                 )
 
-    def to_xml(self, validate=True, pretty_print=True, warnings=None, enketo=False):
+    def to_xml(self, validate=True, pretty_print=False, warnings=None, enketo=False):
         """
         Generates the XForm XML.
         validate is True by default - pass the XForm XML through ODK Validator.
-        pretty_print is True by default - formats the XML for readability.
+        pretty_print is False by default - formats the XML for readability.
         warnings - if a list is passed it stores all warnings generated
         enketo - pass the XForm XML though Enketo Validator.
 

--- a/pyxform/tests/xls2xform_tests.py
+++ b/pyxform/tests/xls2xform_tests.py
@@ -60,7 +60,7 @@ class XLS2XFormTests(TestCase):
         arg_list = [
             "--json",
             "--skip_validate",
-            "--no_pretty_print",
+            "--pretty_print",
             arg_xlsform,
             arg_output,
         ]
@@ -69,7 +69,7 @@ class XLS2XFormTests(TestCase):
         self.assertEqual(arg_output, args.output_path)
         self.assertEqual(True, args.json)
         self.assertEqual(False, args.skip_validate)
-        self.assertEqual(False, args.no_pretty_print)
+        self.assertEqual(True, args.pretty_print)
 
     def test_create_parser_file_name_with_space(self):
         """Should interpret the path correctly."""
@@ -103,10 +103,10 @@ class XLS2XFormTests(TestCase):
         args = _create_parser().parse_args(arg_list)
         self.assertEqual(False, args.enketo_validate)
 
-    def test_create_parser_no_pretty_print_default_true(self):
-        """Should have no_pretty_print=True if not specified."""
+    def test_create_parser_pretty_print_default_False(self):
+        """Should have pretty_print=False if not specified."""
         args = _create_parser().parse_args(["xlsform.xlsx", "."])
-        self.assertEqual(True, args.no_pretty_print)
+        self.assertFalse(args.pretty_print)
 
     def test_validator_args_logic_skip_validate_alone(self):
         """Should deactivate both validators."""
@@ -171,7 +171,7 @@ class XLS2XFormTests(TestCase):
             skip_validate=False,
             odk_validate=False,
             enketo_validate=False,
-            no_pretty_print=False,
+            pretty_print=False,
         ),
     )
     @mock.patch("pyxform.xls2xform.xls2xform_convert")
@@ -199,7 +199,7 @@ class XLS2XFormTests(TestCase):
             skip_validate=False,
             odk_validate=False,
             enketo_validate=False,
-            no_pretty_print=False,
+            pretty_print=False,
         ),
     )
     @mock.patch("pyxform.xls2xform.xls2xform_convert")

--- a/pyxform/xls2xform.py
+++ b/pyxform/xls2xform.py
@@ -97,9 +97,9 @@ def _create_parser():
         help="Run the Enketo Validate XForm external validator.",
     )
     parser.add_argument(
-        "--no_pretty_print",
-        action="store_false",
-        default=True,
+        "--pretty_print",
+        action="store_true",
+        default=False,
         help="Print XML forms with collapsed whitespace instead of pretty-printed.",
     )
     return parser
@@ -149,7 +149,7 @@ def main_cli():
                 xlsform_path=args.path_to_XLSForm,
                 xform_path=args.output_path,
                 validate=args.odk_validate,
-                pretty_print=args.no_pretty_print,
+                pretty_print=args.pretty_print,
                 enketo=args.enketo_validate,
             )
 
@@ -171,7 +171,7 @@ def main_cli():
             xlsform_path=args.path_to_XLSForm,
             xform_path=args.output_path,
             validate=args.odk_validate,
-            pretty_print=args.no_pretty_print,
+            pretty_print=args.pretty_print,
             enketo=args.enketo_validate,
         )
         if len(warnings) > 0:


### PR DESCRIPTION
if the cli flag ** --pretty_print ** is not given then xform file is printed as ugly, explicitly providing the flag converts .xlsx file to pretty-printed .xml. This as discussed here has the advantage that the xform sizes have relatively less size when ugly_printed as opposed to when pretty-printed.

fixes #162