### PR TITLE
Add support for start-geopoint

### DIFF
--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -51,14 +51,15 @@ class SurveyElementBuilder(object):
     # we use this CLASSES dict to create questions from dictionaries
     QUESTION_CLASSES = {
         "": Question,
+        "action": Question,
         "input": InputQuestion,
-        "trigger": TriggerQuestion,
-        "select": MultipleChoiceQuestion,
-        "select1": MultipleChoiceQuestion,
         "odk:rank": MultipleChoiceQuestion,
-        "upload": UploadQuestion,
         "osm": OsmUploadQuestion,
         "range": RangeQuestion,
+        "select": MultipleChoiceQuestion,
+        "select1": MultipleChoiceQuestion,
+        "trigger": TriggerQuestion,
+        "upload": UploadQuestion,
     }
 
     SECTION_CLASSES = {

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -371,4 +371,9 @@ QUESTION_TYPE_DICT = {
     "xml-external": {
         # Only effect is to add an external instance.
     },
+    "start-geopoint": {
+        "control": {"tag": "action"},
+        "bind": {"type": "geopoint"},
+        "action": {"name": "odk:setgeopoint", "event": "odk-instance-first-load"},
+    },
 }

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -446,6 +446,7 @@ class Survey(Section):
         model_children += [node("instance", self.xml_instance())]
         model_children += list(self._generate_instances())
         model_children += self.xml_bindings()
+        model_children += self.xml_actions()
 
         if self.submission_url or self.public_key or self.auto_send or self.auto_delete:
             submission_attrs = dict()

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -60,6 +60,7 @@ class SurveyElement(dict):
         "query": unicode,
         "autoplay": unicode,
         "flat": lambda: False,
+        "action": unicode,
     }
 
     def _default(self):
@@ -418,6 +419,30 @@ class SurveyElement(dict):
         doesn't make sense to implement here in the base class.
         """
         raise NotImplementedError("Control not implemented")
+
+    def xml_action(self):
+        """
+        Return the action for this survey element.
+        """
+        if self.action:
+            action_dict = self.action.copy()
+            if action_dict:
+                name = action_dict["name"]
+                del action_dict["name"]
+                return node(name, ref=self.get_xpath(), **action_dict)
+
+        return None
+
+    def xml_actions(self):
+        """
+        Return a list of actions for this node and all its descendants.
+        """
+        result = []
+        for e in self.iter_descendants():
+            xml_action = e.xml_action()
+            if xml_action is not None:
+                result.append(xml_action)
+        return result
 
 
 def hashable(v):

--- a/pyxform/tests_v1/test_set_geopoint.py
+++ b/pyxform/tests_v1/test_set_geopoint.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Test setgeopoint widget.
+"""
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class SetGeopointTest(PyxformTestCase):
+    """Test setgeopoint widget class."""
+
+    def test_setgeopoint(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                |             |          |
+            |        | type           | name        | label    |
+            |        | start-geopoint | my-location | my label |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/my-location" type="geopoint"/>',
+                '<odk:setgeopoint event="odk-instance-first-load" ref="/data/my-location"/>',
+                "",
+            ],
+        )

--- a/pyxform/validators/odk_validate/__init__.py
+++ b/pyxform/validators/odk_validate/__init__.py
@@ -34,7 +34,9 @@ def install_exists():
 
 
 def _call_validator(path_to_xform, bin_file_path=ODK_VALIDATE_PATH):
-    return run_popen_with_timeout(["java", "-Djava.awt.headless=true", "-jar", bin_file_path, path_to_xform], 100)
+    return run_popen_with_timeout(
+        ["java", "-Djava.awt.headless=true", "-jar", bin_file_path, path_to_xform], 100
+    )
 
 
 def install_ok(bin_file_path=ODK_VALIDATE_PATH):
@@ -57,7 +59,11 @@ def check_java_version():
     Raises EnvironmentError exception if java version is less than java 8.
     """
     try:
-        stderr = str(run_popen_with_timeout(["java", "-Djava.awt.headless=true", "-version"], 100)[3])
+        stderr = str(
+            run_popen_with_timeout(
+                ["java", "-Djava.awt.headless=true", "-version"], 100
+            )[3]
+        )
     except OSError as os_error:
         stderr = str(os_error)
     # convert string to unicode for python2


### PR DESCRIPTION
Closes #336

The template of the question is in `question_type_dictionary.py`. I define a new attribute, `action` that will later be used to get all actions in the form. 

Note that in the ODK XForms spec, [actions](https://opendatakit.github.io/xforms-spec/#actions) can happen after the bind (what I'd like to call `model actions`) or inside a control (what I'd like to call `control actions`). For now, I name functions/variables generically and expect what we can parameterize these later (e.g., add a `type` attribute whose value can either be `model` or `control`)

In `survey_element.py`, I took the code we use for binds and make minor changes. The differences here are that I check for the existence of an `action`, drop the `name` attribute from what we pass on, and use `ref` instead of `nodeset`. I'm not sure that `self.get_xpath()` is the correct method to use for the ref, but it does seem to work.

In `survey.py`, we take the JSON that we've built and output it.

Rebased on https://github.com/XLSForm/pyxform/pull/346 to get a green build.