### PR TITLE
Ignore pyxform_validator_update files that are user-specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ env
 # ignore pypi manifest
 MANIFEST
 pyxform/tests/test_output/
+
+# ignore pyxform_validator_update files
+pyxform/validators/odk_validate/.last_check
+pyxform/validators/odk_validate/latest.json

--- a/pyxform/validators/odk_validate/__init__.py
+++ b/pyxform/validators/odk_validate/__init__.py
@@ -34,7 +34,9 @@ def install_exists():
 
 
 def _call_validator(path_to_xform, bin_file_path=ODK_VALIDATE_PATH):
-    return run_popen_with_timeout(["java", "-Djava.awt.headless=true", "-jar", bin_file_path, path_to_xform], 100)
+    return run_popen_with_timeout(
+        ["java", "-Djava.awt.headless=true", "-jar", bin_file_path, path_to_xform], 100
+    )
 
 
 def install_ok(bin_file_path=ODK_VALIDATE_PATH):
@@ -57,7 +59,11 @@ def check_java_version():
     Raises EnvironmentError exception if java version is less than java 8.
     """
     try:
-        stderr = str(run_popen_with_timeout(["java", "-Djava.awt.headless=true", "-version"], 100)[3])
+        stderr = str(
+            run_popen_with_timeout(
+                ["java", "-Djava.awt.headless=true", "-version"], 100
+            )[3]
+        )
     except OSError as os_error:
         stderr = str(os_error)
     # convert string to unicode for python2


### PR DESCRIPTION
Unlike `installed.json` which is repo-specific, these files are user-specific and so should be probably be ignored. One alternative might be that we move these to a `/tmp`, but `.gitgnore` seemed like the narrowest solution.

Rebased on https://github.com/XLSForm/pyxform/pull/346 to get a green build.