### PR TITLE
Google submissions do allow underscores

### DIFF
--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -203,19 +203,6 @@ class BasicXls2JsonApiTests(TestCase):
         ]
         self.assertEqual(choice_filter_survey.to_json_dict()["children"], expected_dict)
 
-    def test_underscore_warnings(self):
-        """Raise warnings incase there are underscores in column names"""
-        warnings = []
-        parse_file_to_json(utils.path_to_text_fixture("hidden.xls"), warnings=warnings)
-        self.assertGreater(len(warnings), 0)
-        warning = (
-            "Google Sheets submissions don't allow underscores in the "
-            "column name. If you intend to use Google Sheets "
-            "submissions, replace underscores with hyphens in the "
-            "following names: hidden_test"
-        )
-        self.assertIn(warning, warnings)
-
 
 class CsvReaderEquivalencyTest(TestCase):
     def test_equivalency(self):

--- a/pyxform/tests/xlsform_spec_test.py
+++ b/pyxform/tests/xlsform_spec_test.py
@@ -98,7 +98,7 @@ class WarningsTest(unittest.TestCase):
         warnings = []
         pyxform.xls2json.parse_file_to_json(path_to_excel_file, warnings=warnings)
         self.assertEquals(
-            len(warnings), 22, "Found " + str(len(warnings)) + " warnings"
+            len(warnings), 21, "Found " + str(len(warnings)) + " warnings"
         )
 
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -590,8 +590,6 @@ def workbook_to_json(
 
     # Rows from the survey sheet that should be nested in meta
     survey_meta = []
-    # Google Sheets submissions don't allow underscores in the column name
-    names_with_underscores = []
 
     for row in survey_sheet:
         row_number += 1
@@ -621,8 +619,6 @@ def workbook_to_json(
         question_type = row.get(constants.TYPE)
         question_name = row.get(constants.NAME)
 
-        if question_name and "_" in question_name:
-            names_with_underscores.append(question_name)
         if not question_type:
             # if name and label are also missing,
             # then its a comment row, and we skip it with warning
@@ -1223,13 +1219,6 @@ def workbook_to_json(
         # Put the row in the json dict as is:
         parent_children_array.append(row)
 
-    if names_with_underscores:
-        warnings.append(
-            "Google Sheets submissions don't allow underscores in the "
-            "column name. If you intend to use Google Sheets submissions, "
-            "replace underscores with hyphens in the following names: "
-            "{}".format(", ".join(names_with_underscores))
-        )
     if len(stack) != 1:
         raise PyXFormError(
             "Unmatched begin statement: "


### PR DESCRIPTION
Closes #353 and reverts https://github.com/XLSForm/pyxform/pull/299 because ODK Collect v1.23.3 allows submissions with underscores as shown here:
<img width="656" alt="Screen Shot 2019-09-05 at 2 41 49 PM" src="https://user-images.githubusercontent.com/32369/64385452-52819900-cfeb-11e9-9f90-a95a158cd4fe.png">

For further proof, https://github.com/opendatakit/collect/pull/1851/commits/3cca371037e21178b910ee0fadaa49cbf99cdf15 shows that the code in Collect that does this check was removed.

In the future, we really should test these PRs end to end before merging.