### PR TITLE
Fix spelling and update failing tests

### DIFF
--- a/pyxform/tests_v1/test_fields.py
+++ b/pyxform/tests_v1/test_fields.py
@@ -100,7 +100,7 @@ class FieldsTests(PyxformTestCase):
             """
 
         expected = """
-            <select1 ref="/pyxform_autotestname/S1">
+    <select1 ref="/pyxform_autotestname/S1">
       <label>s1</label>
       <item>
         <label>a</label>
@@ -116,7 +116,7 @@ class FieldsTests(PyxformTestCase):
       </item>
     </select1>
 """
-        self.assertPyxformXform(md=md, model__contins=[expected], run_odk_validate=True)
+        self.assertPyxformXform(md=md, xml__contains=[expected], run_odk_validate=True)
 
     def test_choice_list_without_duplicates_is_successful(self):
         md = """
@@ -133,7 +133,7 @@ class FieldsTests(PyxformTestCase):
             """
 
         expected = """
-            <select1 ref="/pyxform_autotestname/S1">
+    <select1 ref="/pyxform_autotestname/S1">
       <label>s1</label>
       <item>
         <label>a</label>
@@ -145,4 +145,4 @@ class FieldsTests(PyxformTestCase):
       </item>
     </select1>
 """
-        self.assertPyxformXform(md=md, model__contins=[expected], run_odk_validate=True)
+        self.assertPyxformXform(md=md, xml__contains=[expected], run_odk_validate=True)

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -243,7 +243,7 @@ class TestRepeat(PyxformTestCase):
     </group>
     """  # noqa
 
-        self.assertPyxformXform(md=md, model__contins=[expected], run_odk_validate=True)
+        self.assertPyxformXform(md=md, model__contains=[expected], run_odk_validate=True)
 
     def test_hints_are_present_within_groups(self):
         """Tests that hints are present within groups."""

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -206,16 +206,15 @@ class TestRepeat(PyxformTestCase):
             """  # noqa
 
         expected = """
-
-      <group ref="/Families/pets">
+    <group ref="/pyxform_autotestname/pets">
       <label>Pets</label>
       <hint>Pet details</hint>
-      <repeat nodeset="/Families/pets">
-        <input ref="/Families/pets/pets_name">
-          <label>Pet's Name</label>
-          <hint>Pets name hint</hint>
+      <repeat nodeset="/pyxform_autotestname/pets">
+        <input ref="/pyxform_autotestname/pets/pets_name">
+          <label>Pet's name</label>
+          <hint>Pet's name hint</hint>
         </input>
-        <select1 ref="/Families/pets/pet_type">
+        <select1 ref="/pyxform_autotestname/pets/pet_type">
           <label>Type of pet</label>
           <hint>Type of pet hint</hint>
           <item>
@@ -235,15 +234,15 @@ class TestRepeat(PyxformTestCase):
             <value>fish</value>
           </item>
         </select1>
-        <upload mediatype="image/*" ref="/Families/pets/pet_picture">
+        <upload mediatype="image/*" ref="/pyxform_autotestname/pets/pet_picture">
           <label>Picture of pet</label>
           <hint>Take a nice photo</hint>
         </upload>
       </repeat>
     </group>
-    """  # noqa
+"""
 
-        self.assertPyxformXform(md=md, model__contains=[expected], run_odk_validate=True)
+        self.assertPyxformXform(md=md, xml__contains=[expected], run_odk_validate=True)
 
     def test_hints_are_present_within_groups(self):
         """Tests that hints are present within groups."""

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -187,8 +187,8 @@ class TestRepeat(PyxformTestCase):
             ],
         )
 
-    def test_hints_are_present_within_repeats(self):
-        """Hints are present within repeats"""
+    def test_hints_are_not_present_within_repeats(self):
+        """Hints are not present within repeats"""
         md = """
             | survey |                   |                |                   |                      |
             |        | type              | name           | label             | hint                 |
@@ -208,7 +208,6 @@ class TestRepeat(PyxformTestCase):
         expected = """
     <group ref="/pyxform_autotestname/pets">
       <label>Pets</label>
-      <hint>Pet details</hint>
       <repeat nodeset="/pyxform_autotestname/pets">
         <input ref="/pyxform_autotestname/pets/pets_name">
           <label>Pet's name</label>

--- a/pyxform/tests_v1/test_support_external_instances.py
+++ b/pyxform/tests_v1/test_support_external_instances.py
@@ -183,14 +183,12 @@ class ExternalCSVInstancesBugsTest(PyxformTestCase):
             |                  | cities       | Kisumu         |
             |                  | cities       | Mombasa        |
             """
-        expected = [
-            """<itemset nodeset="instance('cities')/root/item">
-            <value ref="name"/>
-            <label ref="label"/>
-            </itemset>"""
-        ]  # noqa
+        expected = """
+    <input query="instance('cities')/root/item[S1= /pyxform_autotestname/S1  and county= /pyxform_autotestname/county ]" ref="/pyxform_autotestname/city">
+"""
+
         self.assertPyxformXform(
-            md=md, debug=False, model__contins=[expected], run_odk_validate=True
+            md=md, debug=False, xml__contains=[expected], run_odk_validate=True
         )
 
     def test_list_name_not_in_external_choices_sheet_raises_error(self):


### PR DESCRIPTION
Mostly whitespace and root node name changes, but there are two commits that need close consideration. 

* 9a934535106703c3e2ffdd358670c1b30b311bda - Confirm this is the correct syntax for external instances. @lognaturel, can you sanity check this?

* d885690ecb1ab0008a0ab18f6b5034b1922e0d83 - Confirm that groups and repeats shouldn't display hints. It's not in the spec (https://opendatakit.github.io/xforms-spec/#groups and https://opendatakit.github.io/xforms-spec/#repeats) and pyxform currently doesn't output hints. Sanity check, @MartijnR?