### PR TITLE
Run codecov in subshell to prevent blocking build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           name: upload coverage report
           command: |
             /home/circleci/.local/bin/coverage xml
-            /home/circleci/.local/bin/codecov --required -X search gcov pycov -f coverage.xml
+            (/home/circleci/.local/bin/codecov --required -X search gcov pycov -f coverage.xml) || echo 'Codecov failed to upload'
       - run:
           name: Building artifacts
           command: |


### PR DESCRIPTION
Codecov's upload to S3 sometimes fails with the following error:
`Error: HTTPSConnectionPool(host='codecov.io', port=443): Max retries exceeded with url`

I considered using the hacky approach at https://github.com/codecov/codecov-python/issues/158#issuecomment-514282362 but that would have resulted in a pretty messy command for us.

`for i in 1 2 3; do /home/circleci/.local/bin/codecov --required -X search gcov pycov -f coverage.xml && break || sleep 30; done` seems like it'd be better, but I guess I don't think we need to hammer codecov's servers. I don't think code coverage reports are that important anyway.

Rather than all these retries, I think we should just run it in a subshell. If it works on the run, great. If not, it doesn't block the build. I got the idea from https://github.com/mapbox/mapbox-gl-native/pull/15248.

I don't have a great way to confirm the subshell command works on master, but it's a safe merge.