### PR TITLE
Default to 'data' when filename is invalid.

### DIFF
--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -78,7 +78,8 @@ class PyxformMarkdown(object):
         # ideally, when all these tests are working, this would be
         # refactored as well
         survey = create_survey_element_from_dict(imported_survey_json)
-        survey.name = kwargs.get("name")
+        if not kwargs.get("skip_name"):
+            survey.name = kwargs.get("name")
         survey.title = kwargs.get("title")
         survey.id_string = kwargs.get("id_string")
 

--- a/pyxform/tests_v1/test_form_name.py
+++ b/pyxform/tests_v1/test_form_name.py
@@ -26,3 +26,68 @@ class FormNameTest(PyxformTestCase):
                 '</input>',
             ],
         )
+
+    def test_default_to_data_when_no_name(self):
+        """
+        Test no form_name and skipping name field, default to 'data'.
+        """
+
+        self.assertPyxformXform(
+            md="""
+               | survey |      |      |           |
+               |        | type | name | label     |
+               |        | text | city | City Name |
+               """,
+            skip_name=True,
+            id_string='some-id',
+            instance__contains=['<data id="some-id">'],
+            model__contains=['<bind nodeset="/data/city" type="string"/>'],
+            xml__contains=[
+                '<input ref="/data/city">',
+                '<label>City Name</label>',
+                '</input>',
+            ],
+        )
+
+    def test_default_form_name_to_superclass_definition(self):
+        """
+        Test no form_name and not skipping name field, default to super class definition.
+        """
+
+        self.assertPyxformXform(
+            md="""
+               | survey |      |      |           |
+               |        | type | name | label     |
+               |        | text | city | City Name |
+               """,
+            id_string='some-id',
+            instance__contains=['<pyxform_autotestname id="some-id">'],
+            model__contains=['<bind nodeset="/pyxform_autotestname/city" type="string"/>'],
+            xml__contains=[
+                '<input ref="/pyxform_autotestname/city">',
+                '<label>City Name</label>',
+                '</input>',
+            ],
+        )
+
+    def test_default_form_name_to_superclass_definition(self):
+        """
+        Test no form_name and setting name field, should use name field.
+        """
+
+        self.assertPyxformXform(
+            md="""
+               | survey |      |      |           |
+               |        | type | name | label     |
+               |        | text | city | City Name |
+               """,
+            name='some-name',
+            id_string='some-id',
+            instance__contains=['<some-name id="some-id">'],
+            model__contains=['<bind nodeset="/some-name/city" type="string"/>'],
+            xml__contains=[
+                '<input ref="/some-name/city">',
+                '<label>City Name</label>',
+                '</input>',
+            ],
+        )

--- a/pyxform/tests_v1/test_form_name.py
+++ b/pyxform/tests_v1/test_form_name.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Test setting form name to data.
+"""
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+class FormNameTest(PyxformTestCase):
+
+    def test_default_to_data(self):
+        """
+        Test using data as the name of the form which will generate <data />.
+        """
+        self.assertPyxformXform(
+            md="""
+               | survey |      |      |           |
+               |        | type | name | label     |
+               |        | text | city | City Name |
+               """,
+            name='data',
+            id_string='some-id',
+            instance__contains=['<data id="some-id">'],
+            model__contains=['<bind nodeset="/data/city" type="string"/>'],
+            xml__contains=[
+                '<input ref="/data/city">',
+                '<label>City Name</label>',
+                '</input>',
+            ],
+        )

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1315,7 +1315,7 @@ def parse_file_to_json(
     
     file_name = unicode(get_filename(path))
     if is_valid_xml_tag(file_name):
-      default_name = file_name
+        default_name = file_name
 
     return workbook_to_json(workbook_dict, default_name, default_language, warnings)
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -299,7 +299,7 @@ def process_range_question_type(row):
 
 
 def workbook_to_json(
-    workbook_dict, form_name=None, default_language="default", warnings=None
+    workbook_dict, form_name='data', default_language="default", warnings=None
 ):
     """
     workbook_dict -- nested dictionaries representing a spreadsheet.

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1304,7 +1304,7 @@ def get_filename(path):
 
 
 def parse_file_to_json(
-    path, default_name=None, default_language="default", warnings=None, file_object=None
+    path, default_name='data', default_language="default", warnings=None, file_object=None
 ):
     """
     A wrapper for workbook_to_json
@@ -1312,8 +1312,11 @@ def parse_file_to_json(
     if warnings is None:
         warnings = []
     workbook_dict = parse_file_to_workbook_dict(path, file_object)
-    if default_name is None:
-        default_name = unicode(get_filename(path))
+    
+    file_name = unicode(get_filename(path))
+    if is_valid_xml_tag(file_name):
+      default_name = file_name
+
     return workbook_to_json(workbook_dict, default_name, default_language, warnings)
 
 


### PR DESCRIPTION
Addresses #130

When the xls filename start with number, and the user doesn't set the 'name' in the settings sheet, the pyxform will complain because it will try to use the filename as an xml tag.

This will default the xml tag to data when the filename is not a valid xml tag.