### PR TITLE
Passing filename as the default form id parameter.

### DIFF
--- a/pyxform/tests/test_expected_output/survey_no_name.xml
+++ b/pyxform/tests/test_expected_output/survey_no_name.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <h:head>
-    <h:title>data</h:title>
+    <h:title>survey_no_name</h:title>
     <model>
       <instance>
-        <data id="data">
+        <data id="survey_no_name">
           <state/>
           <meta>
             <instanceID/>

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -299,7 +299,11 @@ def process_range_question_type(row):
 
 
 def workbook_to_json(
-    workbook_dict, form_name=None, default_language="default", warnings=None
+    workbook_dict,
+    form_name=None,
+    form_id=None,
+    default_language="default",
+    warnings=None,
 ):
     """
     workbook_dict -- nested dictionaries representing a spreadsheet.
@@ -388,7 +392,7 @@ def workbook_to_json(
         )
 
     # Here we create our json dict root with default settings:
-    id_string = settings.get(constants.ID_STRING, form_name)
+    id_string = settings.get(constants.ID_STRING, form_id)
     sms_keyword = settings.get(constants.SMS_KEYWORD, id_string)
     json_dict = {
         constants.TYPE: constants.SURVEY,
@@ -1316,7 +1320,10 @@ def parse_file_to_json(
     if warnings is None:
         warnings = []
     workbook_dict = parse_file_to_workbook_dict(path, file_object)
-    return workbook_to_json(workbook_dict, default_name, default_language, warnings)
+    default_form_id = unicode(get_filename(path))
+    return workbook_to_json(
+        workbook_dict, default_name, default_form_id, default_language, warnings
+    )
 
 
 def organize_by_values(dict_list, key):

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -301,7 +301,7 @@ def process_range_question_type(row):
 def workbook_to_json(
     workbook_dict,
     form_name=None,
-    form_id=None,
+    fallback_form_name=None,
     default_language="default",
     warnings=None,
 ):
@@ -392,7 +392,7 @@ def workbook_to_json(
         )
 
     # Here we create our json dict root with default settings:
-    id_string = settings.get(constants.ID_STRING, form_id)
+    id_string = settings.get(constants.ID_STRING, fallback_form_name)
     sms_keyword = settings.get(constants.SMS_KEYWORD, id_string)
     json_dict = {
         constants.TYPE: constants.SURVEY,
@@ -1320,9 +1320,9 @@ def parse_file_to_json(
     if warnings is None:
         warnings = []
     workbook_dict = parse_file_to_workbook_dict(path, file_object)
-    default_form_id = unicode(get_filename(path))
+    fallback_form_name = unicode(get_filename(path))
     return workbook_to_json(
-        workbook_dict, default_name, default_form_id, default_language, warnings
+        workbook_dict, default_name, fallback_form_name, default_language, warnings
     )
 
 


### PR DESCRIPTION
Fix #388.

Introduce a new parameter for the ```workbook_to_json``` by passing the xls filename as the default value for the form_id. This will be replaced with value from the ```settings``` tab if supplied.