### PR TITLE
Add identify-user audit attribute

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -94,7 +94,7 @@ LOCATION_PRIORITY = "location-priority"
 LOCATION_MIN_INTERVAL = "location-min-interval"
 LOCATION_MAX_AGE = "location-max-age"
 TRACK_CHANGES = "track-changes"
-USER_IDENTITY = "user-identity"
+IDENTIFY_USER = "identify-user"
 
 # supported bind keywords for which external instances will be created for pulldata function
 EXTERNAL_INSTANCES = ["calculate", "constraint", "readonly", "required", "relevant"]

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -94,6 +94,7 @@ LOCATION_PRIORITY = "location-priority"
 LOCATION_MIN_INTERVAL = "location-min-interval"
 LOCATION_MAX_AGE = "location-max-age"
 TRACK_CHANGES = "track-changes"
+USER_IDENTITY = "user-identity"
 
 # supported bind keywords for which external instances will be created for pulldata function
 EXTERNAL_INSTANCES = ["calculate", "constraint", "readonly", "required", "relevant"]

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -192,10 +192,10 @@ class AuditTest(PyxformTestCase):
             md="""
             | survey |        |          |                   |
             |        | type   |   name   | parameters        |
-            |        | audit  |   audit  | user-identity=foo |
+            |        | audit  |   audit  | identify-user=foo |
             """,
             errored=True,
-            error__contains=["user-identity must be set to true or false"],
+            error__contains=["identify-user must be set to true or false"],
         )
 
     def test_audit_identify_user_true(self):
@@ -204,13 +204,13 @@ class AuditTest(PyxformTestCase):
             md="""
             | survey |        |          |                    |
             |        | type   |   name   | parameters         |
-            |        | audit  |   audit  | user-identity=true |
+            |        | audit  |   audit  | identify-user=true |
             """,
             xml__contains=[
                 "<meta>",
                 "<audit/>",
                 "</meta>",
-                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:user-identity="true"/>',
+                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:identify-user="true"/>',
             ],
         )
 
@@ -220,13 +220,13 @@ class AuditTest(PyxformTestCase):
             md="""
             | survey |        |          |                    |
             |        | type   |   name   | parameters         |
-            |        | audit  |   audit  | user-identity=false |
+            |        | audit  |   audit  | identify-user=false |
             """,
             xml__contains=[
                 "<meta>",
                 "<audit/>",
                 "</meta>",
-                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:user-identity="false"/>',
+                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:identify-user="false"/>',
             ],
         )
 

--- a/pyxform/tests_v1/test_audit.py
+++ b/pyxform/tests_v1/test_audit.py
@@ -186,6 +186,50 @@ class AuditTest(PyxformTestCase):
             error__contains=["track-changes must be set to true or false"],
         )
 
+    def test_audit_identify_user_foo(self):
+        self.assertPyxformXform(
+            name="meta_audit",
+            md="""
+            | survey |        |          |                   |
+            |        | type   |   name   | parameters        |
+            |        | audit  |   audit  | user-identity=foo |
+            """,
+            errored=True,
+            error__contains=["user-identity must be set to true or false"],
+        )
+
+    def test_audit_identify_user_true(self):
+        self.assertPyxformXform(
+            name="meta_audit",
+            md="""
+            | survey |        |          |                    |
+            |        | type   |   name   | parameters         |
+            |        | audit  |   audit  | user-identity=true |
+            """,
+            xml__contains=[
+                "<meta>",
+                "<audit/>",
+                "</meta>",
+                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:user-identity="true"/>',
+            ],
+        )
+
+    def test_audit_identify_user_false(self):
+        self.assertPyxformXform(
+            name="meta_audit",
+            md="""
+            | survey |        |          |                    |
+            |        | type   |   name   | parameters         |
+            |        | audit  |   audit  | user-identity=false |
+            """,
+            xml__contains=[
+                "<meta>",
+                "<audit/>",
+                "</meta>",
+                '<bind nodeset="/meta_audit/meta/audit" type="binary" odk:user-identity="false"/>',
+            ],
+        )
+
     def test_audit_location_track_changes(self):
         self.assertPyxformXform(
             name="meta_audit",

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -652,7 +652,7 @@ def workbook_to_json(
                     constants.LOCATION_MIN_INTERVAL,
                     constants.LOCATION_MAX_AGE,
                     constants.TRACK_CHANGES,
-                    constants.USER_IDENTITY,
+                    constants.IDENTIFY_USER,
                 ],
             )
 
@@ -676,22 +676,22 @@ def workbook_to_json(
                         }
                     )
 
-            if constants.USER_IDENTITY in parameters.keys():
+            if constants.IDENTIFY_USER in parameters.keys():
                 if (
-                    parameters[constants.USER_IDENTITY] != "true"
-                    and parameters[constants.USER_IDENTITY] != "false"
+                    parameters[constants.IDENTIFY_USER] != "true"
+                    and parameters[constants.IDENTIFY_USER] != "false"
                 ):
                     raise PyXFormError(
-                        constants.USER_IDENTITY + " must be set to true or false: "
-                        "'%s' is an invalid value" % parameters[constants.USER_IDENTITY]
+                        constants.IDENTIFY_USER + " must be set to true or false: "
+                        "'%s' is an invalid value" % parameters[constants.IDENTIFY_USER]
                     )
                 else:
                     new_dict["bind"] = new_dict.get("bind", {})
                     new_dict["bind"].update(
                         {
                             "odk:"
-                            + constants.USER_IDENTITY: parameters[
-                                constants.USER_IDENTITY
+                            + constants.IDENTIFY_USER: parameters[
+                                constants.IDENTIFY_USER
                             ]
                         }
                     )

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -652,6 +652,7 @@ def workbook_to_json(
                     constants.LOCATION_MIN_INTERVAL,
                     constants.LOCATION_MAX_AGE,
                     constants.TRACK_CHANGES,
+                    constants.USER_IDENTITY,
                 ],
             )
 
@@ -671,6 +672,26 @@ def workbook_to_json(
                             "odk:"
                             + constants.TRACK_CHANGES: parameters[
                                 constants.TRACK_CHANGES
+                            ]
+                        }
+                    )
+
+            if constants.USER_IDENTITY in parameters.keys():
+                if (
+                    parameters[constants.USER_IDENTITY] != "true"
+                    and parameters[constants.USER_IDENTITY] != "false"
+                ):
+                    raise PyXFormError(
+                        constants.USER_IDENTITY + " must be set to true or false: "
+                        "'%s' is an invalid value" % parameters[constants.USER_IDENTITY]
+                    )
+                else:
+                    new_dict["bind"] = new_dict.get("bind", {})
+                    new_dict["bind"].update(
+                        {
+                            "odk:"
+                            + constants.USER_IDENTITY: parameters[
+                                constants.USER_IDENTITY
                             ]
                         }
                     )


### PR DESCRIPTION
This adds the `identify-user` as defined in [this spec](https://docs.google.com/document/d/1lVObIqvM75tCSA5w8Iu3WropJDQmpE3Cap3GWOepTOY/edit#). The original discussion around this feature is [here](https://forum.opendatakit.org/t/approaches-for-linking-form-instance-changes-to-individuals/20189) on the Forum.