### PR TITLE
Add pyxform version to XForm output, closes #393

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -28,6 +28,7 @@ COMPACT_DELIMITER = "delimiter"
 COMPACT_TAG = "compact_tag"
 
 VERSION = "version"
+PYXFORM_VERSION = "pyxform_version"
 PUBLIC_KEY = "public_key"
 SUBMISSION_URL = "submission_url"
 AUTO_SEND = "auto_send"

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -28,7 +28,7 @@ COMPACT_DELIMITER = "delimiter"
 COMPACT_TAG = "compact_tag"
 
 VERSION = "version"
-PYXFORM_VERSION = "pyxform_version"
+GENERATED_BY = "generated_by"
 PUBLIC_KEY = "public_key"
 SUBMISSION_URL = "submission_url"
 AUTO_SEND = "auto_send"

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -130,6 +130,7 @@ class Survey(Section):
             "public_key": unicode,
             "instance_xmlns": unicode,
             "version": unicode,
+            "pyxform_version": unicode,
             "choices": dict,
             "style": unicode,
             "attribute": dict,
@@ -474,6 +475,9 @@ class Survey(Section):
 
         if self.version:
             result.setAttribute("version", self.version)
+
+        if self.pyxform_version:
+            result.setAttribute("odk:pyxform-version", self.pyxform_version)
 
         if self.prefix:
             result.setAttribute("odk:prefix", self.prefix)

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -130,7 +130,7 @@ class Survey(Section):
             "public_key": unicode,
             "instance_xmlns": unicode,
             "version": unicode,
-            "pyxform_version": unicode,
+            "generated_by": unicode,
             "choices": dict,
             "style": unicode,
             "attribute": dict,
@@ -476,8 +476,8 @@ class Survey(Section):
         if self.version:
             result.setAttribute("version", self.version)
 
-        if self.pyxform_version:
-            result.setAttribute("odk:pyxform-version", self.pyxform_version)
+        if self.generated_by:
+            result.setAttribute("odk:generated-by", self.generated_by)
 
         if self.prefix:
             result.setAttribute("odk:prefix", self.prefix)

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -159,8 +159,10 @@ class BuilderTests(TestCase):
                 },
             ],
         }
+        actual_dict = survey.to_json_dict()
+        actual_dict.pop("pyxform_version", None)
         self.maxDiff = None
-        self.assertEqual(survey.to_json_dict(), expected_dict)
+        self.assertEqual(actual_dict, expected_dict)
 
     def test_select_one_question_with_identical_choice_name(self):
         """
@@ -199,8 +201,10 @@ class BuilderTests(TestCase):
                 },
             ],
         }
+        actual_dict = survey.to_json_dict()
+        actual_dict.pop("pyxform_version", None)
         self.maxDiff = None
-        self.assertEqual(survey.to_json_dict(), expected_dict)
+        self.assertEqual(actual_dict, expected_dict)
 
     def test_loop(self):
         survey = utils.create_survey_from_fixture("loop", filetype=FIXTURE_FILETYPE)
@@ -312,8 +316,10 @@ class BuilderTests(TestCase):
                 },
             ],
         }
+        actual_dict = survey.to_json_dict()
+        actual_dict.pop("pyxform_version", None)
         self.maxDiff = None
-        self.assertEqual(survey.to_json_dict(), expected_dict)
+        self.assertEqual(actual_dict, expected_dict)
 
     def test_sms_columns(self):
         survey = utils.create_survey_from_fixture("sms_info", filetype=FIXTURE_FILETYPE)
@@ -449,7 +455,9 @@ class BuilderTests(TestCase):
             "title": "SMS Example",
             "type": "survey",
         }
-        self.assertEqual(survey.to_json_dict(), expected_dict)
+        actual_dict = survey.to_json_dict()
+        actual_dict.pop("pyxform_version", None)
+        self.assertEqual(actual_dict, expected_dict)
 
     def test_style_column(self):
         survey = utils.create_survey_from_fixture(
@@ -488,7 +496,9 @@ class BuilderTests(TestCase):
             "title": "My Survey",
             "type": "survey",
         }
-        self.assertEqual(survey.to_json_dict(), expected_dict)
+        actual_dict = survey.to_json_dict()
+        actual_dict.pop("pyxform_version", None)
+        self.assertEqual(actual_dict, expected_dict)
 
     STRIP_NS_FROM_TAG_RE = re.compile(r"\{.+\}")
 

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -160,7 +160,7 @@ class BuilderTests(TestCase):
             ],
         }
         actual_dict = survey.to_json_dict()
-        actual_dict.pop("pyxform_version", None)
+        actual_dict.pop("generated_by", None)
         self.maxDiff = None
         self.assertEqual(actual_dict, expected_dict)
 
@@ -202,7 +202,7 @@ class BuilderTests(TestCase):
             ],
         }
         actual_dict = survey.to_json_dict()
-        actual_dict.pop("pyxform_version", None)
+        actual_dict.pop("generated_by", None)
         self.maxDiff = None
         self.assertEqual(actual_dict, expected_dict)
 
@@ -317,7 +317,7 @@ class BuilderTests(TestCase):
             ],
         }
         actual_dict = survey.to_json_dict()
-        actual_dict.pop("pyxform_version", None)
+        actual_dict.pop("generated_by", None)
         self.maxDiff = None
         self.assertEqual(actual_dict, expected_dict)
 
@@ -456,7 +456,7 @@ class BuilderTests(TestCase):
             "type": "survey",
         }
         actual_dict = survey.to_json_dict()
-        actual_dict.pop("pyxform_version", None)
+        actual_dict.pop("generated_by", None)
         self.assertEqual(actual_dict, expected_dict)
 
     def test_style_column(self):
@@ -497,7 +497,7 @@ class BuilderTests(TestCase):
             "type": "survey",
         }
         actual_dict = survey.to_json_dict()
-        actual_dict.pop("pyxform_version", None)
+        actual_dict.pop("generated_by", None)
         self.assertEqual(actual_dict, expected_dict)
 
     STRIP_NS_FROM_TAG_RE = re.compile(r"\{.+\}")

--- a/pyxform/tests/group_test.py
+++ b/pyxform/tests/group_test.py
@@ -57,7 +57,7 @@ class GroupTests(TestCase):
                 },
             ],
         }
-        x_results.pop("pyxform_version", None)
+        x_results.pop("generated_by", None)
         self.maxDiff = None
         self.assertEqual(x_results, expected_dict)
 

--- a/pyxform/tests/group_test.py
+++ b/pyxform/tests/group_test.py
@@ -57,6 +57,7 @@ class GroupTests(TestCase):
                 },
             ],
         }
+        x_results.pop("pyxform_version", None)
         self.maxDiff = None
         self.assertEqual(x_results, expected_dict)
 

--- a/pyxform/tests/loop_tests.py
+++ b/pyxform/tests/loop_tests.py
@@ -90,5 +90,5 @@ class LoopTests(TestCase):
             ],
         }
         actual_dict = survey.to_json_dict()
-        actual_dict.pop("pyxform_version", None)
+        actual_dict.pop("generated_by", None)
         self.assertEquals(actual_dict, expected_dict)

--- a/pyxform/tests/loop_tests.py
+++ b/pyxform/tests/loop_tests.py
@@ -89,4 +89,6 @@ class LoopTests(TestCase):
                 },
             ],
         }
-        self.assertEquals(survey.to_json_dict(), expected_dict)
+        actual_dict = survey.to_json_dict()
+        actual_dict.pop("pyxform_version", None)
+        self.assertEquals(actual_dict, expected_dict)

--- a/pyxform/tests/settings_test.py
+++ b/pyxform/tests/settings_test.py
@@ -56,7 +56,7 @@ class SettingsTests(TestCase):
             ],
         }
         actual_dict = survey_reader.to_json_dict()
-        actual_dict.pop("pyxform_version", None)
+        actual_dict.pop("generated_by", None)
         self.assertEqual(actual_dict, expected_dict)
 
     def test_settings(self):

--- a/pyxform/tests/settings_test.py
+++ b/pyxform/tests/settings_test.py
@@ -55,7 +55,9 @@ class SettingsTests(TestCase):
                 },
             ],
         }
-        self.assertEqual(survey_reader.to_json_dict(), expected_dict)
+        actual_dict = survey_reader.to_json_dict()
+        actual_dict.pop("pyxform_version", None)
+        self.assertEqual(actual_dict, expected_dict)
 
     def test_settings(self):
         survey = create_survey_from_path(self.path)

--- a/pyxform/tests/tests_by_file.py
+++ b/pyxform/tests/tests_by_file.py
@@ -37,6 +37,7 @@ class MainTest(TestCase):
                 path_to_excel_file, default_name=root_filename
             )
             survey = pyxform.create_survey_element_from_dict(json_survey)
+            survey.pyxform_version = ""
             survey.print_xform_to_file(path_to_output_xform)
 
             # Compare with the expected output:

--- a/pyxform/tests/tests_by_file.py
+++ b/pyxform/tests/tests_by_file.py
@@ -37,7 +37,7 @@ class MainTest(TestCase):
                 path_to_excel_file, default_name=root_filename
             )
             survey = pyxform.create_survey_element_from_dict(json_survey)
-            survey.pyxform_version = ""
+            survey.generated_by = ""
             survey.print_xform_to_file(path_to_output_xform)
 
             # Compare with the expected output:

--- a/pyxform/tests/utils.py
+++ b/pyxform/tests/utils.py
@@ -64,6 +64,10 @@ class XFormTestCase(TestCase):
         xform1 = ETree.fromstring(xform1.encode("utf-8"))
         xform2 = ETree.fromstring(xform2.encode("utf-8"))
 
+        # Remove the odk:pyxform-version attribute from the primary instance child
+        self.remove_pyxform_version_attribute(xform1)
+        self.remove_pyxform_version_attribute(xform2)
+
         # Sort tags under <model> section in each form
         self.sort_model(xform1)
         self.sort_model(xform2)
@@ -92,6 +96,15 @@ class XFormTestCase(TestCase):
 
             key = elem_get_tag
         elems[:] = sorted(elems, key=key)
+
+    def remove_pyxform_version_attribute(self, xform):
+        xforms_ns = "{http://www.w3.org/2002/xforms}"
+        odk_ns = "{http://www.opendatakit.org/xforms}"
+        primary_instance = xform.find(".//" + xforms_ns + "instance")
+
+        # Remove the pyxform-version attribute
+        if primary_instance is not None:
+            primary_instance[0].attrib.pop(odk_ns + "pyxform-version", None)
 
     def sort_model(self, xform):
         ns = "{http://www.w3.org/2002/xforms}"

--- a/pyxform/tests/utils.py
+++ b/pyxform/tests/utils.py
@@ -64,9 +64,9 @@ class XFormTestCase(TestCase):
         xform1 = ETree.fromstring(xform1.encode("utf-8"))
         xform2 = ETree.fromstring(xform2.encode("utf-8"))
 
-        # Remove the odk:pyxform-version attribute from the primary instance child
-        self.remove_pyxform_version_attribute(xform1)
-        self.remove_pyxform_version_attribute(xform2)
+        # Remove the odk:generated-by attribute from the primary instance child
+        self.remove_generated_by_attribute(xform1)
+        self.remove_generated_by_attribute(xform2)
 
         # Sort tags under <model> section in each form
         self.sort_model(xform1)
@@ -97,14 +97,14 @@ class XFormTestCase(TestCase):
             key = elem_get_tag
         elems[:] = sorted(elems, key=key)
 
-    def remove_pyxform_version_attribute(self, xform):
+    def remove_generated_by_attribute(self, xform):
         xforms_ns = "{http://www.w3.org/2002/xforms}"
         odk_ns = "{http://www.opendatakit.org/xforms}"
         primary_instance = xform.find(".//" + xforms_ns + "instance")
 
-        # Remove the pyxform-version attribute
+        # Remove the generated-by attribute
         if primary_instance is not None:
-            primary_instance[0].attrib.pop(odk_ns + "pyxform-version", None)
+            primary_instance[0].attrib.pop(odk_ns + "generated-by", None)
 
     def sort_model(self, xform):
         ns = "{http://www.w3.org/2002/xforms}"

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -43,6 +43,7 @@ class BasicXls2JsonApiTests(TestCase):
             with codecs.open(output_path, "rb", encoding="utf-8") as actual_file:
                 expected_json = json.load(expected_file)
                 actual_json = json.load(actual_file)
+                actual_json.pop("pyxform_version", None)
                 self.assertEqual(expected_json, actual_json)
 
     def test_hidden(self):
@@ -140,6 +141,7 @@ class BasicXls2JsonApiTests(TestCase):
             with codecs.open(output_path, "rb", encoding="utf-8") as actual_file:
                 expected_json = json.load(expected_file)
                 actual_json = json.load(actual_file)
+                actual_json.pop("pyxform_version", None)
                 self.assertEqual(expected_json, actual_json)
 
     def test_choice_filter_choice_fields(self):

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -43,7 +43,7 @@ class BasicXls2JsonApiTests(TestCase):
             with codecs.open(output_path, "rb", encoding="utf-8") as actual_file:
                 expected_json = json.load(expected_file)
                 actual_json = json.load(actual_file)
-                actual_json.pop("pyxform_version", None)
+                actual_json.pop("generated_by", None)
                 self.assertEqual(expected_json, actual_json)
 
     def test_hidden(self):
@@ -141,7 +141,7 @@ class BasicXls2JsonApiTests(TestCase):
             with codecs.open(output_path, "rb", encoding="utf-8") as actual_file:
                 expected_json = json.load(expected_file)
                 actual_json = json.load(actual_file)
-                actual_json.pop("pyxform_version", None)
+                actual_json.pop("generated_by", None)
                 self.assertEqual(expected_json, actual_json)
 
     def test_choice_filter_choice_fields(self):

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -174,6 +174,10 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
             else:
                 survey = kwargs.get("survey")
 
+            # Remove the pyxform-version attribute
+            if survey:
+                survey.pyxform_version = ""
+
             xml = survey._to_pretty_xml()
             root = ETree.fromstring(xml.encode("utf-8"))
 

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -174,9 +174,9 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
             else:
                 survey = kwargs.get("survey")
 
-            # Remove the pyxform-version attribute
+            # Remove the generated-by attribute
             if survey:
-                survey.pyxform_version = ""
+                survey.generated_by = ""
 
             xml = survey._to_pretty_xml()
             root = ETree.fromstring(xml.encode("utf-8"))

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import subprocess
 from collections import Counter
 
 from pyxform import aliases, constants
@@ -406,6 +407,7 @@ def workbook_to_json(
         # problems for formhub.
         # constants.VERSION : datetime.datetime.now().strftime("%Y%m%d%H"),
         constants.CHILDREN: [],
+        constants.PYXFORM_VERSION: get_git_describe_tags(),
     }
     # Here the default settings are overridden by those in the settings sheet
     json_dict.update(settings)
@@ -1434,6 +1436,12 @@ def get_parameters(raw_parameters, allowed_parameters):
             )
 
     return params
+
+
+def get_git_describe_tags():
+    return subprocess.check_output(
+        ["git", "describe", "--tags", "HEAD"], universal_newlines=True
+    ).strip()[1:]
 
 
 class SpreadsheetReader(object):

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -407,7 +407,7 @@ def workbook_to_json(
         # problems for formhub.
         # constants.VERSION : datetime.datetime.now().strftime("%Y%m%d%H"),
         constants.CHILDREN: [],
-        constants.PYXFORM_VERSION: get_git_describe_tags(),
+        constants.GENERATED_BY: ("pyxform " + get_git_describe_tags()).strip(),
     }
     # Here the default settings are overridden by those in the settings sheet
     json_dict.update(settings)
@@ -1439,9 +1439,12 @@ def get_parameters(raw_parameters, allowed_parameters):
 
 
 def get_git_describe_tags():
-    return subprocess.check_output(
-        ["git", "describe", "--tags", "HEAD"], universal_newlines=True
-    ).strip()[1:]
+    try:
+        return subprocess.check_output(
+            ["git", "describe", "--tags", "HEAD"], universal_newlines=True
+        ).strip()
+    except:
+        return ""
 
 
 class SpreadsheetReader(object):


### PR DESCRIPTION
Please check extra carefully, as I didn't really know what I was doing.

This code assumes each tag has the format 'v'+semantic version, as we've been using so far (except for vv0.88). If you think that may possibly change, I'd be happy to add a few lines to chop off any non numeric starting characters. Or we could not omit any characters (except trimming) and leave it up the data collection clients to do.