### PR TITLE
Do not use is not with literals

### DIFF
--- a/pyxform/validators/error_cleaner.py
+++ b/pyxform/validators/error_cleaner.py
@@ -40,9 +40,9 @@ class ErrorCleaner(object):
     @staticmethod
     def _remove_java_content(line):
         # has a java filename (with line number)
-        has_java_filename = line.find(".java:") is not -1
+        has_java_filename = line.find(".java:") != -1
         # starts with '    at java class path or method path'
-        is_a_java_method = line.find("\tat") is not -1
+        is_a_java_method = line.find("\tat") != -1
         if not has_java_filename and not is_a_java_method:
             # remove java.lang.RuntimeException
             if line.startswith("java.lang.RuntimeException: "):


### PR DESCRIPTION
I got this syntax warning (probably from Python 3.8?) when I ran this code in a Flask app. 
```
SyntaxWarning: "is not" with a literal. Did you mean "!="?
```
As noted at https://discuss.python.org/t/demoting-the-is-operator-to-avoid-an-identity-crisis/86 `is not` should not be used with literals.