### PR TITLE
Better Python 2/3 unicode support for strings

### DIFF
--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -219,9 +219,7 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
                 )
             for v_err in odk_validate_error__contains:
                 self.assertContains(
-                    e.args[0].decode("utf-8"),
-                    v_err,
-                    msg_prefix="odk_validate_error__contains",
+                    e.args[0], v_err, msg_prefix="odk_validate_error__contains"
                 )
         else:
             survey = True

--- a/pyxform/validators/odk_validate/__init__.py
+++ b/pyxform/validators/odk_validate/__init__.py
@@ -3,7 +3,7 @@
 odk_validate.py
 A python wrapper around ODK Validate
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import logging
 import os
@@ -66,9 +66,6 @@ def check_java_version():
         )
     except OSError as os_error:
         stderr = str(os_error)
-    # convert string to unicode for python2
-    if sys.version_info.major < 3:
-        stderr = stderr.strip().decode("utf-8")
     if "java version" not in stderr and "openjdk version" not in stderr:
         raise EnvironmentError("pyxform odk validate dependency: java not found")
     # extract version number from version string
@@ -110,8 +107,7 @@ def check_xform(path_to_xform):
     else:
         if returncode > 0:  # Error invalid
             raise ODKValidateError(
-                b"ODK Validate Errors:\n"
-                + ErrorCleaner.odk_validate(stderr).encode("utf-8")
+                "ODK Validate Errors:\n" + ErrorCleaner.odk_validate(stderr)
             )
         elif returncode == 0:
             if stderr:


### PR DESCRIPTION
The use of a byte string in raising `ODKValidateError` has strange downstream behavior. For example, if you use jsonify to output that string, you get `b` added to your output like so:
<img width="582" alt="Screen Shot 2019-11-15 at 7 17 41 PM" src="https://user-images.githubusercontent.com/32369/68987386-50ec0280-07de-11ea-972e-9ca35ee1a18c.png">

Instead, I use the futures library, which is designed for Python 2/3 code to do the right thing with the string. 

While I was poking around for other Python 2/3 string problems, I saw the use of `sys.version_info.major` and that seemed unnecessary so I removed it.