### PR TITLE
Identify first argument of pulldata by splitting on comma

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -315,15 +315,21 @@ class Survey(Section):
                 instance=node("instance", id=file_id, src=uri),
             )
 
-        formulas = get_pulldata_functions(element)
-        if len(formulas) > 0:
-            formula_instances = []
-            for formula in formulas:
-                pieces = formula.split('"') if '"' in formula else formula.split("'")
-                if len(pieces) > 1 and pieces[1]:
-                    file_id = pieces[1]
-                    formula_instances.append(get_instance_info(element, file_id))
-            return formula_instances
+        pulldata_calls = get_pulldata_functions(element)
+        if len(pulldata_calls) > 0:
+            pulldata_instances = []
+            for pulldata_call in pulldata_calls:
+                pulldata_arguments = re.sub("pulldata\s*\(\s*", "", pulldata_call)
+                parsed_pulldata_arguments = pulldata_arguments.split(",")
+                if len(parsed_pulldata_arguments) > 0:
+                    first_argument = parsed_pulldata_arguments[0]
+                    first_argument = (
+                        first_argument.replace("'", "").replace('"', "").strip()
+                    )
+                    pulldata_instances.append(
+                        get_instance_info(element, first_argument)
+                    )
+            return pulldata_instances
         return None
 
     @staticmethod

--- a/pyxform/tests_v1/test_support_external_instances.py
+++ b/pyxform/tests_v1/test_support_external_instances.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """
 Test external instance syntax
+
+See also test_xmldata
 """
 from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 

--- a/pyxform/tests_v1/test_xmldata.py
+++ b/pyxform/tests_v1/test_xmldata.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Test xml-external syntax.
+Test xml-external syntax and instances generated from pulldata calls.
+
+See also test_support_external_instances
 """
 from pyxform.errors import PyXFormError
 from pyxform.tests_v1.pyxform_test_case import PyxformTestCase, PyxformTestError
@@ -414,3 +416,24 @@ class ExternalInstanceTests(PyxformTestCase):
         xml = survey._to_pretty_xml()
         self.assertEqual(1, xml.count(node1))
         self.assertEqual(1, xml.count(node2))
+
+    def test_mixed_quotes_and_functions_in_pulldata(self):
+        # re: https://github.com/XLSForm/pyxform/issues/398
+        self.assertPyxformXform(
+            name="pulldata",
+            md="""
+                | survey |             |            |       |                                                            |
+                |        | type        | name       | label | calculation                                                |
+                |        | text        | rcid       | ID    |                                                            |
+                |        | calculate   | calculate1 |       | pulldata("instance1","first","rcid",concat("Foo",${rcid})) |
+                |        | calculate   | calculate2 |       | pulldata('instance2',"last",'rcid',concat('RC',${rcid}))   |
+                |        | calculate   | calculate3 |       | pulldata('instance3','envelope','rcid',"Bar")              |
+                |        | calculate   | calculate4 |       | pulldata('instance4'          ,'envelope','rcid',"Bar")    |
+                """,  # noqa
+            xml__contains=[
+                '<instance id="instance1" src="jr://file-csv/instance1.csv"/>',
+                '<instance id="instance2" src="jr://file-csv/instance2.csv"/>',
+                '<instance id="instance3" src="jr://file-csv/instance3.csv"/>',
+                '<instance id="instance4" src="jr://file-csv/instance4.csv"/>',
+            ],
+        )


### PR DESCRIPTION
Closes #398

In the issue, I mentioned using `csv` to handle getting the arguments from the `pulldata` call but I realized it's not all that helpful because it only deals with double quotes (and not single quotes) and because the first argument can't be dynamic anyway. That is, the `pulldata` implementation as it exists in Collect does allow for the first argument to be dynamic so you could have it be the result of e.g. a `concat` function call to dynamically use different files with the same prefix depending on some selection. But that won't work when authoring XLSForms now that a secondary instance declaration is added because the value of that first argument is used as the instance ID and needs to be a valid XML identifier. All that to say that we can just split on commas and strip quotes around the first argument which is what I've done here.