### PR TITLE
Remove unsupported or old Python CI builds, add new ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,7 @@ jobs:
       - run:
           name: Test code is well formatted
           command: |
-            if ! type /home/circleci/.local/bin/black > /dev/null; then
-                echo "Black is not supported in this python version :("
-            else
-                output="$(/home/circleci/.local/bin/black pyxform --check  2>&1 >/dev/null)"
-                if [[ $output == *"would be reformatted"* ]]; then
-                    echo 'The source code could use a bit more black.'
-                    exit 1
-                fi
-            fi
+            /home/circleci/.local/bin/black pyxform --check || exit;
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  py-3.7: &build-template
+  py-3.8: &build-template
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     working_directory: ~/work
     steps:
       - checkout
@@ -27,7 +27,7 @@ jobs:
             if ! type /home/circleci/.local/bin/black > /dev/null; then
                 echo "Black is not supported in this python version :("
             else
-                output="$(/home/circleci/.local/bin/black --target-version=py27 pyxform --check  2>&1 >/dev/null)"
+                output="$(/home/circleci/.local/bin/black pyxform --check  2>&1 >/dev/null)"
                 if [[ $output == *"would be reformatted"* ]]; then
                     echo 'The source code could use a bit more black.'
                     exit 1
@@ -56,23 +56,13 @@ jobs:
           paths:
             - /home/circleci/.local/lib
             - /home/circleci/.local/bin
-  py-3.6:
+  py-3.7:
     <<: *build-template
     docker:
-      - image: circleci/python:3.6
-  py-3.5:
-    <<: *build-template
-    docker:
-      - image: circleci/python:3.5
-  py-2.7:
-    <<: *build-template
-    docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.7
 workflows:
   version: 2
   build:
     jobs:
+      - py-3.8
       - py-3.7
-      - py-3.6
-      - py-3.5
-      - py-2.7

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ You can run tests with::
 
 Before committing, make sure to format your code using `black`::
 
-    black --target-version=py27 pyxform
+    black pyxform
 
 Documentation
 =============

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,11 @@ environment:
 
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
-    # The list here is complete (excluding Python 2.6, which
-    # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python35-x64"
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
   - ps: $env:Path = "$env:PYTHON;$env:PYTHON\Scripts;$env:Path"

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -8,7 +8,7 @@ if [ -n "$FILES" ]; then
 fi
 
 if [ -n "$FILES" ]; then
-    if black --target-version=py27 $FILES; then
+    if black $FILES; then
         touch .commit
     fi
 fi

--- a/requirements.pip
+++ b/requirements.pip
@@ -6,29 +6,29 @@
 #
 appdirs==1.4.3            # via black
 argparse==1.4.0           # via unittest2
-astroid==2.2.5; python_version > "3.2"            # via pylint
+astroid==1.6.6            # via pylint
 attrs==19.1.0             # via black
-black==19.3b0; python_version > "3.5"
+black==19.10b0
 click==7.0                # via black, pip-tools
 entrypoints==0.3          # via flake8
 flake8==3.7.7
 formencode==1.3.1
-functools32==3.2.3.post2; python_version < "3.2"
 isort==4.3.20
 lazy-object-proxy==1.4.1  # via astroid
 linecache2==1.0.0         # via traceback2
 mccabe==0.6.1             # via flake8, pylint
 mock==3.0.5
 nose==1.3.7
+pathspec==0.6.0           # via black
 pip-tools==3.7.0
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
-pylint==2.3.1; python_version > "3.2"
-pylint==1.9.4; python_version < "3.3"
-six==1.12.0               # via astroid, mock, pip-tools, unittest2
+pylint==1.9.4
+regex==2019.12.19         # via black
+six==1.12.0               # via astroid, mock, pip-tools, pylint, unittest2
 toml==0.10.0              # via black
 traceback2==1.4.0         # via unittest2
-typed-ast==1.3.5; python_version > "3.2"          # via astroid
+typed-ast==1.4.0          # via black
 unicodecsv==0.14.1
 unittest2==1.1.0
 wrapt==1.11.1             # via astroid


### PR DESCRIPTION
Following the table at https://en.wikipedia.org/wiki/History_of_Python#Table_of_versions, I made these changes: 
* Python 2.7 is dropped because it will receive no security fixes starting Jan 2020 so we should not test on or target formatting to it.
* Python 3.5 is dropped because you can't run black in it. Also it reached end of full support in August 2017 and will receive no security fixes starting Sept 2020. Also, it makes builds slower to have so many Pythons.
* Python 3.6 is dropped because it will reach end of full support at the end of this year. Also, it makes builds slower to have so many Pythons.
* Python 3.8 has been released so we should test on it

Then I 
* Simplified formatting check now that we've dropped Python 2.7 and 3.5. Now if it returns an error code, we list the files so folks can see what files CI thinks they should run black on and exit.

Also
* The version of typed-ast we had didn't support Python 3.8, so went ahead and ran `pip-compile --output-file=requirements.pip requirements.in` to get the most correct requirements.


Fixes https://github.com/XLSForm/pyxform/issues/407