### PR TITLE
Fix spelling

### DIFF
--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -15,7 +15,7 @@ def generate_new_dict():
         "/home/nathan/aptana-workspace/pyxform" "/pyxform/question_types/all.xls"
     )
     json_dict = QuestionTypesReader(path_to_question_types).to_json_dict()
-    print_pyobj_to_json(json_dict, "new_quesiton_type_dict.json")
+    print_pyobj_to_json(json_dict, "new_question_type_dict.json")
 
 
 QUESTION_TYPE_DICT = {

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -11,7 +11,7 @@ def generate_new_dict():
     type dictionary from all.xls again.
     It shouldn't be called as part of any application.
     """
-    path_to_question_types = ( "/pyxform/question_types/all.xls" )
+    path_to_question_types = "/pyxform/question_types/all.xls"
     json_dict = QuestionTypesReader(path_to_question_types).to_json_dict()
     print_pyobj_to_json(json_dict, "new_question_type_dict.json")
 

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -11,9 +11,7 @@ def generate_new_dict():
     type dictionary from all.xls again.
     It shouldn't be called as part of any application.
     """
-    path_to_question_types = (
-        "/home/nathan/aptana-workspace/pyxform" "/pyxform/question_types/all.xls"
-    )
+    path_to_question_types = ( "/pyxform/question_types/all.xls" )
     json_dict = QuestionTypesReader(path_to_question_types).to_json_dict()
     print_pyobj_to_json(json_dict, "new_question_type_dict.json")
 

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -248,7 +248,7 @@ class DefaultToSurveyTest(TestCase):
     def test_default_sheet_name_to_survey(self):
         xls_path = utils.path_to_text_fixture("survey_no_name.xlsx")
         dict_value = xls_to_dict(xls_path)
-        print (json.dumps(dict_value))
+        print(json.dumps(dict_value))
         self.assertTrue("survey" in json.dumps(dict_value))
         self.assertTrue("state" in json.dumps(dict_value))
         self.assertTrue("The State" in json.dumps(dict_value))


### PR DESCRIPTION
Fix spelling and removed unused path. I confirmed that `new_quesiton_type_dict` and `nathan` and `aptana` were not used else where in the code base.