### PR TITLE
Ensure stable ordering of attributes for tests

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -716,6 +716,21 @@ class Survey(Section):
     def _to_ugly_xml(self):
         return '<?xml version="1.0"?>' + self.xml().toxml()
 
+    def _to_testable_xml(self):
+        """Preserves attribute ordering across all Python versions.
+
+        See python_test_case.reorder_attributes for related code.
+        """
+        tree = ETree.fromstring(self.xml().toxml())
+        for el in tree.iter():
+            attrib = el.attrib
+            if len(attrib) > 1:
+                # adjust attribute order, e.g. by sorting
+                attribs = sorted(attrib.items())
+                attrib.clear()
+                attrib.update(attribs)
+        return ETree.tostring(tree, encoding="utf-8").decode("utf-8")
+
     def _to_pretty_xml(self):
         """
         I want the to_xml method to by default validate the xml we are

--- a/pyxform/tests/fixtures/strings.ini
+++ b/pyxform/tests/fixtures/strings.ini
@@ -12,7 +12,7 @@ test_simple_integer_question_type_multilingual_binding = <bind nodeset="/test/in
 test_simple_date_question_type_multilingual_control = <input ref="/test/date_q"><label ref="jr:itext('/test/date_q:label')"/></input>
 test_simple_date_question_type_multilingual_binding = <bind nodeset="/test/date_q" type="date"/>
 test_simple_phone_number_question_type_multilingual_control = <input ref="/test/phone_number_q"><label ref="jr:itext('/test/phone_number_q:label')"/><hint>Enter numbers only.</hint></input>
-test_simple_phone_number_question_type_multilingual_binding = <bind constraint="regex(., '^\d*$')" nodeset="/test/phone_number_q" type="string"/>
+test_simple_phone_number_question_type_multilingual_binding = constraint="regex(., '^\d*$')"
 test_simple_select_all_question_multilingual_control = <select ref="/test/select_all_q"><label ref="jr:itext('/test/select_all_q:label')"/><item><label ref="jr:itext('/test/select_all_q/f:label')"/><value>f</value></item><item><label ref="jr:itext('/test/select_all_q/g:label')"/><value>g</value></item><item><label ref="jr:itext('/test/select_all_q/h:label')"/><value>h</value></item></select>
 test_simple_select_all_question_multilingual_binding = <bind nodeset="/test/select_all_q" type="select"/>
 test_simple_decimal_question_multilingual_control = <input ref="/test/decimal_q"><label ref="jr:itext('/test/decimal_q:label')"/></input>

--- a/pyxform/tests/j2x_question_tests.py
+++ b/pyxform/tests/j2x_question_tests.py
@@ -163,7 +163,9 @@ class Json2XformQuestionValidationTests(TestCase):
         self.assertEqual(ctw(q.xml_control()), expected_phone_number_control_xml)
 
         if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_binding()), expected_phone_number_binding_xml)
+            self.assertEqual(
+                expected_phone_number_binding_xml in ctw(q.xml_binding()), True
+            )
 
     def test_simple_select_all_question_multilingual(self):
         """

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -343,6 +343,8 @@ def reorder_attributes(root):
 
         See bottom of https://docs.python.org/3/library/xml.etree.elementtree.html#element-objects and 
         https://github.com/python/cpython/commit/a3697db0102b9b6747fe36009e42f9b08f0c1ea8 for more information.
+
+        See survey._to_testable_xml for related code.
         """
     for el in root.iter():
         attrib = el.attrib

--- a/pyxform/tests_v1/test_dynamic_default.py
+++ b/pyxform/tests_v1/test_dynamic_default.py
@@ -40,7 +40,7 @@ class DynamicDefaultTests(PyxformTestCase):
             kwargs={"id_string": "id", "name": "dynamic", "title": "some-title"},
             autoname=False,
         )
-        survey_xml = survey._to_pretty_xml()
+        survey_xml = survey._to_testable_xml()
 
         self.assertContains(survey_xml, "<first_name/>", 1)
         self.assertContains(survey_xml, "<last_name>not_func$</last_name>", 1)
@@ -92,7 +92,7 @@ class DynamicDefaultTests(PyxformTestCase):
             kwargs={"id_string": "id", "name": "dynamic", "title": "some-title"},
             autoname=False,
         )
-        survey_xml = survey._to_pretty_xml()
+        survey_xml = survey._to_testable_xml()
 
         self.assertContains(survey_xml, "<feeling>not_func$</feeling>", 2)
         self.assertContains(survey_xml, "<age/>", 2)

--- a/pyxform/tests_v1/test_whitespace.py
+++ b/pyxform/tests_v1/test_whitespace.py
@@ -29,7 +29,7 @@ class WhitespaceTest(PyxformTestCase):
           """
 
         survey = self.md_to_pyxform_survey(md_raw=md)
-        expected = """<submission action="https://odk.ona.io/random_person/submission" base64RsaPublicKey="MIIB" method="post"/>"""
-        xml = survey._to_pretty_xml()
+        expected = """<submission action="https://odk.ona.io/random_person/submission" base64RsaPublicKey="MIIB" method="post" />"""
+        xml = survey._to_testable_xml()
         self.assertEqual(1, xml.count(expected))
         self.assertPyxformXform(md=md, xml__contains=expected, run_odk_validate=True)


### PR DESCRIPTION
In 5c7c5a0f14cab112cd6aa267d94fd67897503678, we use the same code from https://github.com/XLSForm/pyxform/pull/412 to produce what I call "testable" XML (XML with a stable ordering). I couldn't find an easy way to de-duplicate the code without invasive changes. A more experienced Pythonista might know better.

9bec7ffe00c7984d67cca8e73bf104cdb034f72e, I narrowed the test to not depend on attribute order.