### PR TITLE
Sort attributes when building xml.dom.minidom.Element objects

### DIFF
--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -101,9 +101,11 @@ def node(*args, **kwargs):
     unicode_args = [u for u in args if type(u) == unicode]
     assert len(unicode_args) <= 1
     parsed_string = False
-    # kwargs is an xml attribute dictionary,
-    # here we convert it to a xml.dom.minidom.Element
-    for k, v in iter(kwargs.items()):
+
+    # Convert the kwargs xml attribute dictionary to a xml.dom.minidom.Element. Sort the
+    # attributes to guarantee a consistent order across Python versions.
+    # See pyxform_test_case.reorder_attributes for details.
+    for k, v in iter(sorted(kwargs.items())):
         if k in blocked_attributes:
             continue
         if k == "toParseString":


### PR DESCRIPTION
Fixes failing tests on Python 3.8.1.

I have run all tests on Python 3.7.2 and Python 3.8.1.

#412 forced an alphanumeric ordering of attributes when generating XML from test cases. When attributes have namespaces, attribute order is different between these two cases:
- XML generated from test cases when using `assertPyxformXform`
- XML that is output when running `pyxform` in other contexts 

This has been filed at https://github.com/XLSForm/pyxform/issues/414. It means that #412 fixed the tests that use `assertPyxformXform` but not the tests that actually generate real XML output.

This PR sorts attributes when building the true XML output.