### PR TITLE
Remove support for generated-by reverting #394

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -28,7 +28,6 @@ COMPACT_DELIMITER = "delimiter"
 COMPACT_TAG = "compact_tag"
 
 VERSION = "version"
-GENERATED_BY = "generated_by"
 PUBLIC_KEY = "public_key"
 SUBMISSION_URL = "submission_url"
 AUTO_SEND = "auto_send"

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -134,7 +134,6 @@ class Survey(Section):
             "public_key": unicode,
             "instance_xmlns": unicode,
             "version": unicode,
-            "generated_by": unicode,
             "choices": dict,
             "style": unicode,
             "attribute": dict,
@@ -526,9 +525,6 @@ class Survey(Section):
 
         if self.version:
             result.setAttribute("version", self.version)
-
-        if self.generated_by:
-            result.setAttribute("odk:generated-by", self.generated_by)
 
         if self.prefix:
             result.setAttribute("odk:prefix", self.prefix)

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -159,10 +159,8 @@ class BuilderTests(TestCase):
                 },
             ],
         }
-        actual_dict = survey.to_json_dict()
-        actual_dict.pop("generated_by", None)
         self.maxDiff = None
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEqual(survey.to_json_dict(), expected_dict)
 
     def test_select_one_question_with_identical_choice_name(self):
         """
@@ -201,10 +199,8 @@ class BuilderTests(TestCase):
                 },
             ],
         }
-        actual_dict = survey.to_json_dict()
-        actual_dict.pop("generated_by", None)
         self.maxDiff = None
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEqual(survey.to_json_dict(), expected_dict)
 
     def test_loop(self):
         survey = utils.create_survey_from_fixture("loop", filetype=FIXTURE_FILETYPE)
@@ -316,10 +312,8 @@ class BuilderTests(TestCase):
                 },
             ],
         }
-        actual_dict = survey.to_json_dict()
-        actual_dict.pop("generated_by", None)
         self.maxDiff = None
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEqual(survey.to_json_dict(), expected_dict)
 
     def test_sms_columns(self):
         survey = utils.create_survey_from_fixture("sms_info", filetype=FIXTURE_FILETYPE)
@@ -455,9 +449,7 @@ class BuilderTests(TestCase):
             "title": "SMS Example",
             "type": "survey",
         }
-        actual_dict = survey.to_json_dict()
-        actual_dict.pop("generated_by", None)
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEqual(survey.to_json_dict(), expected_dict)
 
     def test_style_column(self):
         survey = utils.create_survey_from_fixture(
@@ -496,9 +488,7 @@ class BuilderTests(TestCase):
             "title": "My Survey",
             "type": "survey",
         }
-        actual_dict = survey.to_json_dict()
-        actual_dict.pop("generated_by", None)
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEqual(survey.to_json_dict(), expected_dict)
 
     STRIP_NS_FROM_TAG_RE = re.compile(r"\{.+\}")
 

--- a/pyxform/tests/group_test.py
+++ b/pyxform/tests/group_test.py
@@ -57,7 +57,6 @@ class GroupTests(TestCase):
                 },
             ],
         }
-        x_results.pop("generated_by", None)
         self.maxDiff = None
         self.assertEqual(x_results, expected_dict)
 

--- a/pyxform/tests/loop_tests.py
+++ b/pyxform/tests/loop_tests.py
@@ -89,6 +89,4 @@ class LoopTests(TestCase):
                 },
             ],
         }
-        actual_dict = survey.to_json_dict()
-        actual_dict.pop("generated_by", None)
-        self.assertEquals(actual_dict, expected_dict)
+        self.assertEquals(survey.to_json_dict(), expected_dict)

--- a/pyxform/tests/settings_test.py
+++ b/pyxform/tests/settings_test.py
@@ -55,9 +55,7 @@ class SettingsTests(TestCase):
                 },
             ],
         }
-        actual_dict = survey_reader.to_json_dict()
-        actual_dict.pop("generated_by", None)
-        self.assertEqual(actual_dict, expected_dict)
+        self.assertEqual(survey_reader.to_json_dict(), expected_dict)
 
     def test_settings(self):
         survey = create_survey_from_path(self.path)

--- a/pyxform/tests/tests_by_file.py
+++ b/pyxform/tests/tests_by_file.py
@@ -37,7 +37,6 @@ class MainTest(TestCase):
                 path_to_excel_file, default_name=root_filename
             )
             survey = pyxform.create_survey_element_from_dict(json_survey)
-            survey.generated_by = ""
             survey.print_xform_to_file(path_to_output_xform)
 
             # Compare with the expected output:

--- a/pyxform/tests/utils.py
+++ b/pyxform/tests/utils.py
@@ -64,10 +64,6 @@ class XFormTestCase(TestCase):
         xform1 = ETree.fromstring(xform1.encode("utf-8"))
         xform2 = ETree.fromstring(xform2.encode("utf-8"))
 
-        # Remove the odk:generated-by attribute from the primary instance child
-        self.remove_generated_by_attribute(xform1)
-        self.remove_generated_by_attribute(xform2)
-
         # Sort tags under <model> section in each form
         self.sort_model(xform1)
         self.sort_model(xform2)
@@ -96,15 +92,6 @@ class XFormTestCase(TestCase):
 
             key = elem_get_tag
         elems[:] = sorted(elems, key=key)
-
-    def remove_generated_by_attribute(self, xform):
-        xforms_ns = "{http://www.w3.org/2002/xforms}"
-        odk_ns = "{http://www.opendatakit.org/xforms}"
-        primary_instance = xform.find(".//" + xforms_ns + "instance")
-
-        # Remove the generated-by attribute
-        if primary_instance is not None:
-            primary_instance[0].attrib.pop(odk_ns + "generated-by", None)
 
     def sort_model(self, xform):
         ns = "{http://www.w3.org/2002/xforms}"

--- a/pyxform/tests/xls2json_tests.py
+++ b/pyxform/tests/xls2json_tests.py
@@ -43,7 +43,6 @@ class BasicXls2JsonApiTests(TestCase):
             with codecs.open(output_path, "rb", encoding="utf-8") as actual_file:
                 expected_json = json.load(expected_file)
                 actual_json = json.load(actual_file)
-                actual_json.pop("generated_by", None)
                 self.assertEqual(expected_json, actual_json)
 
     def test_hidden(self):
@@ -141,7 +140,6 @@ class BasicXls2JsonApiTests(TestCase):
             with codecs.open(output_path, "rb", encoding="utf-8") as actual_file:
                 expected_json = json.load(expected_file)
                 actual_json = json.load(actual_file)
-                actual_json.pop("generated_by", None)
                 self.assertEqual(expected_json, actual_json)
 
     def test_choice_filter_choice_fields(self):

--- a/pyxform/tests_v1/pyxform_test_case.py
+++ b/pyxform/tests_v1/pyxform_test_case.py
@@ -174,10 +174,6 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
             else:
                 survey = kwargs.get("survey")
 
-            # Remove the generated-by attribute
-            if survey:
-                survey.generated_by = ""
-
             xml = survey._to_pretty_xml()
             root = ETree.fromstring(xml.encode("utf-8"))
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -9,7 +9,6 @@ import json
 import os
 import re
 import sys
-import subprocess
 from collections import Counter
 
 from pyxform import aliases, constants
@@ -407,7 +406,6 @@ def workbook_to_json(
         # problems for formhub.
         # constants.VERSION : datetime.datetime.now().strftime("%Y%m%d%H"),
         constants.CHILDREN: [],
-        constants.GENERATED_BY: ("pyxform " + get_git_describe_tags()).strip(),
     }
     # Here the default settings are overridden by those in the settings sheet
     json_dict.update(settings)
@@ -1430,15 +1428,6 @@ def get_parameters(raw_parameters, allowed_parameters):
             )
 
     return params
-
-
-def get_git_describe_tags():
-    try:
-        return subprocess.check_output(
-            ["git", "describe", "--tags", "HEAD"], universal_newlines=True
-        ).strip()
-    except:
-        return ""
 
 
 class SpreadsheetReader(object):


### PR DESCRIPTION
There is an ongoing discussion among other maintainers (@MartijnR, @lognaturel, @tiritea) about the placement of `generated-by` in the DOM as well as how that feature will work with the user-agent string we are thinking about adding. 

Although `generated-by` is in the spec, I thought it wise to pull the implementation in pyxform until we are absolutely certain we want to proceed. If we decide we want to proceed, it will be easy to release this in a point release.

Reverts #394