### PR TITLE
Put setvalue action for repeats in the body

### DIFF
--- a/pyxform/section.py
+++ b/pyxform/section.py
@@ -117,6 +117,11 @@ class RepeatingSection(Section):
         for n in Section.xml_control(self):
             repeat_node.appendChild(n)
 
+        for e in self.children:
+            dynamic_default = e.get_setvalue_node_for_dynamic_default()
+            if dynamic_default:
+                repeat_node.appendChild(dynamic_default)
+
         label = self.xml_label()
         if label:
             return node("group", self.xml_label(), repeat_node, ref=self.get_xpath())

--- a/pyxform/section.py
+++ b/pyxform/section.py
@@ -117,15 +117,31 @@ class RepeatingSection(Section):
         for n in Section.xml_control(self):
             repeat_node.appendChild(n)
 
-        for e in self.children:
-            dynamic_default = e.get_setvalue_node_for_dynamic_default()
-            if dynamic_default:
-                repeat_node.appendChild(dynamic_default)
+        setvalue_nodes = self._get_setvalue_nodes_for_dynamic_defaults()
+
+        for setvalue_node in setvalue_nodes:
+            repeat_node.appendChild(setvalue_node)
 
         label = self.xml_label()
         if label:
             return node("group", self.xml_label(), repeat_node, ref=self.get_xpath())
         return node("group", repeat_node, ref=self.get_xpath(), **self.control)
+
+    # Get setvalue nodes for all descendants of this repeat that have dynamic defaults and aren't nested in other repeats.
+    def _get_setvalue_nodes_for_dynamic_defaults(self):
+        setvalue_nodes = []
+        self._dynamic_defaults_helper(self, setvalue_nodes)
+        return setvalue_nodes
+
+    def _dynamic_defaults_helper(self, current, nodes):
+        for e in current.children:
+            if e.type != "repeat":  # let nested repeats handle their own defaults
+                dynamic_default = e.get_setvalue_node_for_dynamic_default(
+                    in_repeat=True
+                )
+                if dynamic_default:
+                    nodes.append(dynamic_default)
+                self._dynamic_defaults_helper(e, nodes)
 
     # I'm anal about matching function signatures when overriding a function,
     # but there's no reason for kwargs to be an argument

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -342,28 +342,23 @@ class SurveyElement(dict):
             type(self.media) is dict and len(self.media) > 0
         )
 
-    def xml_dynamic_default(self):
+    def get_setvalue_node_for_dynamic_default(self):
         if not self.default or not default_is_dynamic(self.default, self.type):
-            return
+            return None
 
-        default_with_xpaths = self.get_root().insert_xpaths(self.default, self)
-        if self.parent.__class__.__name__ in ["Survey", "GroupedSection"]:
-            default_handler = {"event": "odk-instance-first-load"}
-            return node(
-                "setvalue",
-                ref=self.get_xpath(),
-                value=default_with_xpaths,
-                **default_handler
-            )
+        default_with_xpath_paths = self.get_root().insert_xpaths(self.default, self)
+
+        triggering_events = "odk-instance-first-load"
 
         if self.parent.__class__.__name__ == "RepeatingSection":
-            default_handler = {"event": "odk-instance-first-load odk-new-repeat"}
-            return node(
-                "setvalue",
-                ref=self.get_xpath(),
-                value=default_with_xpaths,
-                **default_handler
-            )
+            triggering_events = triggering_events + " odk-new-repeat"
+
+        return node(
+            "setvalue",
+            ref=self.get_xpath(),
+            value=default_with_xpath_paths,
+            event=triggering_events,
+        )
 
     # XML generating functions, these probably need to be moved around.
     def xml_label(self):
@@ -442,9 +437,12 @@ class SurveyElement(dict):
             xml_binding = e.xml_binding()
             if xml_binding is not None:
                 result.append(xml_binding)
-            dynamic_default = e.xml_dynamic_default()
-            if dynamic_default:
-                result.append(dynamic_default)
+
+            # dynamic defaults for repeats go in the body. All other dynamic defaults (setvalue actions) go in the model
+            if e.parent.__class__.__name__ != "RepeatingSection":
+                dynamic_default = e.get_setvalue_node_for_dynamic_default()
+                if dynamic_default:
+                    result.append(dynamic_default)
         return result
 
     def xml_control(self):

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -342,15 +342,14 @@ class SurveyElement(dict):
             type(self.media) is dict and len(self.media) > 0
         )
 
-    def get_setvalue_node_for_dynamic_default(self):
+    def get_setvalue_node_for_dynamic_default(self, in_repeat=False):
         if not self.default or not default_is_dynamic(self.default, self.type):
             return None
 
         default_with_xpath_paths = self.get_root().insert_xpaths(self.default, self)
 
         triggering_events = "odk-instance-first-load"
-
-        if self.parent.__class__.__name__ == "RepeatingSection":
+        if in_repeat:
             triggering_events = triggering_events + " odk-new-repeat"
 
         return node(
@@ -439,7 +438,16 @@ class SurveyElement(dict):
                 result.append(xml_binding)
 
             # dynamic defaults for repeats go in the body. All other dynamic defaults (setvalue actions) go in the model
-            if e.parent.__class__.__name__ != "RepeatingSection":
+            if (
+                len(
+                    [
+                        ancestor
+                        for ancestor in e.get_lineage()
+                        if ancestor.type == "repeat"
+                    ]
+                )
+                == 0
+            ):
                 dynamic_default = e.get_setvalue_node_for_dynamic_default()
                 if dynamic_default:
                     result.append(dynamic_default)

--- a/pyxform/tests_v1/test_dynamic_default.py
+++ b/pyxform/tests_v1/test_dynamic_default.py
@@ -148,6 +148,28 @@ class DynamicDefaultTests(PyxformTestCase):
             ],
         )
 
+    def test_dynamic_default_in_group_nested_in_repeat(self):
+        self.assertPyxformXform(
+            name="dynamic",
+            md="""
+            | survey |              |          |       |                   |
+            |        | type         | name     | label | default           |
+            |        | begin repeat | repeat   |       |                   |
+            |        | begin group  | group    |       |                   |
+            |        | integer      | foo      | Foo   |                   |
+            |        | integer      | bar      | Bar   | ${foo}            |
+            |        | end group    | group    |       |                   |
+            |        | end repeat   | repeat   |       |                   |
+            """,
+            debug=True,
+            xml__contains=[
+                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/group/bar" value=" ../foo "/>'
+            ],
+            model__excludes=[
+                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/group/bar" value=" ../foo "/>'
+            ],
+        )
+
     def test_handling_arithmetic_expression(self):
         """
         Should use set-value for dynamic default form

--- a/pyxform/tests_v1/test_dynamic_default.py
+++ b/pyxform/tests_v1/test_dynamic_default.py
@@ -69,10 +69,10 @@ class DynamicDefaultTests(PyxformTestCase):
             md=md,
             name="dynamic",
             id_string="id",
+            debug=True,
             model__contains=["<age/>", "<feeling>not_func$</feeling>"],
-            xml__contains=[
-                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/household/age" value="some_rando_func()"/>'
-            ],
+            model__excludes=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/household/age" value="some_rando_func()"/>'],
+            xml__contains=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/household/age" value="some_rando_func()"/>']
         )
 
         survey = self.md_to_pyxform_survey(
@@ -105,7 +105,7 @@ class DynamicDefaultTests(PyxformTestCase):
             |        | integer    | bar      | Bar   | ${foo}            |
             |        | end group  | group    |       |                   |
             """,
-            xml__contains=[
+            model__contains=[
                 '<setvalue event="odk-instance-first-load" ref="/dynamic/group/bar" value=" /dynamic/foo "/>'
             ],
         )
@@ -121,7 +121,7 @@ class DynamicDefaultTests(PyxformTestCase):
             |        | integer      | bar      | Bar   | ${foo}            |
             |        | end group    | group    |       |                   |
             """,
-            xml__contains=[
+            model__contains=[
                 '<setvalue event="odk-instance-first-load" ref="/dynamic/group/bar" value=" /dynamic/group/foo "/>'
             ],
         )
@@ -137,9 +137,8 @@ class DynamicDefaultTests(PyxformTestCase):
             |        | integer      | bar      | Bar   | ${foo}            |
             |        | end repeat   | repeat   |       |                   |
             """,
-            xml__contains=[
-                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/bar" value=" ../foo "/>'
-            ],
+            xml__contains=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/bar" value=" ../foo "/>'],
+            model__excludes=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/bar" value=" ../foo "/>']
         )
 
     def test_handling_arithmetic_expression(self):

--- a/pyxform/tests_v1/test_dynamic_default.py
+++ b/pyxform/tests_v1/test_dynamic_default.py
@@ -69,10 +69,13 @@ class DynamicDefaultTests(PyxformTestCase):
             md=md,
             name="dynamic",
             id_string="id",
-            debug=True,
             model__contains=["<age/>", "<feeling>not_func$</feeling>"],
-            model__excludes=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/household/age" value="some_rando_func()"/>'],
-            xml__contains=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/household/age" value="some_rando_func()"/>']
+            model__excludes=[
+                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/household/age" value="some_rando_func()"/>'
+            ],
+            xml__contains=[
+                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/household/age" value="some_rando_func()"/>'
+            ],
         )
 
         survey = self.md_to_pyxform_survey(
@@ -137,8 +140,12 @@ class DynamicDefaultTests(PyxformTestCase):
             |        | integer      | bar      | Bar   | ${foo}            |
             |        | end repeat   | repeat   |       |                   |
             """,
-            xml__contains=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/bar" value=" ../foo "/>'],
-            model__excludes=['<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/bar" value=" ../foo "/>']
+            xml__contains=[
+                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/bar" value=" ../foo "/>'
+            ],
+            model__excludes=[
+                '<setvalue event="odk-instance-first-load odk-new-repeat" ref="/dynamic/repeat/bar" value=" ../foo "/>'
+            ],
         )
 
     def test_handling_arithmetic_expression(self):


### PR DESCRIPTION
Closes #427

This fixes the regression introduced by https://github.com/XLSForm/pyxform/commit/266ef19a4d4d2a3af069f3b51361ab0b0a927e47. The regression was because I didn't understand what the `in_binding` parameter did and because there was no test coverage for the desired behavior so I added tests and did some refactoring.

While doing this, I realized that dynamic defaults in groups or repeats nested within repeats weren't being handled as expected. https://github.com/XLSForm/pyxform/pull/431/commits/c24e42c072ca231af719e74084453029aaa90d63 adds test coverage and a fix for this.