### PR TITLE
small patch to support another java version string for 9-internal

### DIFF
--- a/pyxform/tests_v1/test_validators.py
+++ b/pyxform/tests_v1/test_validators.py
@@ -32,6 +32,10 @@ OPENJDK_13 = """openjdk version "13" 2019-09-17
 OpenJDK Runtime Environment (build 13+33)
 OpenJDK 64-Bit Server VM (build 13+33, mixed mode, sharing)
 """
+OPENJDK_9_INT = """openjdk version "9-internal"
+OpenJDK Runtime Environment (build 9-internal+0-2016-04-14-195246.buildd.src)
+OpenJDK 64-Bit Server VM (build 9-internal+0-2016-04-14-195246.buildd.src, mixed mode)
+"""
 
 
 class TestValidators(TestCase):
@@ -67,4 +71,8 @@ class TestValidators(TestCase):
 
         with patch(mock_func) as mock_popen:
             mock_popen.return_value = (0, False, "", OPENJDK_13)
+            check_java_version()
+
+        with patch(mock_func) as mock_popen:
+            mock_popen.return_value = (0, False, "", OPENJDK_9_INT)
             check_java_version()

--- a/pyxform/validators/odk_validate/__init__.py
+++ b/pyxform/validators/odk_validate/__init__.py
@@ -75,6 +75,8 @@ def check_java_version():
     java_version = re.findall(r"\"(.+?)\"", java_version_str)[0]
     if "." in java_version:
         major, minor, _ = java_version.split(".")
+    elif "-" in java_version:
+        major, minor = int(java_version.split("-")[0]), 0
     else:
         major, minor = int(java_version), 0
     if not ((int(major) == 1 and int(minor) >= 8) or int(major) >= 8):


### PR DESCRIPTION
when building an onadata docker image, it picked up a java version which fails the logic, preventing any form uploads.