### PR TITLE
Add Github templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- 
+
+Thank you for taking the time to report a pyxform issue!
+
+Before filling this form, visit https://github.com/XLSForm/pyxform/issues?q=is%3Aissue and search to see whether your issue was already reported or fixed. If you find a match, comment on it or add a +1 rather than posting a new issue. If you find a problem you know how to fix, submit a pull request. 🎉
+
+For all problem reports, please use the template below. Also include any relevant stack traces or error messages.
+
+-->
+
+#### Software and hardware versions 
+pyxform v1.x.x, Python v
+
+#### Problem description
+
+#### Steps to reproduce the problem
+
+#### Expected behavior
+
+#### Other information 
+Things you tried, stack traces, related issues, suggestions on how to fix it...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Closes #
+
+#### Why is this the best possible solution? Were any other approaches considered?
+
+#### What are the regression risks?
+
+#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
+
+#### Before submitting this PR, please make sure you have:
+- [ ] included test cases for core behavior and edge cases in `tests_v1`
+- [ ] run `nosetests` and verified all tests pass
+- [ ] run `black pyxform` to format code
+- [ ] verified that any code or assets from external sources are properly credited in comments


### PR DESCRIPTION
It's hard to review pull requests without context around how much thought a contributor put into their solution, how confident they are about it, what alternatives they considered, etc. The proposed PR template is used across ODK tools and generally serves us well. When I'm on the contribution side, I find it keeps me honest and prevents me from being lazy. When I'm on the reviewer side, it helps me know what to pay attention to and how to think about the solution.

I don't feel as strongly about adding the issue template because issues have generally been fine. I think it can be helpful to have some structure there but @MartijnR files most of the issues and has his own excellent structure. @MartijnR, if the issue template annoys you or you'd like to propose an alternative, I don't mind removing it from this PR.