### PR TITLE
Add test for typed calculate, update error message

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -38,8 +38,8 @@ class Question(SurveyElement):
             if nested_setvalues:
                 for setvalue in nested_setvalues:
                     msg = (
-                        "Trigger was added for ${%s} that refers to hidden question. This is not allowed."
-                        % setvalue[0]
+                        "The question ${%s} is not user-visible so it can't be used as a calculation trigger for question ${%s}."
+                        % (self.name, setvalue[0])
                     )
                     raise PyXFormError(msg)
             return None

--- a/pyxform/tests_v1/test_trigger.py
+++ b/pyxform/tests_v1/test_trigger.py
@@ -170,7 +170,22 @@ class TriggerSetvalueTests(PyxformTestCase):
             """,
             errored=True,
             error__contains=[
-                "Trigger was added for ${one-ts} that refers to hidden question. This is not allowed."
+                "The question ${one} is not user-visible so it can't be used as a calculation trigger for question ${one-ts}.",
+            ],
+        )
+
+    def test_typed_calculate_cant_be_trigger(self):
+        self.assertPyxformXform(
+            name="trigger-invalid-ref",
+            md="""
+                | survey |           |        |         |             |
+                |        | type      | name   | trigger | calculation |
+                |        | integer   | two    |         | 1 + 1       |
+                |        | integer   | two-ts | ${two}  | now()       | 
+                """,
+            errored=True,
+            error__contains=[
+                "The question ${two} is not user-visible so it can't be used as a calculation trigger for question ${two-ts}."
             ],
         )
 


### PR DESCRIPTION
Addresses the comments I left at https://github.com/XLSForm/pyxform/pull/457 for @gushil and @MartijnR to consider.

#### Why is this the best possible solution? Were any other approaches considered?
I considered not adding the test but it's easy to do and I can imagine a regression sneaking in.

#### What are the regression risks?
None. This changes a string and adds a test.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments