### PR TITLE
Fixed duplicate label translations for secondary itemsets and use itextID for selects with choices that have media specified

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -195,11 +195,16 @@ class MultipleChoiceQuestion(Question):
         if self["itemset"] and isinstance(self["itemset"], basestring):
             choice_filter = self.get("choice_filter")
             itemset, file_extension = os.path.splitext(self["itemset"])
+            has_media = False
+
+            if choices.get(itemset):
+                has_media = bool(choices.get(itemset)[0].get("media"))
+
             if file_extension in [".csv", ".xml"]:
                 itemset = itemset
                 itemset_label_ref = "label"
             else:
-                if not multi_language:
+                if not multi_language and not has_media:
                     itemset = self["itemset"]
                     itemset_label_ref = "label"
                 else:

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -227,11 +227,12 @@ class Survey(Section):
         """
         instance_element_list = []
         multi_language = isinstance(choice_list[0].get("label"), dict)
+        has_media = bool(choice_list[0].get("media"))
         for idx, choice in enumerate(choice_list):
             choice_element_list = []
             # Add a unique id to the choice element in case there is itext
             # it references
-            if multi_language:
+            if multi_language or has_media:
                 itext_id = "-".join(["static_instance", list_name, str(idx)])
                 choice_element_list.append(node("itextId", itext_id))
 

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -326,7 +326,9 @@ class SurveyElement(dict):
 
             if type(label_or_hint) is dict:
                 for lang, text in label_or_hint.items():
-                    yield {
+                    parent = self.get("parent")
+                    list_name = parent.get("list_name")
+                    translation = {
                         "display_element": display_element,  # Not used
                         "path": self._translation_path(display_element),
                         "element": self,  # Not used
@@ -334,6 +336,11 @@ class SurveyElement(dict):
                         "lang": lang,
                         "text": text,
                     }
+                    if list_name:
+                        name = self.get("name").replace(" ", "_")
+                        itextId = "-".join(["static_instance", list_name, name])
+                        translation.update({"path": itextId})
+                    yield translation
 
     def get_media_keys(self):
         """
@@ -371,9 +378,8 @@ class SurveyElement(dict):
             # then we need to make a label with an itext ref
             parent = self.get("parent")
             if parent and parent.get("list_name"):
-                itextId = "-".join(
-                    ["static_instance", parent.get("list_name"), self.get("name")]
-                )
+                name = self.get("name").replace(" ", "_")
+                itextId = "-".join(["static_instance", parent.get("list_name"), name])
                 ref = f"jr:itext('{itextId}')"
             else:
                 ref = "jr:itext('%s')" % self._translation_path("label")

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -369,7 +369,14 @@ class SurveyElement(dict):
         if self.needs_itext_ref():
             # If there is a dictionary label, or non-empty media dict,
             # then we need to make a label with an itext ref
-            ref = "jr:itext('%s')" % self._translation_path("label")
+            parent = self.get("parent")
+            if parent and parent.get("list_name"):
+                itextId = "-".join(
+                    ["static_instance", parent.get("list_name"), self.get("name")]
+                )
+                ref = f"jr:itext('{itextId}')"
+            else:
+                ref = "jr:itext('%s')" % self._translation_path("label")
             return node("label", ref=ref)
         else:
             survey = self.get_root()

--- a/pyxform/tests/test_expected_output/flat_xlsform_test.xml
+++ b/pyxform/tests/test_expected_output/flat_xlsform_test.xml
@@ -5,162 +5,323 @@
     <model odk:xforms-version="1.0.0">
       <submission action="https://example-odk-aggregate.appspot.com/submission" base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo93+Dgn3iDleC9XMTDH7ez1MOm/BOt287DgkldNkdvrtdC4oUegx3N8Say9tq47k2EOzeLYkezVnKdtserx+g/+R6pDIOS66bwbH+HoslDEUaZRZ47EipSGC1JhtOp/nQGQCsdVc5q/fPvw8d2rLLi+PQUZPBOiBxUo9h/CFc41hl/quUELmylSdL4O06OAP8OCEDA+tl0C2Ik+uCYMDJLD4m7YVbkV7jJXjtILj+GW+noLriFMRsgg7WKQe2j9fw5+v46nzhokOnDnHh+yGwQMfs/B0jfFAgXllLNjIPlXQf2UVzuxEax6wLCyqUXMIjCPSNfnzDRgFB4Qw3QbJCwIDAQAB" method="post"/>
       <itext>
-        <translation default="true()" lang="default">
-          <text id="/flat_xlsform_test/deviceid_test_output:label">
-            <value>-</value>
+        <translation lang="english">
+          <text id="/flat_xlsform_test/skip_to_end:label">
+            <value>Skip to end</value>
           </text>
-          <text id="/flat_xlsform_test/geopoint_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test/no:label">
-            <value>No</value>
-          </text>
-          <text id="/flat_xlsform_test/my_name:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/label-test/no:label">
-            <value>No</value>
-          </text>
-          <text id="/flat_xlsform_test/launch:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/FALSE:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/label-test/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/flat_xlsform_test/acknowledge_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/no:label">
-            <value>No</value>
-          </text>
-          <text id="/flat_xlsform_test/invalid_variable:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-2-test/a:label">
-            <value form="image">jr://images/a.jpg</value>
-          </text>
-          <text id="/flat_xlsform_test/a_decimal:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/address:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/table_list_question/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/flat_xlsform_test/list-nolabel-test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/end_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/required_text:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/today_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/table_list_question:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/image_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/simserial_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/flat_xlsform_test/skip_to_end/no:label">
-            <value>No</value>
-          </text>
-          <text id="/flat_xlsform_test/select_multiple_test/yes:label">
-            <value>Yes</value>
+          <text id="/flat_xlsform_test/email_note:label">
+            <value>You entered an email address</value>
           </text>
           <text id="/flat_xlsform_test/number_label:label">
-            <value>-</value>
+            <value>1</value>
           </text>
-          <text id="/flat_xlsform_test/skip_to_end/yes:label">
-            <value>Yes</value>
+          <text id="/flat_xlsform_test/my_name:label">
+            <value>Enter your name</value>
           </text>
-          <text id="/flat_xlsform_test/_1:label">
-            <value>-</value>
+          <text id="/flat_xlsform_test/invalid_variable:label">
+            <value>Your name is <output value=" /flat_xlsform_test/my_name "/>
+            </value>
           </text>
-          <text id="/flat_xlsform_test/compact-2-test/b:label">
-            <value form="image">jr://images/b.jpg</value>
+          <text id="/flat_xlsform_test/address:label">
+            <value>Enter an address</value>
           </text>
-          <text id="/flat_xlsform_test/barcode_test:label">
-            <value>-</value>
+          <text id="/flat_xlsform_test/text_image_audio_video_test:label">
+            <value>text_image_audio_video_test</value>
+            <value form="image">jr://images/img_test_2.jpg</value>
           </text>
-          <text id="/flat_xlsform_test/calculate_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/select_multiple_test:jr:constraintMsg">
-            <value>-</value>
+          <text id="/flat_xlsform_test/autocomplete_test:label">
+            <value>autocomplete_test</value>
           </text>
           <text id="/flat_xlsform_test/autocomplete_chars_test:label">
+            <value>autocomplete_chars_test</value>
+          </text>
+          <text id="/flat_xlsform_test/a_integer:label">
+            <value>a integer</value>
+          </text>
+          <text id="/flat_xlsform_test/a_decimal:label">
+            <value>constrained decimal</value>
+          </text>
+          <text id="/flat_xlsform_test/required_text:label">
+            <value>required_text</value>
+          </text>
+          <text id="/flat_xlsform_test/select_multiple_test:jr:constraintMsg">
+            <value>Sorry <output value=" /flat_xlsform_test/my_name "/>, you can't select yes and no.</value>
+          </text>
+          <text id="/flat_xlsform_test/select_multiple_test:label">
+            <value>select multiple test</value>
+          </text>
+          <text id="/flat_xlsform_test:label">
+            <value>labeled select group test</value>
+          </text>
+          <text id="/flat_xlsform_test/label-test:label">
+            <value>label-test</value>
+          </text>
+          <text id="/flat_xlsform_test/list-nolabel-test:label">
+            <value>list-nolabel-test</value>
+          </text>
+          <text id="/flat_xlsform_test/table_list_question:label">
+            <value>table list question</value>
+          </text>
+          <text id="/flat_xlsform_test/compact-test:label">
+            <value>compact-test</value>
+          </text>
+          <text id="/flat_xlsform_test/compact-2-test:label">
+            <value>compact-2-test</value>
+          </text>
+          <text id="/flat_xlsform_test/acknowledge_test:label">
+            <value>acknowledge_test</value>
+          </text>
+          <text id="/flat_xlsform_test/date_test:label">
+            <value>date_test</value>
+          </text>
+          <text id="/flat_xlsform_test/time_test:label">
+            <value>time_test</value>
+          </text>
+          <text id="/flat_xlsform_test/datetime_test:label">
+            <value>datetime_test</value>
+          </text>
+          <text id="/flat_xlsform_test/geopoint_test:label">
+            <value>geopoint_test</value>
+          </text>
+          <text id="/flat_xlsform_test/barcode_test:label">
+            <value>barcode_test</value>
+          </text>
+          <text id="/flat_xlsform_test/image_test:label">
+            <value>image_test</value>
+          </text>
+          <text id="/flat_xlsform_test/audio_test:label">
+            <value>audio_test</value>
+          </text>
+          <text id="/flat_xlsform_test/video_test:label">
+            <value>video_test</value>
+          </text>
+          <text id="/flat_xlsform_test/note_test:label">
+            <value>note_test</value>
+          </text>
+          <text id="/flat_xlsform_test/calculate_test_output:label">
+            <value>
+              <output value=" /flat_xlsform_test/calculate_test "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/start_test_output:label">
+            <value>start test output: <output value=" /flat_xlsform_test/start "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/end_test_output:label">
+            <value>end test output: <output value=" /flat_xlsform_test/end "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/today_test_output:label">
+            <value>today_test_output: <output value=" /flat_xlsform_test/today "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/deviceid_test_output:label">
+            <value>deviceid_test_output: <output value=" /flat_xlsform_test/deviceid "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/uri_deviceid_test_output:label">
+            <value>deviceid_test_output: <output value=" /flat_xlsform_test/uri_deviceid "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/simserial_test_output:label">
+            <value>simserial_test_output: <output value=" /flat_xlsform_test/simserial "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/phonenumber_test_output:label">
+            <value>phonenumber_test_output: <output value=" /flat_xlsform_test/phonenumber "/>
+            </value>
+          </text>
+          <text id="/flat_xlsform_test/_1:label">
+            <value>numerical name test</value>
+          </text>
+          <text id="/flat_xlsform_test/FALSE:label">
+            <value>boolean name test</value>
+          </text>
+          <text id="/flat_xlsform_test/launch:label">
+            <value>This launches a fictional application to get an integer result.</value>
+          </text>
+          <text id="static_instance-yes_no-yes">
+            <value>-</value>
+          </text>
+          <text id="static_instance-yes_no-no">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/number_label:hint">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/address:hint">
             <value>-</value>
           </text>
+          <text id="/flat_xlsform_test/text_image_audio_video_test:hint">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/yes:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/no:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/display_image_test:label"/>
+          <text id="static_instance-a_b-a"/>
+          <text id="static_instance-a_b-b"/>
+        </translation>
+        <translation lang="chinese">
+          <text id="static_instance-yes_no-yes">
+            <value>是</value>
+          </text>
+          <text id="static_instance-yes_no-no">
+            <value>没有</value>
+          </text>
+          <text id="/flat_xlsform_test/number_label:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/number_label:hint">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/address:label">
+            <value>您好</value>
+          </text>
+          <text id="/flat_xlsform_test/address:hint">
+            <value>ni hao</value>
+          </text>
           <text id="/flat_xlsform_test/text_image_audio_video_test:label">
-            <value form="image">jr://images/img_test.jpg</value>
-            <value form="audio">jr://audio/audio_test.wav</value>
-            <value form="video">jr://video/test.mov</value>
-            <value>-</value>
+            <value>您好</value>
+            <value form="audio">jr://audio/chinese_audio.wav</value>
           </text>
-          <text id="/flat_xlsform_test/date_test:label">
-            <value>-</value>
+          <text id="/flat_xlsform_test/text_image_audio_video_test:hint">
+            <value>ni hao</value>
           </text>
-          <text id="/flat_xlsform_test/select_multiple_test/no:label">
-            <value>No</value>
+          <text id="/flat_xlsform_test/select_multiple_test:jr:constraintMsg">
+            <value>對不起              <output value=" /flat_xlsform_test/my_name "/>
+，你可以不選擇&quot;是&quot;和&quot;否&quot;。</value>
           </text>
-          <text id="/flat_xlsform_test/autocomplete_test/yes:label">
-            <value>Yes</value>
+          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/yes:label">
+            <value>是</value>
           </text>
-          <text id="/flat_xlsform_test/compact-test/b:label">
-            <value form="image">jr://images/b.jpg</value>
+          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/no:label">
+            <value>没有</value>
           </text>
-          <text id="/flat_xlsform_test/select_multiple_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/a_integer:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/label-test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/start_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/note_test:label">
+          <text id="/flat_xlsform_test/skip_to_end:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/email_note:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/list-nolabel-test/no:label">
-            <value>No</value>
+          <text id="/flat_xlsform_test/my_name:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/invalid_variable:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/autocomplete_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/autocomplete_chars_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/a_integer:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/a_decimal:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/required_text:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/select_multiple_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/label-test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/list-nolabel-test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/table_list_question:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/compact-test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/compact-2-test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/acknowledge_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/date_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/time_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/datetime_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/geopoint_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/barcode_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/image_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/audio_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/video_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/note_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/calculate_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/start_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/end_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/today_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/deviceid_test_output:label">
+            <value>-</value>
           </text>
           <text id="/flat_xlsform_test/uri_deviceid_test_output:label">
             <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/simserial_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/phonenumber_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/_1:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/FALSE:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/launch:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/display_image_test:label"/>
+          <text id="static_instance-a_b-a"/>
+          <text id="static_instance-a_b-b"/>
+        </translation>
+        <translation default="true()" lang="default">
+          <text id="static_instance-yes_no-yes">
+            <value>Yes</value>
+          </text>
+          <text id="static_instance-yes_no-no">
+            <value>No</value>
           </text>
           <text id="/flat_xlsform_test/number_label:hint">
             <value>a note</value>
@@ -168,162 +329,64 @@
           <text id="/flat_xlsform_test/text_image_audio_video_test:hint">
             <value>The goal of this test is to try out all the different media types in many languages to see if there are any bugs inserting media.</value>
           </text>
-          <text id="/flat_xlsform_test/datetime_test:label">
-            <value>-</value>
+          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/yes:label">
+            <value>Yes</value>
           </text>
-          <text id="/flat_xlsform_test/skip_to_end:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-test/a:label">
-            <value form="image">jr://images/a.jpg</value>
-          </text>
-          <text id="/flat_xlsform_test/time_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/table_list_question/no:label">
+          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/no:label">
             <value>No</value>
           </text>
-          <text id="/flat_xlsform_test/phonenumber_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-2-test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/audio_test:label">
+          <text id="/flat_xlsform_test/text_image_audio_video_test:label">
+            <value form="audio">jr://audio/audio_test.wav</value>
+            <value form="video">jr://video/test.mov</value>
+            <value form="image">jr://images/img_test.jpg</value>
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/display_image_test:label">
             <value form="image">jr://images/img_test.jpg</value>
           </text>
-          <text id="/flat_xlsform_test/list-nolabel-test/yes:label">
-            <value>Yes</value>
+          <text id="static_instance-a_b-a">
+            <value form="image">jr://images/a.jpg</value>
           </text>
-          <text id="/flat_xlsform_test/autocomplete_test/no:label">
-            <value>No</value>
+          <text id="static_instance-a_b-b">
+            <value form="image">jr://images/b.jpg</value>
           </text>
-          <text id="/flat_xlsform_test/video_test:label">
+          <text id="/flat_xlsform_test/skip_to_end:label">
             <value>-</value>
           </text>
-        </translation>
-        <translation lang="chinese">
-          <text id="/flat_xlsform_test/deviceid_test_output:label">
+          <text id="/flat_xlsform_test/email_note:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/geopoint_test:label">
+          <text id="/flat_xlsform_test/number_label:label">
             <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test/no:label">
-            <value>没有</value>
           </text>
           <text id="/flat_xlsform_test/my_name:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/label-test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/flat_xlsform_test/launch:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/FALSE:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/label-test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/acknowledge_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/no:label">
-            <value>没有</value>
-          </text>
           <text id="/flat_xlsform_test/invalid_variable:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/compact-2-test/a:label"/>
           <text id="/flat_xlsform_test/address:label">
-            <value>您好</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-test:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/table_list_question/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/list-nolabel-test:label">
+          <text id="/flat_xlsform_test/autocomplete_test:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/end_test_output:label">
+          <text id="/flat_xlsform_test/autocomplete_chars_test:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/today_test_output:label">
+          <text id="/flat_xlsform_test/a_integer:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/table_list_question:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/image_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/simserial_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/skip_to_end/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/flat_xlsform_test/select_multiple_test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/date_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/skip_to_end/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/_1:label">
+          <text id="/flat_xlsform_test/a_decimal:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/required_text:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/barcode_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/calculate_test_output:label">
-            <value>-</value>
-          </text>
           <text id="/flat_xlsform_test/select_multiple_test:jr:constraintMsg">
-            <value>對不起 <output value=" /flat_xlsform_test/my_name "/>，你可以不選擇"是"和"否"。</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/address:hint">
-            <value>ni hao</value>
-          </text>
-          <text id="/flat_xlsform_test/text_image_audio_video_test:label">
-            <value form="audio">jr://audio/chinese_audio.wav</value>
-            <value>您好</value>
-          </text>
-          <text id="/flat_xlsform_test/number_label:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/select_multiple_test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-test/b:label"/>
           <text id="/flat_xlsform_test/select_multiple_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/a_integer:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test:label">
@@ -332,245 +395,83 @@
           <text id="/flat_xlsform_test/label-test:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/autocomplete_test:label">
+          <text id="/flat_xlsform_test/list-nolabel-test:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/start_test_output:label">
+          <text id="/flat_xlsform_test/table_list_question:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/compact-2-test/b:label"/>
-          <text id="/flat_xlsform_test/note_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/display_image_test:label"/>
-          <text id="/flat_xlsform_test/list-nolabel-test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/flat_xlsform_test/uri_deviceid_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/number_label:hint">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/text_image_audio_video_test:hint">
-            <value>ni hao</value>
-          </text>
-          <text id="/flat_xlsform_test/datetime_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/skip_to_end:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/a_decimal:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/time_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/table_list_question/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/flat_xlsform_test/phonenumber_test_output:label">
+          <text id="/flat_xlsform_test/compact-test:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/compact-2-test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/audio_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/video_test:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/email_note:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/list-nolabel-test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-test/a:label"/>
-        </translation>
-        <translation lang="english">
-          <text id="/flat_xlsform_test/deviceid_test_output:label">
-            <value>deviceid_test_output: <output value=" /flat_xlsform_test/deviceid "/></value></text>
-          <text id="/flat_xlsform_test/geopoint_test:label">
-            <value>geopoint_test</value>
-          </text>
-          <text id="/flat_xlsform_test/list-nolabel-test:label">
-            <value>list-nolabel-test</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test/no:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/my_name:label">
-            <value>Enter your name</value>
-          </text>
-          <text id="/flat_xlsform_test/label-test/no:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/launch:label">
-            <value>This launches a fictional application to get an integer result.</value>
-          </text>
-          <text id="/flat_xlsform_test/FALSE:label">
-            <value>boolean name test</value>
-          </text>
-          <text id="/flat_xlsform_test/label-test/yes:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/acknowledge_test:label">
-            <value>acknowledge_test</value>
-          </text>
-          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/no:label">
             <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-2-test/a:label"/>
-          <text id="/flat_xlsform_test/text_image_audio_video_test:hint">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/address:label">
-            <value>Enter an address</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-test:label">
-            <value>compact-test</value>
-          </text>
-          <text id="/flat_xlsform_test/table_list_question/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/today_test_output:label">
-            <value>today_test_output: <output value=" /flat_xlsform_test/today "/></value></text>
-          <text id="/flat_xlsform_test/table_list_question:label">
-            <value>table list question</value>
-          </text>
-          <text id="/flat_xlsform_test/image_test:label">
-            <value>image_test</value>
-          </text>
-          <text id="/flat_xlsform_test/simserial_test_output:label">
-            <value>simserial_test_output: <output value=" /flat_xlsform_test/simserial "/></value></text>
-          <text id="/flat_xlsform_test/reserved_name_for_field_list_labels_25/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/skip_to_end/no:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/start_test_output:label">
-            <value>start test output: <output value=" /flat_xlsform_test/start "/></value></text>
-          <text id="/flat_xlsform_test/number_label:label">
-            <value>1</value>
-          </text>
-          <text id="/flat_xlsform_test/invalid_variable:label">
-            <value>Your name is <output value=" /flat_xlsform_test/my_name "/></value></text>
-          <text id="/flat_xlsform_test/_1:label">
-            <value>numerical name test</value>
-          </text>
-          <text id="/flat_xlsform_test/required_text:label">
-            <value>required_text</value>
-          </text>
-          <text id="/flat_xlsform_test/barcode_test:label">
-            <value>barcode_test</value>
-          </text>
-          <text id="/flat_xlsform_test/calculate_test_output:label">
-            <value><output value=" /flat_xlsform_test/calculate_test "/></value>
-          </text>
-          <text id="/flat_xlsform_test/select_multiple_test:jr:constraintMsg">
-            <value>Sorry <output value=" /flat_xlsform_test/my_name "/>, you can't select yes and no.</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-test/a:label"/>
-          <text id="/flat_xlsform_test/select_multiple_test/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_chars_test:label">
-            <value>autocomplete_chars_test</value>
-          </text>
-          <text id="/flat_xlsform_test/address:hint">
-            <value>-</value>
-          </text>
-          <text id="/flat_xlsform_test/text_image_audio_video_test:label">
-            <value form="image">jr://images/img_test_2.jpg</value>
-            <value>text_image_audio_video_test</value>
           </text>
           <text id="/flat_xlsform_test/date_test:label">
-            <value>date_test</value>
-          </text>
-          <text id="/flat_xlsform_test/list-nolabel-test/yes:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/time_test:label">
-            <value>time_test</value>
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/datetime_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/geopoint_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/barcode_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/image_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/audio_test:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/video_test:label">
+            <value>-</value>
           </text>
           <text id="/flat_xlsform_test/note_test:label">
-            <value>note_test</value>
-          </text>
-          <text id="/flat_xlsform_test/compact-2-test:label">
-            <value>compact-2-test</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_test/no:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/select_multiple_test:label">
-            <value>select multiple test</value>
-          </text>
-          <text id="/flat_xlsform_test/select_multiple_test/no:label">
+          <text id="/flat_xlsform_test/calculate_test_output:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/a_integer:label">
-            <value>a integer</value>
-          </text>
-          <text id="/flat_xlsform_test/table_list_question/no:label">
+          <text id="/flat_xlsform_test/start_test_output:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/label-test:label">
-            <value>label-test</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_test:label">
-            <value>autocomplete_test</value>
-          </text>
-          <text id="/flat_xlsform_test:label">
-            <value>labeled select group test</value>
-          </text>
-          <text id="/flat_xlsform_test/autocomplete_test/yes:label">
+          <text id="/flat_xlsform_test/end_test_output:label">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/display_image_test:label"/>
-          <text id="/flat_xlsform_test/list-nolabel-test/no:label">
+          <text id="/flat_xlsform_test/today_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/deviceid_test_output:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/uri_deviceid_test_output:label">
-            <value>deviceid_test_output: <output value=" /flat_xlsform_test/uri_deviceid "/></value></text>
-          <text id="/flat_xlsform_test/number_label:hint">
             <value>-</value>
           </text>
-          <text id="/flat_xlsform_test/compact-2-test/b:label"/>
-          <text id="/flat_xlsform_test/datetime_test:label">
-            <value>datetime_test</value>
-          </text>
-          <text id="/flat_xlsform_test/skip_to_end:label">
-            <value>Skip to end</value>
-          </text>
-          <text id="/flat_xlsform_test/a_decimal:label">
-            <value>constrained decimal</value>
-          </text>
-          <text id="/flat_xlsform_test/end_test_output:label">
-            <value>end test output: <output value=" /flat_xlsform_test/end "/></value></text>
-          <text id="/flat_xlsform_test/compact-test/b:label"/>
-          <text id="/flat_xlsform_test/audio_test:label">
-            <value>audio_test</value>
-          </text>
-          <text id="/flat_xlsform_test/email_note:label">
-            <value>You entered an email address</value>
-          </text>
-          <text id="/flat_xlsform_test/skip_to_end/yes:label">
+          <text id="/flat_xlsform_test/simserial_test_output:label">
             <value>-</value>
           </text>
           <text id="/flat_xlsform_test/phonenumber_test_output:label">
-            <value>phonenumber_test_output: <output value=" /flat_xlsform_test/phonenumber "/></value></text>
-          <text id="/flat_xlsform_test/video_test:label">
-            <value>video_test</value>
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/_1:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/FALSE:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/launch:label">
+            <value>-</value>
+          </text>
+          <text id="/flat_xlsform_test/address:hint">
+            <value>-</value>
           </text>
         </translation>
       </itext>
@@ -688,11 +589,11 @@
     <select1 ref="/flat_xlsform_test/skip_to_end">
       <label ref="jr:itext('/flat_xlsform_test/skip_to_end:label')"/>
       <item>
-        <label ref="jr:itext('/flat_xlsform_test/skip_to_end/yes:label')"/>
+        <label ref="jr:itext('static_instance-yes_no-yes')"/>
         <value>yes</value>
       </item>
       <item>
-        <label ref="jr:itext('/flat_xlsform_test/skip_to_end/no:label')"/>
+        <label ref="jr:itext('static_instance-yes_no-no')"/>
         <value>no</value>
       </item>
     </select1>
@@ -725,22 +626,22 @@
       <select1 appearance="autocomplete" ref="/flat_xlsform_test/autocomplete_test">
         <label ref="jr:itext('/flat_xlsform_test/autocomplete_test:label')"/>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/autocomplete_test/yes:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-yes')"/>
           <value>yes</value>
         </item>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/autocomplete_test/no:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-no')"/>
           <value>no</value>
         </item>
       </select1>
       <select1 appearance="autocomplete_chars" ref="/flat_xlsform_test/autocomplete_chars_test">
         <label ref="jr:itext('/flat_xlsform_test/autocomplete_chars_test:label')"/>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/autocomplete_chars_test/yes:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-yes')"/>
           <value>yes</value>
         </item>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/autocomplete_chars_test/no:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-no')"/>
           <value>no</value>
         </item>
       </select1>
@@ -757,11 +658,11 @@
         <select appearance="minimal" ref="/flat_xlsform_test/select_multiple_test">
           <label ref="jr:itext('/flat_xlsform_test/select_multiple_test:label')"/>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/select_multiple_test/yes:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-yes')"/>
             <value>yes</value>
           </item>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/select_multiple_test/no:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-no')"/>
             <value>no</value>
           </item>
         </select>
@@ -771,22 +672,22 @@
         <select1 appearance="label" ref="/flat_xlsform_test/label-test">
           <label ref="jr:itext('/flat_xlsform_test/label-test:label')"/>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/label-test/yes:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-yes')"/>
             <value>yes</value>
           </item>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/label-test/no:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-no')"/>
             <value>no</value>
           </item>
         </select1>
         <select1 appearance="list-nolabel" ref="/flat_xlsform_test/list-nolabel-test">
           <label ref="jr:itext('/flat_xlsform_test/list-nolabel-test:label')"/>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/list-nolabel-test/yes:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-yes')"/>
             <value>yes</value>
           </item>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/list-nolabel-test/no:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-no')"/>
             <value>no</value>
           </item>
         </select1>
@@ -807,11 +708,11 @@
           <label ref="jr:itext('/flat_xlsform_test/table_list_question:label')"/>
           <hint>hint</hint>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/table_list_question/yes:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-yes')"/>
             <value>yes</value>
           </item>
           <item>
-            <label ref="jr:itext('/flat_xlsform_test/table_list_question/no:label')"/>
+            <label ref="jr:itext('static_instance-yes_no-no')"/>
             <value>no</value>
           </item>
         </select1>
@@ -819,22 +720,22 @@
       <select1 appearance="compact" ref="/flat_xlsform_test/compact-test">
         <label ref="jr:itext('/flat_xlsform_test/compact-test:label')"/>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/compact-test/a:label')"/>
+          <label ref="jr:itext('static_instance-a_b-a')"/>
           <value>a</value>
         </item>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/compact-test/b:label')"/>
+          <label ref="jr:itext('static_instance-a_b-b')"/>
           <value>b</value>
         </item>
       </select1>
       <select1 appearance="compact-2" ref="/flat_xlsform_test/compact-2-test">
         <label ref="jr:itext('/flat_xlsform_test/compact-2-test:label')"/>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/compact-2-test/a:label')"/>
+          <label ref="jr:itext('static_instance-a_b-a')"/>
           <value>a</value>
         </item>
         <item>
-          <label ref="jr:itext('/flat_xlsform_test/compact-2-test/b:label')"/>
+          <label ref="jr:itext('static_instance-a_b-b')"/>
           <value>b</value>
         </item>
       </select1>

--- a/pyxform/tests/test_expected_output/widgets.xml
+++ b/pyxform/tests/test_expected_output/widgets.xml
@@ -5,56 +5,24 @@
     <model odk:xforms-version="1.0.0">
       <itext>
         <translation default="true()" lang="default">
-          <text id="/widgets/happy_sad_table_2/happy_sad_second_method/happy:label">
+          <text id="static_instance-a_b-a">
+            <value>a</value>
+            <value form="image">jr://images/a.jpg</value>
+          </text>
+          <text id="static_instance-a_b-b">
+            <value>b</value>
+            <value form="image">jr://images/b.jpg</value>
+          </text>
+          <text id="static_instance-happy_sad-happy">
             <value form="image">jr://images/happy.jpg</value>
           </text>
-          <text id="/widgets/happy_sad_table/happy_sad_michael/sad:label">
+          <text id="static_instance-happy_sad-sad">
             <value form="image">jr://images/sad.jpg</value>
           </text>
           <text id="/widgets/happy_sad_table/reserved_name_for_field_list_labels_39/happy:label">
             <value form="image">jr://images/happy.jpg</value>
           </text>
-          <text id="/widgets/happy_sad_table_2/happy_sad_second_method/sad:label">
-            <value form="image">jr://images/sad.jpg</value>
-          </text>
-          <text id="/widgets/happy_sad_table_2/happy_sad_brian2/sad:label">
-            <value form="image">jr://images/sad.jpg</value>
-          </text>
-          <text id="/widgets/happy_sad_table/happy_sad_brian/happy:label">
-            <value form="image">jr://images/happy.jpg</value>
-          </text>
           <text id="/widgets/happy_sad_table/reserved_name_for_field_list_labels_39/sad:label">
-            <value form="image">jr://images/sad.jpg</value>
-          </text>
-          <text id="/widgets/happy_sad_table_2/happy_sad_brian2/happy:label">
-            <value form="image">jr://images/happy.jpg</value>
-          </text>
-          <text id="/widgets/grid_test_audio/a:label">
-            <value form="image">jr://images/a.jpg</value>
-            <value>a</value>
-          </text>
-          <text id="/widgets/grid_test_audio/b:label">
-            <value form="image">jr://images/b.jpg</value>
-            <value>b</value>
-          </text>
-          <text id="/widgets/grid_test/b:label">
-            <value form="image">jr://images/b.jpg</value>
-            <value>b</value>
-          </text>
-          <text id="/widgets/happy_sad_table_2/happy_sad_michael2/sad:label">
-            <value form="image">jr://images/sad.jpg</value>
-          </text>
-          <text id="/widgets/grid_test/a:label">
-            <value form="image">jr://images/a.jpg</value>
-            <value>a</value>
-          </text>
-          <text id="/widgets/happy_sad_table/happy_sad_michael/happy:label">
-            <value form="image">jr://images/happy.jpg</value>
-          </text>
-          <text id="/widgets/happy_sad_table_2/happy_sad_michael2/happy:label">
-            <value form="image">jr://images/happy.jpg</value>
-          </text>
-          <text id="/widgets/happy_sad_table/happy_sad_brian/sad:label">
             <value form="image">jr://images/sad.jpg</value>
           </text>
         </translation>
@@ -325,11 +293,11 @@
       <label>Grid test</label>
       <hint>make sure to put a.jpg and b.jpg in the form-media folder</hint>
       <item>
-        <label ref="jr:itext('/widgets/grid_test/a:label')"/>
+        <label ref="jr:itext('static_instance-a_b-a')"/>
         <value>a</value>
       </item>
       <item>
-        <label ref="jr:itext('/widgets/grid_test/b:label')"/>
+        <label ref="jr:itext('static_instance-a_b-b')"/>
         <value>b</value>
       </item>
     </select1>
@@ -337,11 +305,11 @@
       <label>Grid auto-advance test</label>
       <hint>make sure to put a.jpg and b.jpg in the form-media folder</hint>
       <item>
-        <label ref="jr:itext('/widgets/grid_test_audio/a:label')"/>
+        <label ref="jr:itext('static_instance-a_b-a')"/>
         <value>a</value>
       </item>
       <item>
-        <label ref="jr:itext('/widgets/grid_test_audio/b:label')"/>
+        <label ref="jr:itext('static_instance-a_b-b')"/>
         <value>b</value>
       </item>
     </select1>
@@ -424,33 +392,33 @@
       <select appearance="label" ref="/widgets/happy_sad_table_2/happy_sad_second_method">
         <label>Multi Choice List</label>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table_2/happy_sad_second_method/happy:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-happy')"/>
           <value>happy</value>
         </item>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table_2/happy_sad_second_method/sad:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-sad')"/>
           <value>sad</value>
         </item>
       </select>
       <select appearance="list-nolabel" ref="/widgets/happy_sad_table_2/happy_sad_brian2">
         <label>Brian</label>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table_2/happy_sad_brian2/happy:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-happy')"/>
           <value>happy</value>
         </item>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table_2/happy_sad_brian2/sad:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-sad')"/>
           <value>sad</value>
         </item>
       </select>
       <select appearance="list-nolabel" ref="/widgets/happy_sad_table_2/happy_sad_michael2">
         <label>Michael</label>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table_2/happy_sad_michael2/happy:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-happy')"/>
           <value>happy</value>
         </item>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table_2/happy_sad_michael2/sad:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-sad')"/>
           <value>sad</value>
         </item>
       </select>
@@ -473,22 +441,22 @@
       <select appearance="list-nolabel" ref="/widgets/happy_sad_table/happy_sad_brian">
         <label>Brian</label>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table/happy_sad_brian/happy:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-happy')"/>
           <value>happy</value>
         </item>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table/happy_sad_brian/sad:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-sad')"/>
           <value>sad</value>
         </item>
       </select>
       <select appearance="list-nolabel" ref="/widgets/happy_sad_table/happy_sad_michael">
         <label>Michael</label>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table/happy_sad_michael/happy:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-happy')"/>
           <value>happy</value>
         </item>
         <item>
-          <label ref="jr:itext('/widgets/happy_sad_table/happy_sad_michael/sad:label')"/>
+          <label ref="jr:itext('static_instance-happy_sad-sad')"/>
           <value>sad</value>
         </item>
       </select>

--- a/pyxform/tests/test_expected_output/xlsform_spec_test.xml
+++ b/pyxform/tests/test_expected_output/xlsform_spec_test.xml
@@ -5,581 +5,483 @@
     <model odk:xforms-version="1.0.0">
       <submission action="https://example-odk-aggregate.appspot.com/submission" base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo93+Dgn3iDleC9XMTDH7ez1MOm/BOt287DgkldNkdvrtdC4oUegx3N8Say9tq47k2EOzeLYkezVnKdtserx+g/+R6pDIOS66bwbH+HoslDEUaZRZ47EipSGC1JhtOp/nQGQCsdVc5q/fPvw8d2rLLi+PQUZPBOiBxUo9h/CFc41hl/quUELmylSdL4O06OAP8OCEDA+tl0C2Ik+uCYMDJLD4m7YVbkV7jJXjtILj+GW+noLriFMRsgg7WKQe2j9fw5+v46nzhokOnDnHh+yGwQMfs/B0jfFAgXllLNjIPlXQf2UVzuxEax6wLCyqUXMIjCPSNfnzDRgFB4Qw3QbJCwIDAQAB" method="post"/>
       <itext>
-        <translation default="true()" lang="default">
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/image_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/_1:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/skip_to_end/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/end_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/today_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/audio_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
-            <value>The goal of this test is to try out all the different media types in many languages to see if there are any bugs inserting media.</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/calculate_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/email_note:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label">
-            <value form="image">jr://images/a.jpg</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label">
-            <value form="image">jr://images/b.jpg</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test/b:label">
-            <value form="image">jr://images/b.jpg</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/time_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
-            <value form="image">jr://images/img_test.jpg</value>
-            <value form="audio">jr://audio/audio_test.wav</value>
-            <value form="video">jr://video/test.mov</value>
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/skip_to_end:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/display_image_test:label">
-            <value form="image">jr://images/img_test.jpg</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/date_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/barcode_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/launch:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test/a:label">
-            <value form="image">jr://images/a.jpg</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/number_label:hint">
-            <value>a note</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/video_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/address:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/note_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/number_label:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/FALSE:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label">
-            <value>No</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/geopoint_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/a_decimal:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/my_name:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/skip_to_end/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/datetime_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/address:hint">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test/yes:label">
-            <value>Yes</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/acknowledge_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/invalid_variable:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/a_integer:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/start_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/simserial_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
-            <value>-</value>
-          </text>
-        </translation>
-        <translation lang="chinese">
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/image_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/_1:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/skip_to_end/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/end_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/today_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/audio_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
-            <value>ni hao</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/calculate_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/display_image_test:label"/>
-          <text id="/xlsform_spec_test/everything/autocomplete_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label"/>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test/b:label"/>
-          <text id="/xlsform_spec_test/everything/time_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
-            <value form="audio">jr://audio/chinese_audio.wav</value>
-            <value>您好</value>
-          </text>
-          <text id="/xlsform_spec_test/skip_to_end:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/email_note:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/date_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/barcode_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/launch:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test/a:label"/>
-          <text id="/xlsform_spec_test/everything/number_label:hint">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/video_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/address:label">
-            <value>您好</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/note_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
-            <value>對不起 <output value=" /xlsform_spec_test/everything/my_name "/>，你可以不選擇"是"和"否"。</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/number_label:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/FALSE:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label">
-            <value>没有</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/geopoint_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/a_decimal:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label"/>
-          <text id="/xlsform_spec_test/everything/my_name:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/skip_to_end/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/datetime_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/address:hint">
-            <value>ni hao</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test/yes:label">
-            <value>是</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/acknowledge_test:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/invalid_variable:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/a_integer:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/start_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/simserial_test_output:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
-            <value>-</value>
-          </text>
-        </translation>
         <translation lang="english">
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/_1:label">
-            <value>numerical name test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
-            <value>deviceid_test_output: <output value=" /xlsform_spec_test/everything/uri_deviceid "/></value></text>
-          <text id="/xlsform_spec_test/skip_to_end/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/end_test_output:label">
-            <value>end test output: <output value=" /xlsform_spec_test/everything/end "/></value></text>
-          <text id="/xlsform_spec_test/everything/today_test_output:label">
-            <value>today_test_output: <output value=" /xlsform_spec_test/everything/today "/></value></text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/calculate_test_output:label">
-            <value><output value=" /xlsform_spec_test/everything/calculate_test "/></value>
-          </text>
-          <text id="/xlsform_spec_test/everything/image_test:label">
-            <value>image_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test:label">
-            <value>autocomplete_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
-            <value>list-nolabel-test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label"/>
-          <text id="/xlsform_spec_test/everything/note_test:label">
-            <value>note_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/time_test:label">
-            <value>time_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
-            <value>deviceid_test_output: <output value=" /xlsform_spec_test/everything/deviceid "/></value></text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
-            <value form="image">jr://images/img_test_2.jpg</value>
-            <value>text_image_audio_video_test</value>
-          </text>
           <text id="/xlsform_spec_test/skip_to_end:label">
             <value>Skip to end</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/audio_test:label">
-            <value>audio_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/email_note:label">
-            <value>You entered an email address</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/date_test:label">
-            <value>date_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
-            <value>select multiple test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/barcode_test:label">
-            <value>barcode_test</value>
-          </text>
-          <text id="/xlsform_spec_test/launch:label">
-            <value>This launches a fictional application to get an integer result.</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test/a:label"/>
-          <text id="/xlsform_spec_test/everything/number_label:hint">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/video_test:label">
-            <value>video_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label"/>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/datetime_test:label">
-            <value>datetime_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/skip_to_end/yes:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
-            <value>autocomplete_chars_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
-            <value>Sorry <output value=" /xlsform_spec_test/everything/my_name "/>, you can't select yes and no.</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/number_label:label">
-            <value>1</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
-            <value>table list question</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test:label">
-            <value>repeat_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/FALSE:label">
-            <value>boolean name test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
-            <value>compact-2-test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/geopoint_test:label">
-            <value>geopoint_test</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/a_decimal:label">
-            <value>constrained decimal</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
-            <value>required_text</value>
           </text>
           <text id="/xlsform_spec_test/everything/my_name:label">
             <value>Enter your name</value>
           </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label">
-            <value>-</value>
-          </text>
-          <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
-            <value>phonenumber_test_output: <output value=" /xlsform_spec_test/everything/phonenumber "/></value></text>
-          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
-            <value>label-test</value>
+          <text id="/xlsform_spec_test/everything/invalid_variable:label">
+            <value> Your name is <output value=" /xlsform_spec_test/everything/my_name "/>
+            </value>
           </text>
           <text id="/xlsform_spec_test/everything/address:label">
             <value>Enter an address</value>
           </text>
+          <text id="/xlsform_spec_test/everything/email_note:label">
+            <value>You entered an email address</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/number_label:label">
+            <value>1</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
+            <value>text_image_audio_video_test</value>
+            <value form="image">jr://images/img_test_2.jpg</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/autocomplete_test:label">
+            <value>autocomplete_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
+            <value>autocomplete_chars_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/a_integer:label">
+            <value>a integer</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/a_decimal:label">
+            <value>constrained decimal</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test:label">
+            <value>repeat_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
+            <value>required_text</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
+            <value> Sorry <output value=" /xlsform_spec_test/everything/my_name "/>
+, you can't select yes and no. </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
+            <value>select multiple test</value>
+          </text>
           <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
             <value>labeled select group test</value>
           </text>
-          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label">
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
+            <value>label-test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
+            <value>list-nolabel-test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
+            <value>table list question</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
+            <value>compact-test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
+            <value>compact-2-test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/acknowledge_test:label">
+            <value>acknowledge_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/date_test:label">
+            <value>date_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/time_test:label">
+            <value>time_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/datetime_test:label">
+            <value>datetime_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/geopoint_test:label">
+            <value>geopoint_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/barcode_test:label">
+            <value>barcode_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/image_test:label">
+            <value>image_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/audio_test:label">
+            <value>audio_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/video_test:label">
+            <value>video_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/note_test:label">
+            <value>note_test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/calculate_test_output:label">
+            <value>
+              <output value=" /xlsform_spec_test/everything/calculate_test "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/start_test_output:label">
+            <value> start test output: <output value=" /xlsform_spec_test/everything/start "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/end_test_output:label">
+            <value> end test output: <output value=" /xlsform_spec_test/everything/end "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/today_test_output:label">
+            <value> today_test_output: <output value=" /xlsform_spec_test/everything/today "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
+            <value> deviceid_test_output: <output value=" /xlsform_spec_test/everything/deviceid "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
+            <value> deviceid_test_output: <output value=" /xlsform_spec_test/everything/uri_deviceid "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/simserial_test_output:label">
+            <value> simserial_test_output: <output value=" /xlsform_spec_test/everything/simserial "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
+            <value> phonenumber_test_output: <output value=" /xlsform_spec_test/everything/phonenumber "/>
+            </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/_1:label">
+            <value>numerical name test</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/FALSE:label">
+            <value>boolean name test</value>
+          </text>
+          <text id="/xlsform_spec_test/launch:label">
+            <value>This launches a fictional application to get an integer result.</value>
+          </text>
+          <text id="static_instance-yes_no-yes">
+            <value>-</value>
+          </text>
+          <text id="static_instance-yes_no-no">
             <value>-</value>
           </text>
           <text id="/xlsform_spec_test/everything/address:hint">
             <value>-</value>
           </text>
-          <text id="/xlsform_spec_test/everything/autocomplete_test/yes:label">
+          <text id="/xlsform_spec_test/everything/number_label:hint">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/display_image_test:label"/>
+          <text id="static_instance-a_b-a"/>
+          <text id="static_instance-a_b-b"/>
+        </translation>
+        <translation lang="chinese">
+          <text id="static_instance-yes_no-yes">
+            <value>是</value>
+          </text>
+          <text id="static_instance-yes_no-no">
+            <value>没有</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/address:label">
+            <value>您好</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/address:hint">
+            <value>ni hao</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/number_label:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/number_label:hint">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
+            <value>您好</value>
+            <value form="audio">jr://audio/chinese_audio.wav</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
+            <value>ni hao</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
+            <value> 對不起              <output value=" /xlsform_spec_test/everything/my_name "/>
+，你可以不選擇&quot;是&quot;和&quot;否&quot;。 </value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
+            <value>是</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
+            <value>没有</value>
+          </text>
+          <text id="/xlsform_spec_test/skip_to_end:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/my_name:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/invalid_variable:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/email_note:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/autocomplete_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/a_integer:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/a_decimal:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
             <value>-</value>
           </text>
           <text id="/xlsform_spec_test/everything/acknowledge_test:label">
-            <value>acknowledge_test</value>
+            <value>-</value>
           </text>
-          <text id="/xlsform_spec_test/everything/display_image_test:label"/>
-          <text id="/xlsform_spec_test/everything/invalid_variable:label">
-            <value>Your name is <output value=" /xlsform_spec_test/everything/my_name "/></value></text>
-          <text id="/xlsform_spec_test/everything/repeat_test/compact-test/b:label"/>
-          <text id="/xlsform_spec_test/everything/a_integer:label">
-            <value>a integer</value>
+          <text id="/xlsform_spec_test/everything/date_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/time_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/datetime_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/geopoint_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/barcode_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/image_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/audio_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/video_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/note_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/calculate_test_output:label">
+            <value>-</value>
           </text>
           <text id="/xlsform_spec_test/everything/start_test_output:label">
-            <value>start test output: <output value=" /xlsform_spec_test/everything/start "/></value></text>
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/end_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/today_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
+            <value>-</value>
+          </text>
           <text id="/xlsform_spec_test/everything/simserial_test_output:label">
-            <value>simserial_test_output: <output value=" /xlsform_spec_test/everything/simserial "/></value></text>
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/_1:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/FALSE:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/launch:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/display_image_test:label"/>
+          <text id="static_instance-a_b-a"/>
+          <text id="static_instance-a_b-b"/>
+        </translation>
+        <translation default="true()" lang="default">
+          <text id="static_instance-yes_no-yes">
+            <value>Yes</value>
+          </text>
+          <text id="static_instance-yes_no-no">
+            <value>No</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/number_label:hint">
+            <value>a note</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:hint">
+            <value>The goal of this test is to try out all the different media types in many languages to see if there are any bugs inserting media.</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/yes:label">
+            <value>Yes</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/reserved_name_for_field_list_labels_25/no:label">
+            <value>No</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/text_image_audio_video_test:label">
+            <value form="audio">jr://audio/audio_test.wav</value>
+            <value form="video">jr://video/test.mov</value>
+            <value form="image">jr://images/img_test.jpg</value>
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/display_image_test:label">
+            <value form="image">jr://images/img_test.jpg</value>
+          </text>
+          <text id="static_instance-a_b-a">
+            <value form="image">jr://images/a.jpg</value>
+          </text>
+          <text id="static_instance-a_b-b">
+            <value form="image">jr://images/b.jpg</value>
+          </text>
+          <text id="/xlsform_spec_test/skip_to_end:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/my_name:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/invalid_variable:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/address:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/email_note:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/number_label:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/autocomplete_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/autocomplete_chars_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/a_integer:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/a_decimal:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/required_text:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:jr:constraintMsg">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/name/table_list_question:label">
+            <value>-</value>
+          </text>
           <text id="/xlsform_spec_test/everything/repeat_test/compact-test:label">
-            <value>compact-test</value>
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/repeat_test/compact-2-test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/acknowledge_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/date_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/time_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/datetime_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/geopoint_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/barcode_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/image_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/audio_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/video_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/note_test:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/calculate_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/start_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/end_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/today_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/deviceid_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/uri_deviceid_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/simserial_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/phonenumber_test_output:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/_1:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/FALSE:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/launch:label">
+            <value>-</value>
+          </text>
+          <text id="/xlsform_spec_test/everything/address:hint">
+            <value>-</value>
           </text>
         </translation>
       </itext>
@@ -726,11 +628,11 @@
     <select1 ref="/xlsform_spec_test/skip_to_end">
       <label ref="jr:itext('/xlsform_spec_test/skip_to_end:label')"/>
       <item>
-        <label ref="jr:itext('/xlsform_spec_test/skip_to_end/yes:label')"/>
+        <label ref="jr:itext('static_instance-yes_no-yes')"/>
         <value>yes</value>
       </item>
       <item>
-        <label ref="jr:itext('/xlsform_spec_test/skip_to_end/no:label')"/>
+        <label ref="jr:itext('static_instance-yes_no-no')"/>
         <value>no</value>
       </item>
     </select1>
@@ -763,22 +665,22 @@
       <select1 appearance="autocomplete" ref="/xlsform_spec_test/everything/autocomplete_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_test:label')"/>
         <item>
-          <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_test/yes:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-yes')"/>
           <value>yes</value>
         </item>
         <item>
-          <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_test/no:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-no')"/>
           <value>no</value>
         </item>
       </select1>
       <select1 appearance="autocomplete_chars" ref="/xlsform_spec_test/everything/autocomplete_chars_test">
         <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_chars_test:label')"/>
         <item>
-          <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_chars_test/yes:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-yes')"/>
           <value>yes</value>
         </item>
         <item>
-          <label ref="jr:itext('/xlsform_spec_test/everything/autocomplete_chars_test/no:label')"/>
+          <label ref="jr:itext('static_instance-yes_no-no')"/>
           <value>no</value>
         </item>
       </select1>
@@ -798,11 +700,11 @@
             <select appearance="minimal" ref="/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test">
               <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test:label')"/>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/yes:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-yes')"/>
                 <value>yes</value>
               </item>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/group_test/select_multiple_test/no:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-no')"/>
                 <value>no</value>
               </item>
             </select>
@@ -812,22 +714,22 @@
             <select1 appearance="label" ref="/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test">
               <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test:label')"/>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/yes:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-yes')"/>
                 <value>yes</value>
               </item>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/label-test/no:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-no')"/>
                 <value>no</value>
               </item>
             </select1>
             <select1 appearance="list-nolabel" ref="/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test">
               <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test:label')"/>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/yes:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-yes')"/>
                 <value>yes</value>
               </item>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/labeled_select_group/list-nolabel-test/no:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-no')"/>
                 <value>no</value>
               </item>
             </select1>
@@ -848,11 +750,11 @@
               <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/table_list_question:label')"/>
               <hint>hint</hint>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/table_list_question/yes:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-yes')"/>
                 <value>yes</value>
               </item>
               <item>
-                <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/name/table_list_question/no:label')"/>
+                <label ref="jr:itext('static_instance-yes_no-no')"/>
                 <value>no</value>
               </item>
             </select1>
@@ -860,22 +762,22 @@
           <select1 appearance="compact" ref="/xlsform_spec_test/everything/repeat_test/compact-test">
             <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-test:label')"/>
             <item>
-              <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-test/a:label')"/>
+              <label ref="jr:itext('static_instance-a_b-a')"/>
               <value>a</value>
             </item>
             <item>
-              <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-test/b:label')"/>
+              <label ref="jr:itext('static_instance-a_b-b')"/>
               <value>b</value>
             </item>
           </select1>
           <select1 appearance="compact-2" ref="/xlsform_spec_test/everything/repeat_test/compact-2-test">
             <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-2-test:label')"/>
             <item>
-              <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-2-test/a:label')"/>
+              <label ref="jr:itext('static_instance-a_b-a')"/>
               <value>a</value>
             </item>
             <item>
-              <label ref="jr:itext('/xlsform_spec_test/everything/repeat_test/compact-2-test/b:label')"/>
+              <label ref="jr:itext('static_instance-a_b-b')"/>
               <value>b</value>
             </item>
           </select1>

--- a/pyxform/tests/xml_tests.py
+++ b/pyxform/tests/xml_tests.py
@@ -35,10 +35,10 @@ class XMLTests(utils.XFormTestCase):
           <text id="/yes_or_no_question/good_day:label">
             <value>have you had a good day today?</value>
           </text>
-          <text id="/yes_or_no_question/good_day/no:label">
+          <text id="static_instance-yes_or_no-no">
             <value>no</value>
           </text>
-          <text id="/yes_or_no_question/good_day/yes:label">
+          <text id="static_instance-yes_or_no-yes">
             <value>yes</value>
           </text>
         </translation>
@@ -61,11 +61,11 @@ class XMLTests(utils.XFormTestCase):
     <select1 ref="/yes_or_no_question/good_day">
       <label ref="jr:itext('/yes_or_no_question/good_day:label')"/>
       <item>
-        <label ref="jr:itext('/yes_or_no_question/good_day/yes:label')"/>
+        <label ref="jr:itext('static_instance-yes_or_no-yes')"/>
         <value>yes</value>
       </item>
       <item>
-        <label ref="jr:itext('/yes_or_no_question/good_day/no:label')"/>
+        <label ref="jr:itext('static_instance-yes_or_no-no')"/>
         <value>no</value>
       </item>
     </select1>

--- a/pyxform/tests_v1/test_inline_translations.py
+++ b/pyxform/tests_v1/test_inline_translations.py
@@ -59,12 +59,12 @@ class InlineTranslationsTest(PyxformTestCase):
             name="data",
             id_string="some-id",
             model__contains=[
-                '<text id="static_instance-states-0">',
-                '<text id="static_instance-states-1">',
-                '<text id="static_instance-states-2">',
-                "<itextId>static_instance-states-0</itextId>",
-                "<itextId>static_instance-states-1</itextId>",
-                "<itextId>static_instance-states-2</itextId>",
+                '<text id="static_instance-states-option_a">',
+                '<text id="static_instance-states-option_b">',
+                '<text id="static_instance-states-option_c">',
+                "<itextId>static_instance-states-option_a</itextId>",
+                "<itextId>static_instance-states-option_b</itextId>",
+                "<itextId>static_instance-states-option_c</itextId>",
             ],
             model__excludes=[
                 "<label>a</label>",

--- a/pyxform/tests_v1/test_rank.py
+++ b/pyxform/tests_v1/test_rank.py
@@ -79,21 +79,21 @@ class RangeWidgetTest(PyxformTestCase):
                 """<text id="/data/order:label">
             <value>Ranger</value>
           </text>""",
-                """<text id="/data/order/a:label">
+                """<text id="static_instance-mylist-a">
             <value>AA</value>
           </text>""",
-                """<text id="/data/order/b:label">
+                """<text id="static_instance-mylist-b">
             <value>BB</value>
           </text>""",
                 "</translation>",
                 """<odk:rank ref="/data/order">
       <label ref="jr:itext('/data/order:label')"/>
       <item>
-        <label ref="jr:itext('/data/order/a:label')"/>
+        <label ref="jr:itext('static_instance-mylist-a')"/>
         <value>a</value>
       </item>
       <item>
-        <label ref="jr:itext('/data/order/b:label')"/>
+        <label ref="jr:itext('static_instance-mylist-b')"/>
         <value>b</value>
       </item>
     </odk:rank>""",

--- a/pyxform/tests_v1/test_translations.py
+++ b/pyxform/tests_v1/test_translations.py
@@ -75,3 +75,41 @@ class TransaltionsTest(PyxformTestCase):
             ],
             itext__excludes=['<value form="audio">jr://audio/-</value>'],
         )
+
+    def test_select_with_choice_filter_translation(self):
+        """Test translations are correctly generated for selects with choice filters"""
+        xform_md = """
+        | survey |                    |                 |                                 |                           |
+        |        | type               | name            | label                           | choice_filter             |
+        |        | select_one consent | consent         | Would you like to participate ? |                           |
+        |        | select_one mood    | enumerator_mood | How are you feeling today ?     | selected(${consent}, 'y') |
+        | choices |
+        |         | list_name | name | label | label::Latin | media::image |
+        |         | mood      | h    | Happy | Felix        | happy.jpg    |
+        |         | mood      | s    | Sad   | Miserabilis  | sad.jpg      |
+        |         | consent   | y    | Yes   |              |              |
+        |         | consent   | n    | No    |              |              |
+        """
+        self.assertPyxformXform(
+            name="mood_form",
+            id_string="mood_form",
+            md=xform_md,
+            errored=False,
+            debug=False,
+            itext__contains=[
+                '<translation default="true()" lang="default">',
+                '<text id="static_instance-mood-h">',
+                "<value>Happy</value>",
+                '<value form="image">jr://images/happy.jpg</value>',
+                '<text id="static_instance-mood-s">',
+                "<value>Sad</value>",
+                '<value form="image">jr://images/sad.jpg</value>',
+                '<translation lang="Latin">',
+                "<value>Felix</value>",
+                "<value>Miserabilis</value>",
+            ],
+            itext__excludes=[
+                '<text id="/data/enumerator_mood/h:label">',
+                '<text id="/data/enumerator_mood/s:label">',
+            ],
+        )

--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -418,6 +418,7 @@ class XFormToDictBuilder:
             question["type"] = obj["mediatype"].replace("/*", "")
         if "item" in obj:
             children = []
+            question["list_name"] = self._get_list_name(obj["item"])
             for i in obj["item"]:
                 if isinstance(i, dict) and "label" in i.keys() and "value" in i.keys():
                     k, v = self._get_label(i["label"])
@@ -545,6 +546,15 @@ class XFormToDictBuilder:
             self.translations = [self.translations]
         assert "text" in self.translations[0]
         assert "lang" in self.translations[0]
+
+    def _get_list_name(self, itemset):
+        item = itemset[0]
+        if isinstance(item.get("label"), dict):
+            label_ref = item["label"].get("ref")
+            if "static_instance" in label_ref:
+                label_ref = label_ref.replace("jr:itext('", "").replace("')", "")
+                return label_ref.split("-")[1]
+        return ""
 
     def _get_label(self, label_obj, key="label"):
         if isinstance(label_obj, dict):


### PR DESCRIPTION
Closes #464, #463 

#### Why is this the best possible solution? Were any other approaches considered?

#### What are the regression risks?

None.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments
