### PR TITLE
Java versions can have patch versions

### DIFF
--- a/pyxform/tests_v1/test_validators.py
+++ b/pyxform/tests_v1/test_validators.py
@@ -36,6 +36,10 @@ OPENJDK_9_INT = """openjdk version "9-internal"
 OpenJDK Runtime Environment (build 9-internal+0-2016-04-14-195246.buildd.src)
 OpenJDK 64-Bit Server VM (build 9-internal+0-2016-04-14-195246.buildd.src, mixed mode)
 """
+OPENJDK_11_PATCH = """openjdk version "11.0.9.1" 2020-11-04
+OpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)
+OpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)
+"""
 
 
 class TestValidators(TestCase):
@@ -75,4 +79,8 @@ class TestValidators(TestCase):
 
         with patch(mock_func) as mock_popen:
             mock_popen.return_value = (0, False, "", OPENJDK_9_INT)
+            check_java_version()
+
+        with patch(mock_func) as mock_popen:
+            mock_popen.return_value = (0, False, "", OPENJDK_11_PATCH)
             check_java_version()

--- a/pyxform/validators/odk_validate/__init__.py
+++ b/pyxform/validators/odk_validate/__init__.py
@@ -74,11 +74,11 @@ def check_java_version():
     # Using regex to find that in the string
     java_version = re.findall(r"\"(.+?)\"", java_version_str)[0]
     if "." in java_version:
-        major, minor, _ = java_version.split(".")
+        major, minor = java_version.split(".")[0], java_version.split(".")[1]
     elif "-" in java_version:
-        major, minor = int(java_version.split("-")[0]), 0
+        major, minor = java_version.split("-")[0], 0
     else:
-        major, minor = int(java_version), 0
+        major, minor = java_version, 0
     if not ((int(major) == 1 and int(minor) >= 8) or int(major) >= 8):
         raise EnvironmentError(
             "pyxform odk validate dependency: " "java 8 or newer version not found"


### PR DESCRIPTION
Resolves https://forum.getodk.org/t/problem-converting-with-xlsform-online-due-to-too-many-values-to-unpack/31163. This problem is occuring because the default Java on Ubuntu was upgraded to version "11.0.9.1" on 2020-11-04. Our code assumes no patch version.

This change will require a hotfix to pyxform.

#### Why is this the best possible solution? Were any other approaches considered?
Narrowest patch I could think of. I assume there is a major and minor version, and that both are ints. I also assume that the other version information doesn't matter. 

#### What are the regression risks?
I remove the int wrappers in favor of the int() wrapping in the check that raises the exception

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [X] included test cases for core behavior and edge cases in `tests_v1`
- [X] run `nosetests` and verified all tests pass
- [X] run `black pyxform` to format code
- [X] verified that any code or assets from external sources are properly credited in comments