### PR TITLE
When indexed-repeat is used within a repeat, 1st, 2nd, 4th, and 6th a…

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -877,26 +877,9 @@ class Survey(Section):
         Given a dictionary of xpaths, return a function we can use to
         replace ${varname} with the xpath to varname.
         """
-        name = matchobj.group(2)
-        last_saved = matchobj.group(1) is not None
-        intro = (
-            "There has been a problem trying to replace %s with the "
-            "XPath to the survey element named '%s'." % (matchobj.group(0), name)
-        )
-        if name not in self._xpath:
-            raise PyXFormError(intro + " There is no survey element with this name.")
-        if self._xpath[name] is None:
-            raise PyXFormError(
-                intro + " There are multiple survey elements" " with this name."
-            )
-        if (
-            not last_saved
-            and context
-            and not (
-                context["type"] == "calculate"
-                and "indexed-repeat" in context["bind"]["calculate"]
-            )
-        ):
+
+        def _relative_path(name):
+            return_path = None
             xpath, context_xpath = self._xpath[name], context.get_xpath()
             # share same root i.e repeat_a from /data/repeat_a/...
             if (
@@ -912,7 +895,63 @@ class Survey(Section):
                     ref_path = ref_path if ref_path.endswith(name) else "/%s" % name
                     prefix = " current()/" if use_current else " "
 
-                    return prefix + "/".join([".."] * steps) + ref_path + " "
+                    return_path = prefix + "/".join([".."] * steps) + ref_path + " "
+
+            return return_path
+
+        name = matchobj.group(2)
+        last_saved = matchobj.group(1) is not None
+        intro = (
+            "There has been a problem trying to replace %s with the "
+            "XPath to the survey element named '%s'." % (matchobj.group(0), name)
+        )
+        if name not in self._xpath:
+            raise PyXFormError(intro + " There is no survey element with this name.")
+        if self._xpath[name] is None:
+            raise PyXFormError(
+                intro + " There are multiple survey elements" " with this name."
+            )
+
+        return_relative_path = False
+        if not last_saved and context:
+            if context["type"] != "calculate":
+                indexed_repeat = None
+                if (
+                    "bind" in context
+                    and "calculate" in context["bind"]
+                    and "indexed-repeat" in context["bind"]["calculate"]
+                ):
+                    indexed_repeat = context["bind"]["calculate"]
+                elif "default" in context and "indexed-repeat" in context["default"]:
+                    indexed_repeat = context["default"]
+
+                if "type" in context and context["type"] == "text":
+                    indexed_repeat_name_index = None
+                    if indexed_repeat is not None:
+                        indexed_repeat_parameters = indexed_repeat.strip()[
+                            len("indexed-repeat") :
+                        ][1:-1].split(",")
+                        name_param = "${{{0}}}".format(name)
+                        for idx, param in enumerate(indexed_repeat_parameters):
+                            if name_param in param.strip():
+                                indexed_repeat_name_index = idx
+
+                    if (
+                        indexed_repeat_name_index is not None
+                        and indexed_repeat_name_index not in [0, 1, 3, 5]
+                    ) or indexed_repeat is None:
+                        return_relative_path = True
+                else:
+                    if indexed_repeat is None:
+                        return_relative_path = True
+            else:
+                if "indexed-repeat" not in context["bind"]["calculate"]:
+                    return_relative_path = True
+
+        if return_relative_path:
+            relative_path = _relative_path(name)
+            if relative_path is not None:
+                return relative_path
 
         last_saved_prefix = (
             "instance('" + LAST_SAVED_INSTANCE_NAME + "')" if last_saved else ""

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -918,13 +918,18 @@ class Survey(Section):
                         return True
 
                     # It is possible to have multiple indexed-repeat in an expression
-                    for indexed_repeat in indexed_repeat_regex.finditer(
+                    indexed_repeats_iter = indexed_repeat_regex.finditer(
                         matchobj.string
-                    ):
+                    )
+                    for indexed_repeat in indexed_repeats_iter:
 
                         # Make sure current ${name} is in the correct indexed-repeat
                         if current_matchobj.end() > indexed_repeat.end():
-                            continue
+                            try:
+                                next(indexed_repeats_iter)
+                                continue
+                            except StopIteration:
+                                return True
 
                         # ${name} outside of indexed-repeat always using relative path
                         if (

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -516,3 +516,75 @@ class TestRepeat(PyxformTestCase):
                 """<setvalue event="odk-instance-first-load odk-new-repeat" ref="/data/family/person/prev_name" value="indexed-repeat( /data/family/person/name ,  /data/family , 1,  /data/family/person , 2)"/>"""  # noqa pylint: disable=line-too-long
             ],
         )
+
+    def test_indexed_repeat_math_epression_dreaded_nested_repeat_relative_path_exception(
+        self,
+    ):
+        """Test relative path exception (absolute path) in indexed-repeat() with math expression using dreaded nested repeat."""
+        self.assertPyxformXform(
+            name="data",
+            title="dreaded nested repeat indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            md="""
+                | survey  |                |                |                                  |                                                        |
+                |         | type           | name           | label                            | default                                                |
+                |         | begin_repeat   | family         | Family                           |                                                        |
+                |         | integer        | members_number | How many members in this family? |                                                        |
+                |         | begin_repeat   | person         | Person                           |                                                        |
+                |         | text           | name           | Enter name                       |                                                        |
+                |         | integer        | age            | Enter age                        |                                                        |
+                |         | text           | prev_name      | Expression label                 | 7 * indexed-repeat(${age}, ${family}, 1, ${person}, 2) |
+                |         | end repeat     |                |                                  |                                                        |
+                |         | end repeat     |                |                                  |                                                        |
+            """,  # noqa pylint: disable=line-too-long
+            xml__contains=[
+                """<setvalue event="odk-instance-first-load odk-new-repeat" ref="/data/family/person/prev_name" value="7 * indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2)"/>"""  # noqa pylint: disable=line-too-long
+            ],
+        )
+
+    def test_multiple_indexed_repeat_in_epression_dreaded_nested_repeat_relative_path_exception(
+        self,
+    ):
+        """Test relative path exception (absolute path) in multiple indexed-repeat() inside an expression using dreaded nested repeat."""
+        self.assertPyxformXform(
+            name="data",
+            title="dreaded nested repeat indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            md="""
+                | survey  |                |                |                                  |                                                                                                                 |
+                |         | type           | name           | label                            | default                                                                                                         |
+                |         | begin_repeat   | family         | Family                           |                                                                                                                 |
+                |         | integer        | members_number | How many members in this family? |                                                                                                                 |
+                |         | begin_repeat   | person         | Person                           |                                                                                                                 |
+                |         | text           | name           | Enter name                       |                                                                                                                 |
+                |         | integer        | age            | Enter age                        |                                                                                                                 |
+                |         | text           | prev_name      | Expression label                 | concat(indexed-repeat(${name}, ${family}, 1, ${person}, 2), indexed-repeat(${age}, ${family}, 1, ${person}, 2)) |
+                |         | end repeat     |                |                                  |                                                                                                                 |
+                |         | end repeat     |                |                                  |                                                                                                                 |
+            """,  # noqa pylint: disable=line-too-long
+            xml__contains=[
+                """<setvalue event="odk-instance-first-load odk-new-repeat" ref="/data/family/person/prev_name" value="concat(indexed-repeat( /data/family/person/name ,  /data/family , 1,  /data/family/person , 2), indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2))"/>"""  # noqa pylint: disable=line-too-long
+            ],
+        )
+
+    def test_indexed_repeat_math_epression_with_double_variable_in_dreaded_nested_repeat_relative_path_exception(
+        self,
+    ):
+        """Test relative path exception (absolute path) in indexed-repeat() with math expression and double variable using dreaded nested repeat."""
+        self.assertPyxformXform(
+            name="data",
+            title="dreaded nested repeat indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            md="""
+                | survey  |                |                |                                  |                                                             |
+                |         | type           | name           | label                            | default                                                     |
+                |         | begin_repeat   | family         | Family                           |                                                             |
+                |         | integer        | members_number | How many members in this family? |                                                             |
+                |         | begin_repeat   | person         | Person                           |                                                             |
+                |         | text           | name           | Enter name                       |                                                             |
+                |         | integer        | age            | Enter age                        |                                                             |
+                |         | text           | prev_name      | Expression label                 | ${age} > indexed-repeat(${age}, ${family}, 1, ${person}, 2) |
+                |         | end repeat     |                |                                  |                                                             |
+                |         | end repeat     |                |                                  |                                                             |
+            """,  # noqa pylint: disable=line-too-long
+            xml__contains=[
+                """<setvalue event="odk-instance-first-load odk-new-repeat" ref="/data/family/person/prev_name" value=" ../age  &gt; indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2)"/>"""  # noqa pylint: disable=line-too-long
+            ],
+        )

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -463,7 +463,7 @@ class TestRepeat(PyxformTestCase):
         """Test relative path exception (absolute path) in indexed-repeat() using regular calculation."""
         self.assertPyxformXform(
             name="data",
-            title="regular calculation indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            title="regular calculation indexed-repeat 1st, 2nd, 4th, and 6th argument is using absolute path",
             md="""
                 | survey  |                |           |                                  |                                              |
                 |         | type           | name      | label                            | calculation                                  |
@@ -482,7 +482,7 @@ class TestRepeat(PyxformTestCase):
         """Test relative path exception (absolute path) in indexed-repeat() using dynamic default."""
         self.assertPyxformXform(
             name="data",
-            title="dynamic default indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            title="dynamic default indexed-repeat 1st, 2nd, 4th, and 6th argument is using absolute path",
             md="""
                 | survey  |                |           |                                  |                                                    |
                 |         | type           | name      | label                            | default                                            |
@@ -496,11 +496,11 @@ class TestRepeat(PyxformTestCase):
             ],
         )
 
-    def test_indexed_repeat_dreaded_nested_repeat_relative_path_exception(self):
-        """Test relative path exception (absolute path) in indexed-repeat() using dreaded nested repeat."""
+    def test_indexed_repeat_nested_repeat_relative_path_exception(self):
+        """Test relative path exception (absolute path) in indexed-repeat() using nested repeat."""
         self.assertPyxformXform(
             name="data",
-            title="dreaded nested repeat indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            title="In nested repeat, indexed-repeat 1st, 2nd, 4th, and 6th argument is using absolute path",
             md="""
                 | survey  |                |                |                                                        |                                                     |
                 |         | type           | name           | label                                                  | default                                             |
@@ -517,16 +517,14 @@ class TestRepeat(PyxformTestCase):
             ],
         )
 
-    def test_indexed_repeat_math_epression_dreaded_nested_repeat_relative_path_exception(
-        self,
-    ):
-        """Test relative path exception (absolute path) in indexed-repeat() with math expression using dreaded nested repeat."""
+    def test_indexed_repeat_math_epression_nested_repeat_relative_path_exception(self,):
+        """Test relative path exception (absolute path) in indexed-repeat() with math expression using nested repeat."""
         self.assertPyxformXform(
             name="data",
-            title="dreaded nested repeat indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            title="In nested repeat, indexed-repeat 1st, 2nd, 4th, and 6th argument is using absolute path",
             md="""
                 | survey  |                |                |                                  |                                                        |
-                |         | type           | name           | label                            | default                                                |
+                |         | type           | name           | label                            | calculation                                            |
                 |         | begin_repeat   | family         | Family                           |                                                        |
                 |         | integer        | members_number | How many members in this family? |                                                        |
                 |         | begin_repeat   | person         | Person                           |                                                        |
@@ -537,20 +535,20 @@ class TestRepeat(PyxformTestCase):
                 |         | end repeat     |                |                                  |                                                        |
             """,  # noqa pylint: disable=line-too-long
             xml__contains=[
-                """<setvalue event="odk-instance-first-load odk-new-repeat" ref="/data/family/person/prev_name" value="7 * indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2)"/>"""  # noqa pylint: disable=line-too-long
+                """<bind calculate="7 * indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2)" nodeset="/data/family/person/prev_name" type="string"/>"""  # noqa pylint: disable=line-too-long
             ],
         )
 
-    def test_multiple_indexed_repeat_in_epression_dreaded_nested_repeat_relative_path_exception(
+    def test_multiple_indexed_repeat_in_epression_nested_repeat_relative_path_exception(
         self,
     ):
-        """Test relative path exception (absolute path) in multiple indexed-repeat() inside an expression using dreaded nested repeat."""
+        """Test relative path exception (absolute path) in multiple indexed-repeat() inside an expression using nested repeat."""
         self.assertPyxformXform(
             name="data",
-            title="dreaded nested repeat indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            title="In nested repeat, indexed-repeat 1st, 2nd, 4th, and 6th argument is using absolute path",
             md="""
                 | survey  |                |                |                                  |                                                                                                                 |
-                |         | type           | name           | label                            | default                                                                                                         |
+                |         | type           | name           | label                            | required                                                                                                        |
                 |         | begin_repeat   | family         | Family                           |                                                                                                                 |
                 |         | integer        | members_number | How many members in this family? |                                                                                                                 |
                 |         | begin_repeat   | person         | Person                           |                                                                                                                 |
@@ -561,20 +559,44 @@ class TestRepeat(PyxformTestCase):
                 |         | end repeat     |                |                                  |                                                                                                                 |
             """,  # noqa pylint: disable=line-too-long
             xml__contains=[
-                """<setvalue event="odk-instance-first-load odk-new-repeat" ref="/data/family/person/prev_name" value="concat(indexed-repeat( /data/family/person/name ,  /data/family , 1,  /data/family/person , 2), indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2))"/>"""  # noqa pylint: disable=line-too-long
+                """<bind nodeset="/data/family/person/prev_name" required="concat(indexed-repeat( /data/family/person/name ,  /data/family , 1,  /data/family/person , 2), indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2))" type="string"/>"""  # noqa pylint: disable=line-too-long
             ],
         )
 
-    def test_indexed_repeat_math_epression_with_double_variable_in_dreaded_nested_repeat_relative_path_exception(
+    def test_mixed_variables_and_indexed_repeat_in_epression_nested_repeat_relative_path_exception(
         self,
     ):
-        """Test relative path exception (absolute path) in indexed-repeat() with math expression and double variable using dreaded nested repeat."""
+        """Test relative path exception (absolute path) in an expression contains variables and indexed-repeat() using nested repeat."""
         self.assertPyxformXform(
             name="data",
-            title="dreaded nested repeat indexed-repeat 1st, 2nd, 4th, and 6th parameters is using absolute path",
+            title="In nested repeat, indexed-repeat 1st, 2nd, 4th, and 6th argument is using absolute path",
+            md="""
+                | survey  |                |                |                                  |                                                                                                                 |
+                |         | type           | name           | label                            | calculation                                                                                                        |
+                |         | begin_repeat   | family         | Family                           |                                                                                                                 |
+                |         | integer        | members_number | How many members in this family? |                                                                                                                 |
+                |         | begin_repeat   | person         | Person                           |                                                                                                                 |
+                |         | text           | name           | Enter name                       |                                                                                                                 |
+                |         | integer        | age            | Enter age                        |                                                                                                                 |
+                |         | text           | prev_name      | Expression label                 | concat(${name}, indexed-repeat(${age}, ${family}, 1, ${person}, 2), ${age})                                     |
+                |         | end repeat     |                |                                  |                                                                                                                 |
+                |         | end repeat     |                |                                  |                                                                                                                 |
+            """,  # noqa pylint: disable=line-too-long
+            xml__contains=[
+                """<bind calculate="concat( ../name , indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2),  ../age )" nodeset="/data/family/person/prev_name" type="string"/>"""  # noqa pylint: disable=line-too-long
+            ],
+        )
+
+    def test_indexed_repeat_math_epression_with_double_variable_in_nested_repeat_relative_path_exception(
+        self,
+    ):
+        """Test relative path exception (absolute path) in indexed-repeat() with math expression and double variable using nested repeat."""
+        self.assertPyxformXform(
+            name="data",
+            title="In nested repeat, indexed-repeat 1st, 2nd, 4th, and 6th argument is using absolute path",
             md="""
                 | survey  |                |                |                                  |                                                             |
-                |         | type           | name           | label                            | default                                                     |
+                |         | type           | name           | label                            | relevant                                                    |
                 |         | begin_repeat   | family         | Family                           |                                                             |
                 |         | integer        | members_number | How many members in this family? |                                                             |
                 |         | begin_repeat   | person         | Person                           |                                                             |
@@ -585,6 +607,6 @@ class TestRepeat(PyxformTestCase):
                 |         | end repeat     |                |                                  |                                                             |
             """,  # noqa pylint: disable=line-too-long
             xml__contains=[
-                """<setvalue event="odk-instance-first-load odk-new-repeat" ref="/data/family/person/prev_name" value=" ../age  &gt; indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2)"/>"""  # noqa pylint: disable=line-too-long
+                """<bind nodeset="/data/family/person/prev_name" relevant=" ../age  &gt; indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2)" type="string"/>"""  # noqa pylint: disable=line-too-long
             ],
         )


### PR DESCRIPTION
…rgument not using relative path.

Closes #
Fix #484 
#### Why is this the best possible solution? Were any other approaches considered?
The one that works and passed tests.
#### What are the regression risks?
All tests passed, including new ones.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No
#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments