### PR TITLE
Prevent untyped calculates from being used as calculation triggers

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -32,7 +32,9 @@ class Question(SurveyElement):
         return node(self.name, **attributes)
 
     def xml_control(self):
-        if ("calculate" in self.bind or self.trigger) and not (self.label or self.hint):
+        if self.type == "calculate" or (
+            ("calculate" in self.bind or self.trigger) and not (self.label or self.hint)
+        ):
             nested_setvalues = self.get_root().get_setvalues_for_question_name(
                 self.name
             )

--- a/pyxform/tests_v1/test_trigger.py
+++ b/pyxform/tests_v1/test_trigger.py
@@ -174,6 +174,21 @@ class TriggerSetvalueTests(PyxformTestCase):
             ],
         )
 
+    def test_when_trigger_refers_to_calculate_with_label_error_is_shown(self):
+        self.assertPyxformXform(
+            name="trigger-invalid-ref",
+            md="""
+            | survey |           |        |                      |         |             |
+            |        | type      | name   | label                | trigger | calculation |
+            |        | calculate | one    | A label              |         | 5 + 4       |
+            |        | calculate | one-ts |                      | ${one}  | now()       |
+            """,
+            errored=True,
+            error__contains=[
+                "The question ${one} is not user-visible so it can't be used as a calculation trigger for question ${one-ts}.",
+            ],
+        )
+
     def test_typed_calculate_cant_be_trigger(self):
         self.assertPyxformXform(
             name="trigger-invalid-ref",


### PR DESCRIPTION
Closes #486

@gushil I took this on to hopefully give you a little extra time for #485. I think you're best positioned to see if there's a way to make it a little easier to work with. I should hopefully also have a bit of time for it tomorrow.

#### Why is this the best possible solution? Were any other approaches considered?
I didn't consider any alternatives. This extends the existing logic to treat any question with a `calculate` type as ineligible to be a calculation trigger.

#### What are the regression risks?
The only change is to the logic that for a given question suppresses body tags and produces an error if it's used as a trigger. The worst case would be if this adds cases that are actually suppose to lead to body elements

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments