### PR TITLE
Add warning for images without max-pixel

### DIFF
--- a/pyxform/tests/xlsform_spec_test.py
+++ b/pyxform/tests/xlsform_spec_test.py
@@ -100,7 +100,7 @@ class WarningsTest(unittest.TestCase):
             path_to_excel_file, default_name="warnings", warnings=warnings
         )
         self.assertEquals(
-            len(warnings), 21, "Found " + str(len(warnings)) + " warnings"
+            len(warnings), 22, "Found " + str(len(warnings)) + " warnings"
         )
 
 

--- a/pyxform/tests_v1/test_max_pixels.py
+++ b/pyxform/tests_v1/test_max_pixels.py
@@ -49,3 +49,19 @@ class MaxPixelsTest(PyxformTestCase):
                 "Accepted parameters are 'max-pixels': 'foo' is an invalid parameter."
             ],
         )
+
+    def test_image_with_no_max_pixels_should_warn(self):
+        warnings = []
+
+        self.md_to_pyxform_survey(
+            """
+            | survey |       |            |         |
+            |        | type  | name       | label   |
+            |        | image | my_image   | Image   |
+            |        | image | my_image_1 | Image 1 |
+            """,
+            warnings=warnings,
+        )
+
+        self.assertTrue(len(warnings) == 2)
+        self.assertTrue("max-pixels" in warnings[0] and "max-pixels" in warnings[1])

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1280,6 +1280,11 @@ def workbook_to_json(
 
                 new_dict["bind"] = new_dict.get("bind", {})
                 new_dict["bind"].update({"orx:max-pixels": parameters["max-pixels"]})
+            else:
+                warnings.append(
+                    (row_format_string % row_number)
+                    + " Use the max-pixels parameter to speed up sending and save storage space. Learn more: https://xlsform.org/#image"
+                )
             parent_children_array.append(new_dict)
             continue
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -512,7 +512,7 @@ def workbook_to_json(
                                 "The name column for the '{}' choice list contains these duplicates: {}. Duplicate names "
                                 "will be impossible to identify in analysis unless a previous value in a cascading "
                                 "select differentiates them. If this is intentional, you can set the "
-                                "allow_choice_duplicates setting to 'yes'. Read more: https://xlsform.org/#choice-names.".format(
+                                "allow_choice_duplicates setting to 'yes'. Learn more: https://xlsform.org/#choice-names.".format(
                                     list_name,
                                     ", ".join(
                                         [


### PR DESCRIPTION
Closes #475

#### Why is this the best possible solution? Were any other approaches considered?
It's the narrowest change. I used the shortest possible warning to make it easier to read.

Note there is one unrelated commit to make the Learn/read more consistent throughout pyxform.

#### What are the regression risks?
None that I can think of. It's just a warning. If you have a lot of images, you could get a lot of these warnings. I toyed with the idea of de-duping it so you only get one generic one, but I think row numbers are more helpful.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [X] included test cases for core behavior and edge cases in `tests_v1`
- [X] run `nosetests` and verified all tests pass
- [X] run `black pyxform` to format code
- [X] verified that any code or assets from external sources are properly credited in comments