### PR TITLE
Clearer message for max-pixels warning

### DIFF
--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1283,7 +1283,7 @@ def workbook_to_json(
             else:
                 warnings.append(
                     (row_format_string % row_number)
-                    + " Use the max-pixels parameter to speed up sending and save storage space. Learn more: https://xlsform.org/#image"
+                    + " Use the max-pixels parameter to speed up submission sending and save storage space. Learn more: https://xlsform.org/#image"
                 )
             parent_children_array.append(new_dict)
             continue


### PR DESCRIPTION
I'm not sure I love the existing message because it's not clear to the form designer what "sending" refers to. We could replace "sending" with...
* "form sending" (matches language in Collect)
* "image uploads/uploading" (matches form design data type)