### PR TITLE
Use same versions as requirements.pip to prevent unexpected upgrades …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ pyxform - Python library that converts XLSForms to XForms.
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "xlrd>=1.1.0",
-    "unicodecsv>=0.14.1",
-    "formencode",
-    "unittest2",
+    "xlrd==1.2.0",
+    "unicodecsv==0.14.1",
+    "formencode==1.3.1",
+    "unittest2==1.1.0",
     'functools32==3.2.3.post2 ; python_version < "3.2"',
 ]
 


### PR DESCRIPTION
I noticed in https://github.com/getodk/pyxform-http that we getting at "Error reading .xls file: Excel xlsx file; not supported" error when uploading an xlsx file. This only happened with our Docker build, not with our local pip build.

It seems that our Docker build's pip install runs `setup.py` which has a different version rules than `requirements.in`. The former allows `xlrd>=1.1.0` which is dangerous because it means we can allow major version changes (and thus breaking behavior). In our case, our Docker build used xlrd v2.0 which doesn't support xlsx files.

This PR is a narrow change that changes `setup.py`'s version behavior to match `requirements.in`.