### PR TITLE
Release v1.3.4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,8 +5,10 @@ Pyxform Changelog
 
 * #510 Show a more helpful error message is section name is equal to form name
   * Agus Hilman @gushil (OpenClinica)
+* #507 Fixed KeyError that occurs with some dynamic default expressions
+  * Agus Hilman @gushil (OpenClinica)
 * #484 Use absolute path for first argument in indexed-repeat() output 
-   * Agus Hilman @gushil (OpenClinica)
+  * Agus Hilman @gushil (OpenClinica)
 
 # v1.3.3, 2020-12-17
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,13 @@
 Pyxform Changelog
 
+
+# v1.3.4, 2021-01-15
+
+* #510 Show a more helpful error message is section name is equal to form name
+  * Agus Hilman @gushil (OpenClinica)
+* #484 Use absolute path for first argument in indexed-repeat() output 
+   * Agus Hilman @gushil (OpenClinica)
+
 # v1.3.3, 2020-12-17
 
 * #500 Use same versions as requirements.pip to prevent unexpected upgrades

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ===============
-pyxform v1.3.3
+pyxform v1.3.4
 ===============
 
 |circleci|  |appveyor| |codecov| |black|
@@ -121,7 +121,7 @@ Releasing pyxform
 
     pyxform_validator_update odk update ODK-Validate-vx.x.x.jar
 
-2. Run all tests through Validate by setting the default for ``run_odk_validate`` to ``kwargs.get("run_odk_validate", True)`` in ``pyxform_test_case``.
+2. Run all tests through Validate by setting the default for ``run_odk_validate`` to ``kwargs.get("run_odk_validate", True)`` in ``pyxform/tests_v1/pyxform_test_case.py``.
 3. Draft a new GitHub release with the list of merged PRs. Follow the title and description pattern of the previous release.
 4. Checkout a release branch from latest upstream master.
 5. Update ``CHANGES.txt`` with the text of the draft release.

--- a/pyxform/__init__.py
+++ b/pyxform/__init__.py
@@ -4,7 +4,7 @@ pyxform is a Python library designed to make authoring XForms for ODK
 Collect easy.
 """
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 from pyxform.builder import (
     SurveyElementBuilder,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ REQUIRES = [
 
 setup(
     name="pyxform",
-    version="1.3.3",
+    version="1.3.4",
     author="github.com/xlsform",
     author_email="info@xlsform.org",
     packages=find_packages(),


### PR DESCRIPTION
I noticed there are 10 failing ODK Validate tests (step 2 of release steps), but that was the case in the previous version as well, and I'm guessing may have been the case for much longer. Are we just ignoring this?