### PR TITLE
Fix error encountered while converting multi-language XLSForms to JSON

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -219,6 +219,19 @@ class SurveyElement(dict):
         else:
             return lineage[0].name
 
+    def _delete_keys_from_dict(self, dictionary: dict, keys: list):
+        """
+        Deletes a list of keys from a dictionary.
+        Credits: https://stackoverflow.com/a/49723101
+        """
+        for key in keys:
+            if key in dictionary:
+                del dictionary[key]
+
+        for value in dictionary.values():
+            if isinstance(value, dict):
+                self._delete_keys_from_dict(value, keys)
+
     def to_json_dict(self):
         """
         Create a dict copy of this survey element by removing inappropriate
@@ -227,9 +240,9 @@ class SurveyElement(dict):
         self.validate()
         result = self.copy()
         to_delete = ["parent", "question_type_dictionary", "_created"]
-        for key in to_delete:
-            if key in result:
-                del result[key]
+        # Delete all keys that may cause a "Circular Reference"
+        # error while converting the result to JSON
+        self._delete_keys_from_dict(result, to_delete)
         children = result.pop("children")
         result["children"] = []
         for child in children:

--- a/pyxform/tests/xform2json_test.py
+++ b/pyxform/tests/xform2json_test.py
@@ -3,12 +3,11 @@
 Test xform2json module.
 """
 import os
-import json
 from xml.etree.ElementTree import ParseError
 
 from unittest2 import TestCase
 
-from pyxform.builder import create_survey_element_from_dict, create_survey_from_path
+from pyxform.builder import create_survey_from_path
 from pyxform.tests import utils
 from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 from pyxform.xform2json import _try_parse, create_survey_element_from_xml
@@ -51,35 +50,6 @@ class DumpAndLoadXForm2JsonTests(utils.XFormTestCase, PyxformTestCase):
             path = survey.name + ".json"
             if os.path.exists(path):
                 os.remove(path)
-
-    def test_convert_toJSON_multi_language(self):
-        """
-        Test that it's possible to convert XLSForms with multiple languages
-        to JSON and back into XML without losing any of the required information
-        """
-        md = """
-        | survey  |
-        |         | type                   | name  | label:Eng  | label:Fr |
-        |         | text                   | name  | Name       | Prénom   |
-        |         | select_multiple fruits | fruit | Fruit      | Fruit    |
-        |         |                        |       |            |          |
-        | choices | list name              | name  | label:Eng  | label:Fr |
-        |         | fruits                 | 1     | Mango      | Mangue   |
-        |         | fruits                 | 2     | Orange     | Orange   |
-        |         | fruits                 | 3     | Apple      | Pomme    |
-        """
-
-        survey = self.md_to_pyxform_survey(
-            md_raw=md,
-            kwargs={"id_string": "id", "name": "multi-language", "title": "some-title"},
-            autoname=False,
-        )
-        expected_xml = survey.to_xml()
-        generated_json = survey.to_json()
-
-        survey = create_survey_element_from_dict(json.loads(generated_json))
-
-        self.assertEqual(expected_xml, survey.to_xml())
 
 
 class TestXMLParse(TestCase):

--- a/pyxform/tests/xform2json_test.py
+++ b/pyxform/tests/xform2json_test.py
@@ -3,16 +3,18 @@
 Test xform2json module.
 """
 import os
+import json
 from xml.etree.ElementTree import ParseError
 
 from unittest2 import TestCase
 
-from pyxform.builder import create_survey_from_path
+from pyxform.builder import create_survey_element_from_dict, create_survey_from_path
 from pyxform.tests import utils
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 from pyxform.xform2json import _try_parse, create_survey_element_from_xml
 
 
-class DumpAndLoadXForm2JsonTests(utils.XFormTestCase):
+class DumpAndLoadXForm2JsonTests(utils.XFormTestCase, PyxformTestCase):
 
     maxDiff = None
 
@@ -49,6 +51,35 @@ class DumpAndLoadXForm2JsonTests(utils.XFormTestCase):
             path = survey.name + ".json"
             if os.path.exists(path):
                 os.remove(path)
+
+    def test_convert_toJSON_multi_language(self):
+        """
+        Test that it's possible to convert XLSForms with multiple languages
+        to JSON and back into XML without losing any of the required information
+        """
+        md = """
+        | survey  |
+        |         | type                   | name  | label:Eng  | label:Fr |
+        |         | text                   | name  | Name       | Prénom   |
+        |         | select_multiple fruits | fruit | Fruit      | Fruit    |
+        |         |                        |       |            |          |
+        | choices | list name              | name  | label:Eng  | label:Fr |
+        |         | fruits                 | 1     | Mango      | Mangue   |
+        |         | fruits                 | 2     | Orange     | Orange   |
+        |         | fruits                 | 3     | Apple      | Pomme    |
+        """
+
+        survey = self.md_to_pyxform_survey(
+            md_raw=md,
+            kwargs={"id_string": "id", "name": "multi-language", "title": "some-title"},
+            autoname=False,
+        )
+        expected_xml = survey.to_xml()
+        generated_json = survey.to_json()
+
+        survey = create_survey_element_from_dict(json.loads(generated_json))
+
+        self.assertEqual(expected_xml, survey.to_xml())
 
 
 class TestXMLParse(TestCase):

--- a/pyxform/tests_v1/test_xform2json.py
+++ b/pyxform/tests_v1/test_xform2json.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+Test XForm2JSON functionality
+"""
+import json
+
+from pyxform.builder import create_survey_element_from_dict
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class TestXForm2JSON(PyxformTestCase):
+    """
+    Test xform2json module
+    """
+
+    def test_convert_toJSON_multi_language(self):
+        """
+        Test that it's possible to convert XLSForms with multiple languages
+        to JSON and back into XML without losing any of the required information
+        """
+        md = """
+        | survey  |
+        |         | type                   | name  | label:Eng  | label:Fr |
+        |         | text                   | name  | Name       | Prénom   |
+        |         | select_multiple fruits | fruit | Fruit      | Fruit    |
+        |         |                        |       |            |          |
+        | choices | list name              | name  | label:Eng  | label:Fr |
+        |         | fruits                 | 1     | Mango      | Mangue   |
+        |         | fruits                 | 2     | Orange     | Orange   |
+        |         | fruits                 | 3     | Apple      | Pomme    |
+        """
+
+        survey = self.md_to_pyxform_survey(
+            md_raw=md,
+            kwargs={"id_string": "id", "name": "multi-language", "title": "some-title"},
+            autoname=False,
+        )
+        expected_xml = survey.to_xml()
+        generated_json = survey.to_json()
+
+        survey = create_survey_element_from_dict(json.loads(generated_json))
+
+        self.assertEqual(expected_xml, survey.to_xml())


### PR DESCRIPTION
Closes #513

#### Why is this the best possible solution? Were any other approaches considered?

The simplest option removes objects that can't be converted to JSON.

#### What are the regression risks?

- N/A

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments