### PR TITLE
Use itext for dynamic selects with dynamic labels

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -8,7 +8,14 @@ import re
 from pyxform.errors import PyXFormError
 from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
 from pyxform.survey_element import SurveyElement
-from pyxform.utils import basestring, node, unicode, default_is_dynamic
+from pyxform.utils import (
+    basestring,
+    node,
+    unicode,
+    default_is_dynamic,
+    BRACKETED_TAG_REGEX,
+    has_dynamic_label,
+)
 
 
 class Question(SurveyElement):
@@ -212,7 +219,11 @@ class MultipleChoiceQuestion(Question):
                 itemset = itemset
                 itemset_label_ref = "label"
             else:
-                if not multi_language and not has_media:
+                if (
+                    not multi_language
+                    and not has_media
+                    and not has_dynamic_label(choices[itemset], multi_language)
+                ):
                     itemset = self["itemset"]
                     itemset_label_ref = "label"
                 else:

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -210,20 +210,18 @@ class MultipleChoiceQuestion(Question):
             itemset_value_ref = "name"
             itemset, file_extension = os.path.splitext(self["itemset"])
             has_media = False
+            has_dyn_label = False
             is_previous_question = bool(re.match(r"^\${.*}$", self.get("itemset")))
 
             if choices.get(itemset):
                 has_media = bool(choices[itemset][0].get("media"))
+                has_dyn_label = has_dynamic_label(choices[itemset], multi_language)
 
             if file_extension in [".csv", ".xml"]:
                 itemset = itemset
                 itemset_label_ref = "label"
             else:
-                if (
-                    not multi_language
-                    and not has_media
-                    and not has_dynamic_label(choices[itemset], multi_language)
-                ):
+                if not multi_language and not has_media and not has_dyn_label:
                     itemset = self["itemset"]
                     itemset_label_ref = "label"
                 else:

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -17,6 +17,7 @@ from pyxform.utils import (
     BRACKETED_TAG_REGEX,
     LAST_SAVED_REGEX,
     LAST_SAVED_INSTANCE_NAME,
+    has_dynamic_label,
 )
 from pyxform.errors import PyXFormError, ValidationError
 from pyxform.external_instance import ExternalInstance
@@ -270,11 +271,16 @@ class Survey(Section):
         instance_element_list = []
         multi_language = isinstance(choice_list[0].get("label"), dict)
         has_media = bool(choice_list[0].get("media"))
+
         for idx, choice in enumerate(choice_list):
             choice_element_list = []
             # Add a unique id to the choice element in case there is itext
             # it references
-            if multi_language or has_media:
+            if (
+                multi_language
+                or has_media
+                or has_dynamic_label(choice_list, multi_language)
+            ):
                 itext_id = "-".join([list_name, str(idx)])
                 choice_element_list.append(node("itextId", itext_id))
 
@@ -663,7 +669,11 @@ class Survey(Section):
         for list_name, choice_list in self.choices.items():
             multi_language = isinstance(choice_list[0].get("label"), dict)
             has_media = bool(choice_list[0].get("media"))
-            if not multi_language and not has_media:
+            if (
+                not multi_language
+                and not has_media
+                and not has_dynamic_label(choice_list, multi_language)
+            ):
                 continue
             for idx, choice in zip(range(len(choice_list)), choice_list):
                 for name, choice_value in choice.items():

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -289,6 +289,8 @@ class Survey(Section):
                     choice_element_list.append(node(name, unicode(value)))
                 if (
                     not multi_language
+                    and not has_media
+                    and not has_dynamic_label(choice_list, multi_language)
                     and isinstance(value, basestring)
                     and name == "label"
                 ):

--- a/pyxform/tests_v1/test_inline_translations.py
+++ b/pyxform/tests_v1/test_inline_translations.py
@@ -146,3 +146,67 @@ class InlineTranslationsTest(PyxformTestCase):
                 '<text id="/data/foo/c:label">',
             ],
         )
+
+    def test_select_with_dynamic_option_label__and_choice_filter__and_no_translations__generates_itext(
+        self,
+    ):
+        """
+        A select with a choice filter and no translations in which the first option label is dynamic should generate itext for choice labels.
+        """
+        xform_md = """
+            | survey |                    |      |            |               |         |
+            |        | type               | name | label      | choice_filter | default |
+            |        | text               | txt  | Enter text |               | default |
+            |        | select_one choices | one  | Select one | 1 < 2         |         |
+            | choices |
+            |         | list_name | name | label        |
+            |         | choices   | one  | One - ${txt} |
+            """
+        self.assertPyxformXform(
+            name="data",
+            md=xform_md,
+            debug=False,
+            itext__contains=[
+                '<text id="choices-0">',
+                '<value> One - <output value=" /data/txt "/>',
+            ],
+            model__contains=["<itextId>choices-0</itextId>", "<name>one</name>",],
+            xml__contains=['<label ref="jr:itext(itextId)"/>'],
+            xml__excludes=['<label ref="label"/>'],
+        )
+
+    def test_select_with_dynamic_option_label_for_second_choice__and_choice_filter__and_no_translations__generates_itext(
+        self,
+    ):
+        """
+        A select with a choice filter and no translations in which the second option label is dynamic should generate itext for choice labels.
+        """
+        xform_md = """
+            | survey |                    |      |            |               |         |
+            |        | type               | name | label      | choice_filter | default |
+            |        | text               | txt  | Enter text |               | default |
+            |        | select_one choices | one  | Select one | 1 < 2         |         |
+            | choices |
+            |         | list_name | name | label        |
+            |         | choices   | one  | One          |
+            |         | choices   | two  | Two - ${txt} |
+            """
+        self.assertPyxformXform(
+            name="data",
+            md=xform_md,
+            debug=False,
+            itext__contains=[
+                '<text id="choices-0">',
+                "<value>One</value>",
+                '<text id="choices-1">',
+                '<value> Two - <output value=" /data/txt "/>',
+            ],
+            model__contains=[
+                "<itextId>choices-0</itextId>",
+                "<name>one</name>",
+                "<itextId>choices-1</itextId>",
+                "<name>two</name>",
+            ],
+            xml__contains=['<label ref="jr:itext(itextId)"/>'],
+            xml__excludes=['<label ref="label"/>'],
+        )

--- a/pyxform/tests_v1/test_inline_translations.py
+++ b/pyxform/tests_v1/test_inline_translations.py
@@ -98,7 +98,6 @@ class InlineTranslationsTest(PyxformTestCase):
             id_string="some-id",
             md=xform_md,
             errored=False,
-            debug=False,
             model__contains=[
                 '<text id="mood-0">',
                 '<text id="mood-1">',
@@ -110,7 +109,7 @@ class InlineTranslationsTest(PyxformTestCase):
                 '<text id="/data/enumerator_mood/s:label">',
             ],
             xml__contains=['<label ref="jr:itext(itextId)"/>'],
-            xml__excludes=['<label ref="label"/>'],
+            xml__excludes=['<label ref="label"/>', "<label>Happy</label>"],
         )
 
     def test_select_with_choice_filter_and_translations_generates_single_translation(
@@ -172,7 +171,7 @@ class InlineTranslationsTest(PyxformTestCase):
             ],
             model__contains=["<itextId>choices-0</itextId>", "<name>one</name>",],
             xml__contains=['<label ref="jr:itext(itextId)"/>'],
-            xml__excludes=['<label ref="label"/>'],
+            xml__excludes=['<label ref="label"/>', "<label>One - ${txt}</label>"],
         )
 
     def test_select_with_dynamic_option_label_for_second_choice__and_choice_filter__and_no_translations__generates_itext(
@@ -194,7 +193,6 @@ class InlineTranslationsTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md=xform_md,
-            debug=False,
             itext__contains=[
                 '<text id="choices-0">',
                 "<value>One</value>",
@@ -208,5 +206,24 @@ class InlineTranslationsTest(PyxformTestCase):
                 "<name>two</name>",
             ],
             xml__contains=['<label ref="jr:itext(itextId)"/>'],
-            xml__excludes=['<label ref="label"/>'],
+            xml__excludes=['<label ref="label"/>', "<label>One</label>"],
+        )
+
+    def test_select_with_dynamic_option_label__and_choice_filter__and_no_translations__maintains_additional_columns(
+        self,
+    ):
+        """
+        A select with a choice filter and no translations in which the first option label is dynamic should maintain data columns.
+        """
+        xform_md = """
+            | survey |                    |      |            |               |         |
+            |        | type               | name | label      | choice_filter | default |
+            |        | text               | txt  | Enter text |               | default |
+            |        | select_one choices | one  | Select one | 1 < 2         |         |
+            | choices |
+            |         | list_name | name | label        | foo |
+            |         | choices   | one  | One - ${txt} | baz |
+            """
+        self.assertPyxformXform(
+            name="data", md=xform_md, model__contains=["<foo>baz</foo>"],
         )

--- a/pyxform/tests_v1/test_secondary_instance_translations.py
+++ b/pyxform/tests_v1/test_secondary_instance_translations.py
@@ -5,7 +5,7 @@ Testing inlining translation when no translation is specified.
 from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 
 
-class InlineTranslationsTest(PyxformTestCase):
+class TestSecondaryInstanceTest(PyxformTestCase):
     def test_inline_translations(self):
         """
         Dynamic choice (marked with choice filter) should inline the labels instead of using
@@ -226,4 +226,25 @@ class InlineTranslationsTest(PyxformTestCase):
             """
         self.assertPyxformXform(
             name="data", md=xform_md, model__contains=["<foo>baz</foo>"],
+        )
+
+    def test_select_with_dynamic_option_label__and_no_choice_filter__and_no_translations__inlines_output(
+        self,
+    ):
+        """
+        A select without a choice filter and no translations in which the first option label is dynamic should not use itext.
+        """
+        xform_md = """
+            | survey |                    |      |            |
+            |        | type               | name | label      |
+            |        | text               | txt  | Text       |
+            |        | select_one choices | one  | Select one |
+            | choices |
+            |         | list_name | name | label        |
+            |         | choices   | one  | One - ${txt} |
+            """
+        self.assertPyxformXform(
+            name="data",
+            md=xform_md,
+            xml__contains=['<label> One - <output value=" /data/txt "/> </label>'],
         )

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -271,3 +271,12 @@ def default_is_dynamic(element_default, element_type=None):
         dynamic_markers.remove("-")
 
     return any(s in element_default for s in dynamic_markers)
+
+
+# If the first or second choice label includes a reference, we must use itext. Check the first two choices in case first is something like "Other".
+def has_dynamic_label(choice_list, multi_language):
+    if not multi_language:
+        for i in range(0, min(2, len(choice_list))):
+            if re.search(BRACKETED_TAG_REGEX, choice_list[i].get("label")) is not None:
+                return True
+    return False


### PR DESCRIPTION
Closes #515

#### Why is this the best possible solution? Were any other approaches considered?
This is a simplification of #518. I aimed to have a single function that identifies the dynamic label case and to make sure that the checks on conditions for using `itext` are easily readable. I considered seeing if we could avoid the redundancy between those checks but that felt too involved for the moment. 

#### What are the regression risks?
I don't think there's a risk of degraded user experience. I think the worst case would be that we might be generating `itext` too often now but that would generally be safe.

Another risk is related to behavior I changed for consistency that affects selects from itemsets with media. Previously, both `itext` and `label` children were generated in the secondary instance. This is unnecessary but I can imagine some downstream analysis tools or servers relying on it. I think it's clearly better to omit so I think it's ok.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
It would be good to explicitly mention that we can use references for labels but not for names or other columns. I've filed https://github.com/getodk/docs/issues/1329. I'm not sure it fits in to xlsform.org.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments