### PR TITLE
Add support for csv-external

### DIFF
--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -115,7 +115,7 @@ class SurveyElementBuilder(object):
             d = self._sections[section_name]
             full_survey = self.create_survey_element_from_dict(d)
             return full_survey.children
-        elif d["type"] == "xml-external":
+        elif d["type"] in ["xml-external", "csv-external"]:
             return ExternalInstance(**d)
         else:
             self._save_trigger_as_setvalue_and_remove_calculate(d)

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -369,6 +369,9 @@ QUESTION_TYPE_DICT = {
     "xml-external": {
         # Only effect is to add an external instance.
     },
+    "csv-external": {
+        # Only effect is to add an external instance.
+    },
     "start-geopoint": {
         "control": {"tag": "action"},
         "bind": {"type": "geopoint"},

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -312,7 +312,8 @@ class Survey(Section):
     def _generate_external_instances(element):
         if isinstance(element, ExternalInstance):
             name = element["name"]
-            src = "jr://file/{}.xml".format(name)
+            extension = element["type"].split("-")[0]
+            src = "jr://file/{}.{}".format(name, extension)
             return InstanceInfo(
                 type="external",
                 context="[type: {t}, name: {n}]".format(

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -313,7 +313,8 @@ class Survey(Section):
         if isinstance(element, ExternalInstance):
             name = element["name"]
             extension = element["type"].split("-")[0]
-            src = "jr://file/{}.{}".format(name, extension)
+            prefix = "file-csv" if extension == "csv" else "file"
+            src = "jr://{}/{}.{}".format(prefix, name, extension)
             return InstanceInfo(
                 type="external",
                 context="[type: {t}, name: {n}]".format(

--- a/pyxform/tests_v1/test_external_instances.py
+++ b/pyxform/tests_v1/test_external_instances.py
@@ -32,9 +32,7 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | type         | name   | label |
             |        | csv-external | mydata |       |
             """,
-            model__contains=[
-                '<instance id="mydata" src="jr://file/mydata.csv"/>'
-            ],
+            model__contains=['<instance id="mydata" src="jr://file/mydata.csv"/>'],
         )
 
     def test_cannot__use_same_external_xml_id_in_same_section(self):
@@ -182,6 +180,7 @@ class ExternalInstanceTests(PyxformTestCase):
             | survey |                                      |      |       |                                             |
             |        | type                                 | name | label | calculation                                 |
             |        | begin group                          | g1   |       |                                             |
+            |        | text                                 | foo  | Foo   |                                             |
             |        | csv-external                         | city |       |                                             |
             |        | end group                            | g1   |       |                                             |
             |        | begin group                          | g2   |       |                                             |
@@ -191,12 +190,11 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | select_multiple_from_file cities.csv | city | City  |                                             |
             |        | end group                            | g3   |       |                                             |
             |        | begin group                          | g4   |       |                                             |
+            |        | text                                 | foo  | Foo   |                                             |
             |        | calculate                            | city | City  | pulldata('fruits', 'name', 'name', 'mango') |
             |        | end group                            | g4   |       |                                             |
             """,  # noqa
-            model__contains=[
-                '<instance id="city" src="jr://file/city.csv"/>',
-            ]
+            model__contains=['<instance id="city" src="jr://file/city.csv"/>',],
         )
 
     def test_can__use_all_types_together_with_unique_ids(self):
@@ -332,9 +330,7 @@ class ExternalInstanceTests(PyxformTestCase):
         expected = """
       <instance id="pain_locations" src="jr://file-csv/pain_locations.csv"/>
 """  # noqa
-        self.assertPyxformXform(
-            md=md, model__contains=[expected]
-        )
+        self.assertPyxformXform(md=md, model__contains=[expected])
         survey = self.md_to_pyxform_survey(md_raw=md)
         xml = survey._to_pretty_xml()
         self.assertEqual(1, xml.count(expected))
@@ -352,9 +348,7 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | select_one_from_file pain_locations.csv      | pyear  | Location of worst pain this year.  |                                                   |
             """  # noqa
         expected = """<instance id="pain_locations" src="jr://file-csv/pain_locations.csv"/>"""  # noqa
-        self.assertPyxformXform(
-            md=md, model__contains=[expected]
-        )
+        self.assertPyxformXform(md=md, model__contains=[expected])
 
     def test_can__reuse_xml__selects_then_external(self):
         """Re-using the same xml external data source id and URI is OK."""
@@ -386,9 +380,7 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | select_one_from_file pain_locations.xml      | pyear          | Location of worst pain this year.  |
             """  # noqa
         expected = """<instance id="pain_locations" src="jr://file/pain_locations.xml"/>"""  # noqa
-        self.assertPyxformXform(
-            md=md, model__contains=[expected]
-        )
+        self.assertPyxformXform(md=md, model__contains=[expected])
         survey = self.md_to_pyxform_survey(md_raw=md)
         xml = survey._to_pretty_xml()
         self.assertEqual(1, xml.count(expected))
@@ -428,7 +420,11 @@ class ExternalInstanceTests(PyxformTestCase):
         """
         node = """<instance id="ID" src="jr://file-csv/ID.csv"/>"""
 
-        self.assertPyxformXform(md=md, xml__contains=[node])
+        self.assertPyxformXform(
+            md=md,
+            xml__contains=[node],
+            run_odk_validate=False,  # Validate sees self references in readonly as circular but shouldn't
+        )
 
     def test_external_instance_pulldata_required(self):
         """
@@ -441,7 +437,11 @@ class ExternalInstanceTests(PyxformTestCase):
         |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
         """
         node = """<instance id="ID" src="jr://file-csv/ID.csv"/>"""
-        self.assertPyxformXform(md=md, xml__contains=[node], debug=False)
+        self.assertPyxformXform(
+            md=md,
+            xml__contains=[node],
+            run_odk_validate=False,  # Validate sees self references in requireds as circular but shouldn't
+        )
 
     def test_external_instance_pulldata_relevant(self):
         """
@@ -454,7 +454,11 @@ class ExternalInstanceTests(PyxformTestCase):
         |        | text   | Part_ID | Participant ID | pulldata('ID', 'ParticipantID', 'ParticipantIDValue',.) |
         """
         node = """<instance id="ID" src="jr://file-csv/ID.csv"/>"""
-        self.assertPyxformXform(md=md, xml__contains=[node], debug=False)
+        self.assertPyxformXform(
+            md=md,
+            xml__contains=[node],
+            run_odk_validate=False,  # Validate sees self references in relevants as circular but shouldn't
+        )
 
     # This is not something that is recommended since pulldata and choice_filter both should use XPath predicates
     # behind the scenes but it should still be possible.

--- a/pyxform/tests_v1/test_external_instances.py
+++ b/pyxform/tests_v1/test_external_instances.py
@@ -32,7 +32,7 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | type         | name   | label |
             |        | csv-external | mydata |       |
             """,
-            model__contains=['<instance id="mydata" src="jr://file/mydata.csv"/>'],
+            model__contains=['<instance id="mydata" src="jr://file-csv/mydata.csv"/>'],
         )
 
     def test_cannot__use_same_external_xml_id_in_same_section(self):
@@ -78,8 +78,8 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | csv-external | mydata2 |       |
             """,
             model__contains=[
-                '<instance id="mydata" src="jr://file/mydata.csv"/>',
-                '<instance id="mydata2" src="jr://file/mydata2.csv"/>',
+                '<instance id="mydata" src="jr://file-csv/mydata.csv"/>',
+                '<instance id="mydata2" src="jr://file-csv/mydata2.csv"/>',
             ],
         )
 
@@ -194,7 +194,7 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | calculate                            | city | City  | pulldata('fruits', 'name', 'name', 'mango') |
             |        | end group                            | g4   |       |                                             |
             """,  # noqa
-            model__contains=['<instance id="city" src="jr://file/city.csv"/>',],
+            model__contains=['<instance id="city" src="jr://file-csv/city.csv"/>'],
         )
 
     def test_can__use_all_types_together_with_unique_ids(self):

--- a/pyxform/tests_v1/test_external_instances.py
+++ b/pyxform/tests_v1/test_external_instances.py
@@ -2,7 +2,7 @@
 """
 Test xml-external syntax and instances generated from pulldata calls.
 
-See also test_support_external_instances
+See also test_external_instances_for_selects
 """
 from pyxform.errors import PyXFormError
 from pyxform.tests_v1.pyxform_test_case import PyxformTestCase, PyxformTestError
@@ -22,7 +22,19 @@ class ExternalInstanceTests(PyxformTestCase):
             |        | xml-external | mydata |       |
             """,
             model__contains=['<instance id="mydata" src="jr://file/mydata.xml"/>'],
-            run_odk_validate=True,
+        )
+
+    def test_can__output_single_external_csv_item(self):
+        """Simplest possible example to include an external instance."""
+        self.assertPyxformXform(
+            md="""
+            | survey |              |        |       |
+            |        | type         | name   | label |
+            |        | csv-external | mydata |       |
+            """,
+            model__contains=[
+                '<instance id="mydata" src="jr://file/mydata.csv"/>'
+            ],
         )
 
     def test_cannot__use_same_external_xml_id_in_same_section(self):
@@ -56,7 +68,21 @@ class ExternalInstanceTests(PyxformTestCase):
                 '<instance id="mydata" src="jr://file/mydata.xml"/>',
                 '<instance id="mydata2" src="jr://file/mydata2.xml"/>',
             ],
-            run_odk_validate=True,
+        )
+
+    def test_can__use_unique_external_csv_in_same_section(self):
+        """Two unique external instances in the same section is OK."""
+        self.assertPyxformXform(
+            md="""
+            | survey |              |         |       |
+            |        | type         | name    | label |
+            |        | csv-external | mydata  |       |
+            |        | csv-external | mydata2 |       |
+            """,
+            model__contains=[
+                '<instance id="mydata" src="jr://file/mydata.csv"/>',
+                '<instance id="mydata2" src="jr://file/mydata2.csv"/>',
+            ],
         )
 
     def test_cannot__use_same_external_xml_id_across_groups(self):
@@ -78,6 +104,23 @@ class ExternalInstanceTests(PyxformTestCase):
             )
         self.assertIn("Instance names must be unique", repr(ctx.exception))
         self.assertIn("The name 'mydata' was found 3 time(s)", repr(ctx.exception))
+
+    def test_cannot__use_external_xml_and_csv_with_same_filename(self):
+        """Duplicate external instances anywhere raises an error."""
+        with self.assertRaises(PyxformTestError) as ctx:
+            self.assertPyxformXform(
+                md="""
+                | survey |              |        |       |
+                |        | type         | name   | label |
+                |        | csv-external | mydata |       |
+                |        | begin group  | g1     |       |
+                |        | xml-external | mydata |       |
+                |        | end group    | g1     |       |
+                """,
+                model__contains=[],
+            )
+        self.assertIn("Instance names must be unique", repr(ctx.exception))
+        self.assertIn("The name 'mydata' was found 2 time(s)", repr(ctx.exception))
 
     def test_can__use_unique_external_xml_across_groups(self):
         """Unique external instances anywhere is OK."""
@@ -105,7 +148,6 @@ class ExternalInstanceTests(PyxformTestCase):
                 '<instance id="mydata2" src="jr://file/mydata2.xml"/>',
                 '<instance id="mydata3" src="jr://file/mydata3.xml"/>',
             ],
-            run_odk_validate=True,
         )
 
     def test_cannot__use_same_external_xml_id_with_mixed_types(self):
@@ -132,6 +174,30 @@ class ExternalInstanceTests(PyxformTestCase):
                 model__contains=[],
             )
         self.assertIn("The name 'city' was found 2 time(s)", repr(ctx.exception))
+
+    def test_can__use_same_external_csv_id_with_mixed_types(self):
+        """Multiple fields that require the same external instance result in a single instance declaration."""
+        self.assertPyxformXform(
+            md="""
+            | survey |                                      |      |       |                                             |
+            |        | type                                 | name | label | calculation                                 |
+            |        | begin group                          | g1   |       |                                             |
+            |        | csv-external                         | city |       |                                             |
+            |        | end group                            | g1   |       |                                             |
+            |        | begin group                          | g2   |       |                                             |
+            |        | select_one_from_file cities.csv      | city | City  |                                             |
+            |        | end group                            | g2   |       |                                             |
+            |        | begin group                          | g3   |       |                                             |
+            |        | select_multiple_from_file cities.csv | city | City  |                                             |
+            |        | end group                            | g3   |       |                                             |
+            |        | begin group                          | g4   |       |                                             |
+            |        | calculate                            | city | City  | pulldata('fruits', 'name', 'name', 'mango') |
+            |        | end group                            | g4   |       |                                             |
+            """,  # noqa
+            model__contains=[
+                '<instance id="city" src="jr://file/city.csv"/>',
+            ]
+        )
 
     def test_can__use_all_types_together_with_unique_ids(self):
         """Unique instances with other sources present are OK."""
@@ -178,7 +244,6 @@ class ExternalInstanceTests(PyxformTestCase):
       </instance>
 """,
             ],  # noqa
-            run_odk_validate=True,
         )
 
     def test_cannot__use_different_src_same_id__select_then_internal(self):
@@ -268,7 +333,7 @@ class ExternalInstanceTests(PyxformTestCase):
       <instance id="pain_locations" src="jr://file-csv/pain_locations.csv"/>
 """  # noqa
         self.assertPyxformXform(
-            md=md, model__contains=[expected], run_odk_validate=True
+            md=md, model__contains=[expected]
         )
         survey = self.md_to_pyxform_survey(md_raw=md)
         xml = survey._to_pretty_xml()
@@ -288,7 +353,7 @@ class ExternalInstanceTests(PyxformTestCase):
             """  # noqa
         expected = """<instance id="pain_locations" src="jr://file-csv/pain_locations.csv"/>"""  # noqa
         self.assertPyxformXform(
-            md=md, model__contains=[expected], run_odk_validate=True
+            md=md, model__contains=[expected]
         )
 
     def test_can__reuse_xml__selects_then_external(self):
@@ -322,7 +387,7 @@ class ExternalInstanceTests(PyxformTestCase):
             """  # noqa
         expected = """<instance id="pain_locations" src="jr://file/pain_locations.xml"/>"""  # noqa
         self.assertPyxformXform(
-            md=md, model__contains=[expected], run_odk_validate=True
+            md=md, model__contains=[expected]
         )
         survey = self.md_to_pyxform_survey(md_raw=md)
         xml = survey._to_pretty_xml()

--- a/pyxform/tests_v1/test_external_instances_for_selects.py
+++ b/pyxform/tests_v1/test_external_instances_for_selects.py
@@ -2,7 +2,7 @@
 """
 Test external instance syntax
 
-See also test_xmldata
+See also test_external_instances
 """
 from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 

--- a/pyxform/tests_v1/test_secondary_instance_translations.py
+++ b/pyxform/tests_v1/test_secondary_instance_translations.py
@@ -121,7 +121,7 @@ class TestSecondaryInstanceTest(PyxformTestCase):
         xform_md = """
         | survey |                    |      |       |               |
         |        | type               | name | label | choice_filter |
-        |        | select_one list    | foo  | Foo   | name != "     |
+        |        | select_one list    | foo  | Foo   | name != ''    |
         | choices |
         |         | list_name | name | label | image | label::French |
         |         | list      | a    | A     | a.jpg | Ah            |


### PR DESCRIPTION
Closes #271

#### Why is this the best possible solution? Were any other approaches considered?
Uses the same code paths as `xml-external` which reduces risk. I briefly considered treating them differently in some way but that seemed more complex for no payoff.

I tried to come up with the minimal tests we needed to validate the addition. Since the same code is used as with `xml-external`, I think a lot of the cases are already handled but please be on the lookout for anything that might not be covered.

I noticed some tests were configured to always run Validate. We've discussed not doing that to speed up the test suite so I removed that. We always run all tests with Validate before a release. I also added a commit to make sure all tests pass Validate because failures were mostly in the test file I was already in.

#### What are the regression risks?
This is an additive change and I don't see a regression risk. The only existing code that has changed has to do with `xml-external` and that has really good test coverage.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
https://github.com/XLSForm/xlsform.github.io/issues/216

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments