### PR TITLE
${} references in predicates should be expanded using current()

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -889,9 +889,15 @@ class Survey(Section):
         name = matchobj.group(2)
         last_saved = matchobj.group(1) is not None
         is_indexed_repeat = matchobj.string.find("indexed-repeat(") > -1
-        is_predicate = matchobj.string.startswith("instance(")
         indexed_repeat_regex = re.compile(r"indexed-repeat\([^)]+\)")
         function_args_regex = re.compile(r"\b[^()]+\((.*)\)$")
+
+        # check if current matchobj is a predicate
+        # (starts with 'instance(' and have square bracket in it)
+        is_secondary_instance = (
+            matchobj.string.startswith("instance(")
+            and re.search(r"\[(.+)\]", matchobj.string) is not None
+        )
 
         def _relative_path(name):
             """Given name in ${name}, return relative xpath to ${name}."""
@@ -976,7 +982,7 @@ class Survey(Section):
 
         if _is_return_relative_path():
             if not use_current:
-                use_current = is_predicate
+                use_current = is_secondary_instance
             relative_path = _relative_path(name)
             if relative_path:
                 return relative_path

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -889,6 +889,7 @@ class Survey(Section):
         name = matchobj.group(2)
         last_saved = matchobj.group(1) is not None
         is_indexed_repeat = matchobj.string.find("indexed-repeat(") > -1
+        is_predicate = matchobj.string.startswith("instance(")
         indexed_repeat_regex = re.compile(r"indexed-repeat\([^)]+\)")
         function_args_regex = re.compile(r"\b[^()]+\((.*)\)$")
 
@@ -974,6 +975,8 @@ class Survey(Section):
             )
 
         if _is_return_relative_path():
+            if not use_current:
+                use_current = is_predicate
             relative_path = _relative_path(name)
             if relative_path:
                 return relative_path

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -893,8 +893,12 @@ class Survey(Section):
         function_args_regex = re.compile(r"\b[^()]+\((.*)\)$")
         instance_regex = re.compile(r"instance\([^)]+\S+")
 
-        def _is_secondary_instance():
-            """check if current matchobj is a predicate and part of primary instance"""
+        def _in_secondary_instance_predicate():
+            """
+            check if ${} expression represented by matchobj
+            is in a predicate for a path expression for a secondary instance
+            """
+
             # It is possible to have multiple instance in an expression
             instance_match_iter = instance_regex.finditer(matchobj.string)
             for instance_match in instance_match_iter:
@@ -988,7 +992,7 @@ class Survey(Section):
 
         if _is_return_relative_path():
             if not use_current:
-                use_current = _is_secondary_instance()
+                use_current = _in_secondary_instance_predicate()
             relative_path = _relative_path(name)
             if relative_path:
                 return relative_path

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -653,3 +653,32 @@ class TestRepeat(PyxformTestCase):
                 """<bind nodeset="/data/family/person/prev_name" relevant=" ../age  &gt; indexed-repeat( /data/family/person/age ,  /data/family , 1,  /data/family/person , 2)" type="string"/>"""  # noqa pylint: disable=line-too-long
             ],
         )
+
+    def test_repeat_with_reference_path_in_predicate_uses_current(self,):
+        """
+        Test relative path expansion using current if reference path is inside a predicate
+        """
+        xlsform_md = """
+        | survey |                 |              |                                                |                                                             |
+        |        | type            | name         | label                                          | calculation                                                 |
+        |        | begin repeat    | item-repeat  | Item                                           |                                                             |
+        |        | calculate       | item-counter |                                                | position(..)                                                |
+        |        | calculate       | item         |                                                | instance('item')/root/item[itemindex=${item-counter}]/label |
+        |        | begin group     | item-info    | Item info                                      |                                                             |
+        |        | note            | item-note    | All the following questions are about ${item}. |                                                             |
+        |        | select one item | stock-item   | Do you stock this item?                        |                                                             |
+        |        | end group       | item-info    |                                                |                                                             |
+        |        | end repeat      |              |                                                |                                                             |
+        | choices |           |                  |                   |           |
+        |         | list_name | name             | label             | itemindex |
+        |         | item      | gasoline-regular | Gasoline, Regular | 1         |
+        |         | item      | gasoline-premium | Gasoline, Premium | 2         |
+        |         | item      | gasoline-diesel  | Gasoline, Diesel  | 3         |
+        """
+        self.assertPyxformXform(
+            name="data",
+            md=xlsform_md,
+            xml__contains=[
+                """<bind calculate="instance('item')/root/item[itemindex= current()/../item-counter ]/label" nodeset="/data/item-repeat/item" type="string"/>"""  # noqa pylint: disable=line-too-long
+            ],
+        )


### PR DESCRIPTION
Closes #490 

#### Why is this the best possible solution? Were any other approaches considered?
I use simple predicate testing by checking whether current context start with `instance(`. I'm thinking about using external library for xpath checking, but thought that would be too overkill for this case.

#### What are the regression risks?
None, but probably still need some more tests. Open to more tests suggestion!

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments