### PR TITLE
Apply section name check to sections only

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -187,7 +187,7 @@ class Survey(Section):
         root_node_name = self.name
         section_names = []
         for element in self.iter_descendants():
-            if not isinstance(element, Survey) and element.name == root_node_name:
+            if element.type != "survey" and element.name == root_node_name:
                 raise PyXFormError(
                     'The name "%s" is the same as the form name. '
                     "Use a different section name "

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -187,15 +187,17 @@ class Survey(Section):
         root_node_name = self.name
         section_names = []
         for element in self.iter_descendants():
-            if element.type != "survey" and element.name == root_node_name:
-                raise PyXFormError(
-                    'The name "%s" is the same as the form name. '
-                    "Use a different section name "
-                    '(or change the form name in the "name" column of the settings sheet).'
-                    % element.name
-                )
             if isinstance(element, Section):
                 if element.name in section_names:
+                    if element.name == root_node_name:
+                        # The root node name is rarely explictly set; explain
+                        # the problem in a more helpful way (#510)
+                        raise PyXFormError(
+                            'The name "%s" is the same as the form name. '
+                            "Use a different section name "
+                            '(or change the form name in the "name" column of '
+                            "the settings sheet)." % element.name
+                        )
                     raise PyXFormError(
                         "There are two sections with the name %s." % element.name
                     )

--- a/pyxform/tests/builder_tests.py
+++ b/pyxform/tests/builder_tests.py
@@ -40,7 +40,7 @@ class BuilderTests(TestCase):
 
     def setUp(self):
         self.this_directory = os.path.dirname(__file__)
-        survey_out = Survey(name="survey_age", sms_keyword="age", type="survey")
+        survey_out = Survey(name="age", sms_keyword="age", type="survey")
         question = InputQuestion(name="age")
         question.type = "integer"
         question.label = "How old are you?"

--- a/pyxform/tests_v1/test_fields.py
+++ b/pyxform/tests_v1/test_fields.py
@@ -193,4 +193,5 @@ class FieldsTests(PyxformTestCase):
             |         | date        | date     | Observation date  |
             |         | text        | activity | Describe activity |
             """,
+            errored=False,
         )

--- a/pyxform/tests_v1/test_fields.py
+++ b/pyxform/tests_v1/test_fields.py
@@ -179,3 +179,18 @@ class FieldsTests(PyxformTestCase):
             errored=True,
             error__contains=['The name "foo" is the same as the form name'],
         )
+
+    def test_field_name_may_match_form_name(self):
+        """
+        Unlike section names, it's okay for a field name to match the form
+        name, which becomes the XML root node name
+        """
+        self.assertPyxformXform(
+            name="activity",
+            md="""
+            | survey  |             |          |                   |
+            |         | type        | name     | label             |
+            |         | date        | date     | Observation date  |
+            |         | text        | activity | Describe activity |
+            """,
+        )


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?

#511 is a helpful solution to #510, providing less-confusing error text when a group name matches the root node name, but it also ensnared [(unintentionally?)](https://github.com/XLSForm/pyxform/issues/510#issuecomment-763063318) regular question names. Other approaches considered and rejected were:
1. Reverting #511, losing a valuable addition to pyxform and ignoring the problem described in #510;
1. Doing nothing, and thus requiring unnecessary changes to forms that worked with pyxform prior to v1.3.4.

#### What are the regression risks?

Some unknown tool could depend on the recently-added check that prevents question names from equaling the form name.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No; however, if this PR is undesirable, then the documentation should be updated to reflect the new restriction on question names.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments