### PR TITLE
Don't check for dynamic label if there is no label

### DIFF
--- a/pyxform/tests_v1/test_choices_sheet.py
+++ b/pyxform/tests_v1/test_choices_sheet.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+from pyxform.utils import unicode
+
+
+class ChoicesSheetTest(PyxformTestCase):
+    def test_numeric_choice_names__for_static_selects__allowed(self):
+        """
+        Test numeric choice names for static selects.
+        """
+        self.assertPyxformXform(
+            md="""
+            | survey   |                    |      |       |
+            |          | type               | name | label |
+            |          | select_one choices | a    | A     |
+            | choices  |                    |      |       |
+            |          | list_name          | name | label |
+            |          | choices            | 1    | One   |
+            |          | choices            | 2    | Two   |
+            """,
+            xml__contains=["<value>1</value>"],
+        )
+
+    def test_numeric_choice_names__for_dynamic_selects__allowed(self):
+        """
+        Test numeric choice names for dynamic selects.
+        """
+        self.assertPyxformXform(
+            md="""
+            | survey   |                    |      |       |               |
+            |          | type               | name | label | choice_filter |
+            |          | select_one choices | a    | A     | true()        |
+            | choices  |                    |      |       |
+            |          | list_name          | name | label |
+            |          | choices            | 1    | One   |
+            |          | choices            | 2    | Two   |
+            """,
+            xml__contains=['<instance id="choices">', "<item>", "<name>1</name>"],
+        )
+
+    def test_choices_without_labels__for_static_selects__allowed(self):
+        """
+        Test choices without labels for static selects. Validate will NOT fail.
+        """
+        self.assertPyxformXform(
+            md="""
+            | survey   |                    |      |       |
+            |          | type               | name | label |
+            |          | select_one choices | a    | A     |
+            | choices  |                    |      |       |
+            |          | list_name          | name | label |
+            |          | choices            | 1    |       |
+            |          | choices            | 2    |       |
+            """,
+            xml__contains=["<value>1</value>"],
+        )
+
+    def test_choices_without_labels__for_dynamic_selects__allowed_by_pyxform(self):
+        """
+        Test choices without labels for dynamic selects. Validate will fail.
+        """
+        self.assertPyxformXform(
+            md="""
+            | survey   |                    |      |       |               |
+            |          | type               | name | label | choice_filter |
+            |          | select_one choices | a    | A     | true()        |
+            | choices  |                    |      |       |
+            |          | list_name          | name | label |
+            |          | choices            | 1    |       |
+            |          | choices            | 2    |       |
+            """,
+            run_odk_validate=False,
+            xml__contains=['<instance id="choices">', "<item>", "<name>1</name>"],
+        )

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -277,6 +277,10 @@ def default_is_dynamic(element_default, element_type=None):
 def has_dynamic_label(choice_list, multi_language):
     if not multi_language:
         for i in range(0, min(2, len(choice_list))):
-            if re.search(BRACKETED_TAG_REGEX, choice_list[i].get("label")) is not None:
+            if (
+                choice_list[i].get("label") is not None
+                and re.search(BRACKETED_TAG_REGEX, choice_list[i].get("label"))
+                is not None
+            ):
                 return True
     return False


### PR DESCRIPTION
Closes #532

#### Why is this the best possible solution? Were any other approaches considered?
This is a quick prevention of the crash. I think we should also consider #534.

I also added a couple of tests around numeric choice names because I initially thought that might be the issue and it does seem like something that could regress.

#### What are the regression risks?
It's an added `None` check only so I don't believe there are any.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments