### PR TITLE
Fixed ${} references in predicates not being expanded using current()…

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -911,11 +911,13 @@ class Survey(Section):
         """
 
         name = matchobj.group(2)
+        bracketed_tag_name = "${{{0}}}".format(name)
         last_saved = matchobj.group(1) is not None
         is_indexed_repeat = matchobj.string.find("indexed-repeat(") > -1
         indexed_repeat_regex = re.compile(r"indexed-repeat\([^)]+\)")
         function_args_regex = re.compile(r"\b[^()]+\((.*)\)$")
         instance_regex = re.compile(r"instance\([^)]+.+")
+        bracket_regex = re.compile(r"\[([^]]+)\]")
 
         def _in_secondary_instance_predicate():
             """
@@ -926,11 +928,20 @@ class Survey(Section):
             # It is possible to have multiple instance in an expression
             instance_match_iter = instance_regex.finditer(matchobj.string)
             for instance_match in instance_match_iter:
+                # Check whether current ${varname} is in the correct instance_match
                 if (
                     matchobj.start() >= instance_match.start()
                     and matchobj.end() <= instance_match.end()
                 ):
-                    return True
+                    bracket_regex_match_iter = bracket_regex.finditer(matchobj.string)
+                    # Check whether current ${varname} is in the correct bracket_regex_match
+                    for bracket_regex_match in bracket_regex_match_iter:
+                        if (
+                            matchobj.start() >= bracket_regex_match.start()
+                            and matchobj.end() <= bracket_regex_match.end()
+                        ):
+                            return True
+                    return False
             return False
 
         def _relative_path(name):

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -925,23 +925,16 @@ class Survey(Section):
             is in a predicate for a path expression for a secondary instance
             """
 
-            # It is possible to have multiple instance in an expression
-            instance_match_iter = instance_regex.finditer(matchobj.string)
-            for instance_match in instance_match_iter:
-                # Check whether current ${varname} is in the correct instance_match
-                if (
-                    matchobj.start() >= instance_match.start()
-                    and matchobj.end() <= instance_match.end()
-                ):
-                    bracket_regex_match_iter = bracket_regex.finditer(matchobj.string)
-                    # Check whether current ${varname} is in the correct bracket_regex_match
-                    for bracket_regex_match in bracket_regex_match_iter:
-                        if (
-                            matchobj.start() >= bracket_regex_match.start()
-                            and matchobj.end() <= bracket_regex_match.end()
-                        ):
-                            return True
-                    return False
+            if instance_regex.search(matchobj.string) is not None:
+                bracket_regex_match_iter = bracket_regex.finditer(matchobj.string)
+                # Check whether current ${varname} is in the correct bracket_regex_match
+                for bracket_regex_match in bracket_regex_match_iter:
+                    if (
+                        matchobj.start() >= bracket_regex_match.start()
+                        and matchobj.end() <= bracket_regex_match.end()
+                    ):
+                        return True
+                return False
             return False
 
         def _relative_path(name):

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -915,7 +915,7 @@ class Survey(Section):
         is_indexed_repeat = matchobj.string.find("indexed-repeat(") > -1
         indexed_repeat_regex = re.compile(r"indexed-repeat\([^)]+\)")
         function_args_regex = re.compile(r"\b[^()]+\((.*)\)$")
-        instance_regex = re.compile(r"instance\([^)]+\S+")
+        instance_regex = re.compile(r"instance\([^)]+.+")
 
         def _in_secondary_instance_predicate():
             """

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -779,6 +779,106 @@ class TestRepeat(PyxformTestCase):
             ],
         )
 
+    def test_repeat_with_reference_path_with_spaces_in_predicate_uses_current(self,):
+        """
+        Test relative path expansion using current if reference path (with whitespaces before/after an operator of ${name}) is inside a predicate
+        """
+        xlsform_md = """
+        | survey |              |       |       |                                                                   |
+        |        | type         | name  | label | calculation                                                       |
+        |        | xml-external | item  |       |                                                                   |
+        |        | calculate    | pos1  |       | position(..)                                                      |
+        |        | begin repeat | rep5  |       |                                                                   |
+        |        | calculate    | pos5  |       | position(..)                                                      |
+        |        | calculate    | item5 |       | instance('item')/root/item[index= ${pos5} and ${pos1} = 1]/label  |
+        |        | calculate    | item6 |       | instance('item')/root/item[index =${pos5} and ${pos1} = 1]/label  |
+        |        | calculate    | item7 |       | instance('item')/root/item[index = ${pos5} and ${pos1} = 1]/label |
+        |        | end repeat   |       |       |                                                                   |
+        """
+        self.assertPyxformXform(
+            name="data",
+            md=xlsform_md,
+            xml__contains=[
+                """<bind calculate="instance('item')/root/item[index=  current()/../pos5  and  /data/pos1  = 1]/label" nodeset="/data/rep5/item5" type="string"/>""",  # noqa pylint: disable=line-too-long
+                """<bind calculate="instance('item')/root/item[index = current()/../pos5  and  /data/pos1  = 1]/label" nodeset="/data/rep5/item6" type="string"/>""",  # noqa pylint: disable=line-too-long
+                """<bind calculate="instance('item')/root/item[index =  current()/../pos5  and  /data/pos1  = 1]/label" nodeset="/data/rep5/item7" type="string"/>""",  # noqa pylint: disable=line-too-long
+            ],
+        )
+
+    def test_repeat_with_reference_path_in_a_method_with_spaces_in_predicate_uses_current(
+        self,
+    ):
+        """
+        Test relative path expansion using current if reference path in a method (with whitespaces before/after an operator of ${name}) is inside apredicate
+        """
+        xlsform_md = """
+        | survey |              |       |       |                                                                           |
+        |        | type         | name  | label | calculation                                                               |
+        |        | xml-external | item  |       |                                                                           |
+        |        | calculate    | pos1  |       | position(..)                                                              |
+        |        | begin repeat | rep5  |       |                                                                           |
+        |        | calculate    | pos5  |       | position(..)                                                              |
+        |        | calculate    | item5 |       | instance('item')/root/item[index=number(1+ ${pos5} and ${pos1} = 1]/label |
+        |        | end repeat   |       |       |                                                                           |
+        """
+        self.assertPyxformXform(
+            name="data",
+            md=xlsform_md,
+            xml__contains=[
+                """<bind calculate="instance('item')/root/item[index=number(1+  current()/../pos5  and  /data/pos1  = 1]/label" nodeset="/data/rep5/item5" type="string"/>"""  # noqa pylint: disable=line-too-long
+            ],
+        )
+
+    def test_repeat_with_reference_path_with_spaces_in_predicate_with_parenthesis_uses_current(
+        self,
+    ):
+        """
+        Test relative path expansion using current if reference path (with whitespaces before/after an operator of ${name}) is inside a predicate with parenthesis
+        """
+        xlsform_md = """
+        | survey |              |       |       |                                                                     |
+        |        | type         | name  | label | calculation                                                         |
+        |        | xml-external | item  |       |                                                                     |
+        |        | calculate    | pos1  |       | position(..)                                                        |
+        |        | begin repeat | rep5  |       |                                                                     |
+        |        | calculate    | pos5  |       | position(..)                                                        |
+        |        | calculate    | item5 |       | (instance('item')/root/item)[index = ${pos5} and ${pos1} = 1]/label |
+        |        | end repeat   |       |       |                                                                     |
+        """
+        self.assertPyxformXform(
+            name="data",
+            md=xlsform_md,
+            xml__contains=[
+                """<bind calculate="(instance('item')/root/item)[index =  current()/../pos5  and  /data/pos1  = 1]/label" nodeset="/data/rep5/item5" type="string"/>"""  # noqa pylint: disable=line-too-long
+            ],
+        )
+
+    def test_repeat_with_reference_path_with_whitespaces_in_multiple_predicate_uses_current(
+        self,
+    ):
+        """
+        Test relative path expansion using current if reference path (with whitespaces before/after an operator of ${name}) is inside multiple predicate
+        """
+        xlsform_md = """
+        | survey |              |       |       |                                                                                         |
+        |        | type         | name  | label | calculation                                                                             |
+        |        | xml-external | item  |       |                                                                                         |
+        |        | calculate    | pos1  |       | position(..)                                                                            |
+        |        | begin repeat | rep5  |       |                                                                                         |
+        |        | calculate    | pos5  |       | position(..)                                                                            |
+        |        | calculate    | item5 |       | join(' ', instance('item')/root/item)[index = ${pos5} and ${pos1} = 1]/label)           |
+        |        | calculate    | item6 |       | translate(instance('item')/root/item)[index = ${pos5} and ${pos1} = 1]/label, ',', ' ') |
+        |        | end repeat   |       |       |                                                                                         |
+        """
+        self.assertPyxformXform(
+            name="data",
+            md=xlsform_md,
+            xml__contains=[
+                """<bind calculate="join(' ', instance('item')/root/item)[index =  current()/../pos5  and  /data/pos1  = 1]/label)" nodeset="/data/rep5/item5" type="string"/>""",  # noqa pylint: disable=line-too-long
+                """<bind calculate="translate(instance('item')/root/item)[index =  current()/../pos5  and  /data/pos1  = 1]/label, ',', ' ')" nodeset="/data/rep5/item6" type="string"/>""",  # noqa pylint: disable=line-too-long
+            ],
+        )
+
     def test_relative_path_expansion_not_using_current_if_reference_path_is_predicate_but_not_in_a_repeat(
         self,
     ):

--- a/pyxform/tests_v1/test_repeat.py
+++ b/pyxform/tests_v1/test_repeat.py
@@ -836,20 +836,20 @@ class TestRepeat(PyxformTestCase):
         Test relative path expansion using current if reference path (with whitespaces before/after an operator of ${name}) is inside a predicate with parenthesis
         """
         xlsform_md = """
-        | survey |              |       |       |                                                                     |
-        |        | type         | name  | label | calculation                                                         |
-        |        | xml-external | item  |       |                                                                     |
-        |        | calculate    | pos1  |       | position(..)                                                        |
-        |        | begin repeat | rep5  |       |                                                                     |
-        |        | calculate    | pos5  |       | position(..)                                                        |
-        |        | calculate    | item5 |       | (instance('item')/root/item)[index = ${pos5} and ${pos1} = 1]/label |
-        |        | end repeat   |       |       |                                                                     |
+        | survey |              |       |       |                                                                   |
+        |        | type         | name  | label | calculation                                                       |
+        |        | xml-external | item  |       |                                                                   |
+        |        | calculate    | pos1  |       | position(..)                                                      |
+        |        | begin repeat | rep5  |       |                                                                   |
+        |        | calculate    | pos5  |       | position(..)                                                      |
+        |        | calculate    | item5 |       | instance('item')/root/item[index = ${pos5} and ${pos1} = 1]/label |
+        |        | end repeat   |       |       |                                                                   |
         """
         self.assertPyxformXform(
             name="data",
             md=xlsform_md,
             xml__contains=[
-                """<bind calculate="(instance('item')/root/item)[index =  current()/../pos5  and  /data/pos1  = 1]/label" nodeset="/data/rep5/item5" type="string"/>"""  # noqa pylint: disable=line-too-long
+                """<bind calculate="instance('item')/root/item[index =  current()/../pos5  and  /data/pos1  = 1]/label" nodeset="/data/rep5/item5" type="string"/>"""  # noqa pylint: disable=line-too-long
             ],
         )
 


### PR DESCRIPTION
… if the expression contains whitespace before the reference

Closes #531 

#### Why is this the best possible solution? Were any other approaches considered?
Fixing previous working solution.

#### What are the regression risks?
None.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x ] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments