### PR TITLE
[ WIP/ Needs discussion ] handle all binaries with a big constant

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -115,7 +115,7 @@ list_header = {
     "video": "media::video",
 }
 # Note that most of the type aliasing happens in all.xls
-_type = {
+_type_alias_map = {
     "imei": "deviceid",
     "image": "photo",
     "add image prompt": "photo",

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -107,15 +107,14 @@ AUDIO_QUALITY_EXTERNAL = "external"
 # TODO - theres key repetion here to handle the diverse use cases.
 # could I be a function? or a DefaultDict?
 SANDBOXED_TYPE_EP_PREFIX_MAP = {
-    'photo': 'jr://images/',
-    'image': 'jr://images/',
-    'audio': 'jr://audio/',
-    'background-audio': 'jr://audio/',
-    'video': 'jr://video/',
-    'xml': 'jr://file/',
-    'csv': 'jr://file-csv/',
-    'file': 'jr://file/',
-    'file-csv': 'jr://file-csv/',
-    'lastsaved': 'jr://instance/last-saved'
+    "photo": "jr://images/",
+    "image": "jr://images/",
+    "audio": "jr://audio/",
+    "background-audio": "jr://audio/",
+    "video": "jr://video/",
+    "xml": "jr://file/",
+    "csv": "jr://file-csv/",
+    "file": "jr://file/",
+    "file-csv": "jr://file-csv/",
+    "lastsaved": "jr://instance/last-saved",
 }
-

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -102,3 +102,20 @@ AUDIO_QUALITY_VOICE_ONLY = "voice-only"
 AUDIO_QUALITY_LOW = "low"
 AUDIO_QUALITY_NORMAL = "normal"
 AUDIO_QUALITY_EXTERNAL = "external"
+
+# https://getodk.github.io/xforms-spec/#file-endpoints
+# TODO - theres key repetion here to handle the diverse use cases.
+# could I be a function? or a DefaultDict?
+SANDBOXED_TYPE_EP_PREFIX_MAP = {
+    'photo': 'jr://images/',
+    'image': 'jr://images/',
+    'audio': 'jr://audio/',
+    'background-audio': 'jr://audio/',
+    'video': 'jr://video/',
+    'xml': 'jr://file/',
+    'csv': 'jr://file-csv/',
+    'file': 'jr://file/',
+    'file-csv': 'jr://file-csv/',
+    'lastsaved': 'jr://instance/last-saved'
+}
+

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -105,7 +105,7 @@ AUDIO_QUALITY_EXTERNAL = "external"
 
 # https://getodk.github.io/xforms-spec/#file-endpoints
 # TODO - theres values repeated under different keys to handle the diverse use cases.
-# could I be a function? or a DefaultDict?
+# Could I be a function? or a DefaultDict?
 SANDBOXED_TYPE_EP_PREFIX_MAP = {
     "photo": "jr://images/",
     "image": "jr://images/",

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -104,7 +104,7 @@ AUDIO_QUALITY_NORMAL = "normal"
 AUDIO_QUALITY_EXTERNAL = "external"
 
 # https://getodk.github.io/xforms-spec/#file-endpoints
-# TODO - theres key repetion here to handle the diverse use cases.
+# TODO - theres values repeated under different keys to handle the diverse use cases.
 # could I be a function? or a DefaultDict?
 SANDBOXED_TYPE_EP_PREFIX_MAP = {
     "photo": "jr://images/",
@@ -113,8 +113,8 @@ SANDBOXED_TYPE_EP_PREFIX_MAP = {
     "background-audio": "jr://audio/",
     "video": "jr://video/",
     "xml": "jr://file/",
-    "csv": "jr://file-csv/",
     "file": "jr://file/",
+    "csv": "jr://file-csv/",
     "file-csv": "jr://file-csv/",
     "lastsaved": "jr://instance/last-saved",
 }

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -378,7 +378,7 @@ class Survey(Section):
         def get_instance_info(element, file_id):
             # TODO: do we know for sure we are looking for a csv at this point and not an xml file?
             # if so document why.
-            prefix = constants.SANDBOXED_TYPE_EP_PREFIX_MAP['csv']
+            prefix = constants.SANDBOXED_TYPE_EP_PREFIX_MAP["csv"]
             uri = "{}{}.csv".format(prefix, file_id)
 
             return InstanceInfo(
@@ -414,7 +414,7 @@ class Survey(Section):
             file_id, ext = os.path.splitext(itemset)
             uri = "{}{}".format(
                 # Per above if, must be csv or xml.
-                constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(ext[1:], 'jr://file/'),
+                constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(ext[1:], "jr://file/"),
                 itemset,
             )
             return InstanceInfo(
@@ -830,7 +830,8 @@ class Survey(Section):
                             itext_nodes.append(
                                 node(
                                     "value",
-                                    constants.SANDBOXED_TYPE_EP_PREFIX_MAP['image'] + value,
+                                    constants.SANDBOXED_TYPE_EP_PREFIX_MAP["image"]
+                                    + value,
                                     form=media_type,
                                     toParseString=output_inserted,
                                 )
@@ -840,7 +841,10 @@ class Survey(Section):
                             itext_nodes.append(
                                 node(
                                     "value",
-                                    constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(media_type, 'jr://file/') + value,
+                                    constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(
+                                        media_type, "jr://file/"
+                                    )
+                                    + value,
                                     form=media_type,
                                     toParseString=output_inserted,
                                 )

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -311,8 +311,8 @@ class Survey(Section):
         if isinstance(element, ExternalInstance):
             name = element["name"]
             extension = element["type"].split("-")[0]
-            prefix = "file-csv" if extension == "csv" else "file"
-            src = "jr://{}/{}.{}".format(prefix, name, extension)
+            prefix = constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(extension, "jr://file/")
+            src = "{}{}.{}".format(prefix, name, extension)
             return InstanceInfo(
                 type="external",
                 context="[type: {t}, name: {n}]".format(
@@ -376,7 +376,10 @@ class Survey(Section):
             return functions_present
 
         def get_instance_info(element, file_id):
-            uri = "jr://file-csv/{}.csv".format(file_id)
+            # TODO: do we know for sure we are looking for a csv at this point and not an xml file?
+            # if so document why.
+            prefix = constants.SANDBOXED_TYPE_EP_PREFIX_MAP['csv']
+            uri = "{}{}.csv".format(prefix, file_id)
 
             return InstanceInfo(
                 type=u"pulldata",
@@ -409,8 +412,9 @@ class Survey(Section):
         itemset = element.get("itemset")
         if itemset and (itemset.endswith(".csv") or itemset.endswith(".xml")):
             file_id, ext = os.path.splitext(itemset)
-            uri = "jr://%s/%s" % (
-                "file" if ext == ".xml" else "file-%s" % ext[1:],
+            uri = "{}{}".format(
+                # Per above if, must be csv or xml.
+                constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(ext[1:], 'jr://file/'),
                 itemset,
             )
             return InstanceInfo(
@@ -442,7 +446,7 @@ class Survey(Section):
     @staticmethod
     def _get_last_saved_instance():
         name = "__last-saved"  # double underscore used to minimize risk of name conflicts
-        uri = "jr://instance/last-saved"
+        uri = constants.SANDBOXED_TYPE_EP_PREFIX_MAP['lastsaved']
 
         return InstanceInfo(
             type="instance",
@@ -826,7 +830,7 @@ class Survey(Section):
                             itext_nodes.append(
                                 node(
                                     "value",
-                                    "jr://images/" + value,
+                                    constants.SANDBOXED_TYPE_EP_PREFIX_MAP['image'] + value,
                                     form=media_type,
                                     toParseString=output_inserted,
                                 )
@@ -836,7 +840,7 @@ class Survey(Section):
                             itext_nodes.append(
                                 node(
                                     "value",
-                                    "jr://" + media_type + "/" + value,
+                                    constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(media_type, 'jr://file/') + value,
                                     form=media_type,
                                     toParseString=output_inserted,
                                 )

--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ETree
 from operator import itemgetter
 
 from pyxform import builder
+from pyxform.constants import SANDBOXED_TYPE_EP_PREFIX_MAP
 from pyxform.utils import NSMAP
 
 logger = logging.getLogger(__name__)
@@ -574,10 +575,11 @@ class XFormToDictBuilder:
                         if "form" in value and "_text" in value:
                             key = "media"
                             v = value["_text"]
-                            if value["form"] == "image":
-                                v = v.replace("jr://images/", "")
-                            else:
-                                v = v.replace("jr://%s/" % value["form"], "")
+                            if value["form"] in SANDBOXED_TYPE_EP_PREFIX_MAP:
+                                # TODO - it may be a good idea to validate that there is no
+                                # sandboxed file that isnt handled here and keeps its 'jr://' path
+                                # unintentionally.
+                                v = v.replace(SANDBOXED_TYPE_EP_PREFIX_MAP[value["form"]], "")
                             if v == "-":  # skip blank
                                 continue
                             text = {value["form"]: v}
@@ -587,10 +589,10 @@ class XFormToDictBuilder:
                                 k = "media"
                                 m_type = item["form"]
                                 v = item["_text"]
-                                if m_type == "image":
-                                    v = v.replace("jr://images/", "")
-                                else:
-                                    v = v.replace("jr://%s/" % m_type, "")
+                                if m_type in SANDBOXED_TYPE_EP_PREFIX_MAP:
+                                    # TODO - it may be a good idea to validate that there is no
+                                    # sandboxed file that isnt handled in SANDBOXED_TYPE_EP_PREFIX_MAP
+                                    v = v.replace(SANDBOXED_TYPE_EP_PREFIX_MAP[m_type], "")
                                 if v == "-":
                                     continue
                                 if k not in label:

--- a/pyxform/xform2json.py
+++ b/pyxform/xform2json.py
@@ -579,7 +579,9 @@ class XFormToDictBuilder:
                                 # TODO - it may be a good idea to validate that there is no
                                 # sandboxed file that isnt handled here and keeps its 'jr://' path
                                 # unintentionally.
-                                v = v.replace(SANDBOXED_TYPE_EP_PREFIX_MAP[value["form"]], "")
+                                v = v.replace(
+                                    SANDBOXED_TYPE_EP_PREFIX_MAP[value["form"]], ""
+                                )
                             if v == "-":  # skip blank
                                 continue
                             text = {value["form"]: v}
@@ -592,7 +594,9 @@ class XFormToDictBuilder:
                                 if m_type in SANDBOXED_TYPE_EP_PREFIX_MAP:
                                     # TODO - it may be a good idea to validate that there is no
                                     # sandboxed file that isnt handled in SANDBOXED_TYPE_EP_PREFIX_MAP
-                                    v = v.replace(SANDBOXED_TYPE_EP_PREFIX_MAP[m_type], "")
+                                    v = v.replace(
+                                        SANDBOXED_TYPE_EP_PREFIX_MAP[m_type], ""
+                                    )
                                 if v == "-":
                                     continue
                                 if k not in label:

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -303,11 +303,12 @@ def process_range_question_type(row):
 
     return new_dict
 
+
 def process_binary_default(file_type, default_value):
-    if 'jr://' not in default_value:
-        return '{}{}'.format(
-            constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(file_type, 'jr://file/'),
-            default_value
+    if "jr://" not in default_value:
+        return "{}{}".format(
+            constants.SANDBOXED_TYPE_EP_PREFIX_MAP.get(file_type, "jr://file/"),
+            default_value,
         )
     return default_value
 
@@ -1212,8 +1213,10 @@ def workbook_to_json(
             parent_children_array.append(new_dict)
             continue
 
-        if question_type in constants.SANDBOXED_TYPE_EP_PREFIX_MAP and row.get('default'):
-            row['default'] = process_binary_default(question_type, row['default'])
+        if question_type in constants.SANDBOXED_TYPE_EP_PREFIX_MAP and row.get(
+            "default"
+        ):
+            row["default"] = process_binary_default(question_type, row["default"])
 
         if question_type == "photo":
             new_dict = row.copy()

--- a/tests/test_static_defaults.py
+++ b/tests/test_static_defaults.py
@@ -1,4 +1,4 @@
-from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+from tests.pyxform_test_case import PyxformTestCase
 
 
 class StaticDefaultTests(PyxformTestCase):

--- a/tests/test_static_defaults.py
+++ b/tests/test_static_defaults.py
@@ -1,0 +1,41 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+class StaticDefaultTests(PyxformTestCase):
+    def test_static_defaults(self):
+        self.assertPyxformXform(
+            name="static",
+            md="""
+            | survey |              |          |       |                   |
+            |        | type         | name     | label | default           |
+            |        | integer      | numba    | Foo   | foo               |
+            |        | begin repeat | repeat   |       |                   |
+            |        | integer      | bar      | Bar   | 12                |
+            |        | end repeat   | repeat   |       |                   |
+            """,
+            model__contains=["<numba>foo</numba>", "<bar>12</bar>"],
+            model__excludes=["setvalue", "<numba />"],
+        )
+
+    def test_static_image_defaults(self):
+        self.assertPyxformXform(
+            name="static_image",
+            md="""
+            | survey |        |          |       |                |                        |
+            |        | type   | name     | label | parameters     | default                |
+            |        | image  | my_image | Image | max-pixels=640 | my_default_image.jpg   |
+            |        | text   | my_descr | descr |                | no description provied |
+            """,
+            model__contains=[
+                # image needed NS and question typing still exist
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/static_image/my_image" type="binary" orx:max-pixels="640"/>',
+
+                # image default appears
+                "<my_image>jr://images/my_default_image.jpg</my_image>",
+
+                # other defaults appear
+                "<my_descr>no description provied</my_descr>"
+            ],
+            model__excludes=["setvalue", "<my_image></my_image>", "<my_descr></my_descr>"],
+
+        )

--- a/tests/test_static_defaults.py
+++ b/tests/test_static_defaults.py
@@ -1,5 +1,6 @@
 from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
 
+
 class StaticDefaultTests(PyxformTestCase):
     def test_static_defaults(self):
         self.assertPyxformXform(
@@ -29,13 +30,14 @@ class StaticDefaultTests(PyxformTestCase):
                 # image needed NS and question typing still exist
                 'xmlns:orx="http://openrosa.org/xforms"',
                 '<bind nodeset="/static_image/my_image" type="binary" orx:max-pixels="640"/>',
-
                 # image default appears
                 "<my_image>jr://images/my_default_image.jpg</my_image>",
-
                 # other defaults appear
-                "<my_descr>no description provied</my_descr>"
+                "<my_descr>no description provied</my_descr>",
             ],
-            model__excludes=["setvalue", "<my_image></my_image>", "<my_descr></my_descr>"],
-
+            model__excludes=[
+                "setvalue",
+                "<my_image></my_image>",
+                "<my_descr></my_descr>",
+            ],
         )


### PR DESCRIPTION
Closes #405 

#### Why is this the best possible solution? Were any other approaches considered?
This solution centralizes the handling of Sandbox files in a form while adding support for multiple binary default types.

#### What are the regression risks?
Users attempting to add sandbox files that don't conform to expectations might see unexpected behavior - I have tried to avoid this but its worth discussing how common it is.

In testing, I found a few CSV and XML handling bugs, but those were cleared up. Still, I dont know if tests are missing for these and other file types being used in an unexpected way.

Overall, my question is: do we have validation on paths to binary files? if not, is now the time to add it? or could we choke out some much needed flexibility?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
Only if we add stricter validation of file types, and even then only maybe.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments