### PR TITLE
No warning unlabeled group 2

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -141,12 +141,14 @@ yes_no = {
     "false()": False,
 }
 label_optional_types = [
+    "calculate",
     "deviceid",
+    "end",
     "phonenumber",
     "simserial",
-    "calculate",
     "start",
-    "end",
+    "start-geopoint",
     "today",
+    "username",
 ]
 osm = {"osm": constants.OSM_TYPE}

--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -60,6 +60,7 @@ CHOICES = "choices"
 LIST_NAME = "list name"
 CASCADING_SELECT = "cascading_select"
 TABLE_LIST = "table-list"  # hyphenated because it goes in appearance, and convention for appearance column is dashes # noqa
+FIELD_LIST = "field-list"
 
 # The following are the possible sheet names:
 SURVEY = "survey"

--- a/pyxform/tests_v1/test_fieldlist_labels.py
+++ b/pyxform/tests_v1/test_fieldlist_labels.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+Test field-list labels
+"""
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class FieldListLabels(PyxformTestCase):
+    """Test unlabeled group"""
+
+    def test_unlabeled_group(self):
+        warnings = []
+
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey |             |          |         |
+            |        | type        | name     | label   |
+            |        | begin_group | my-group |         |
+            |        | text        | my-text  | my-text |
+            |        | end_group   |          |         |
+            """,
+            warnings=warnings,
+        )
+
+        self.assertTrue(len(warnings) == 1)
+        self.assertTrue("[row : 2] Group has no label" in warnings[0])
+
+    def test_unlabeled_group_alternate_syntax(self):
+        warnings = []
+
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey |             |          |                     |
+            |        | type        | name     | label::English (en) |
+            |        | begin group | my-group |                     |
+            |        | text        | my-text  | my-text             |
+            |        | end group   |          |                     |
+            """,
+            warnings=warnings,
+        )
+
+        self.assertTrue(len(warnings) == 1)
+        self.assertTrue("[row : 2] Group has no label" in warnings[0])
+
+    def test_unlabeled_group_fieldlist(self):
+        warnings = []
+
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey |              |           |         |            |
+            |        | type         | name      | label   | appearance |
+            |        | begin_group  | my-group  |         | field-list |
+            |        | text         | my-text   | my-text |            |
+            |        | end_group    |           |         |            |
+            """,
+            warnings=warnings,
+        )
+
+        self.assertTrue(len(warnings) == 0)
+
+    def test_unlabeled_group_fieldlist_alternate_syntax(self):
+        warnings = []
+
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey |              |           |         |            |
+            |        | type         | name      | label   | appearance |
+            |        | begin group  | my-group  |         | field-list |
+            |        | text         | my-text   | my-text |            |
+            |        | end group    |           |         |            |
+            """,
+            warnings=warnings,
+        )
+
+        self.assertTrue(len(warnings) == 0)
+
+    def test_unlabeled_repeat(self):
+        warnings = []
+
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey |              |           |         |
+            |        | type         | name      | label   |
+            |        | begin_repeat | my-repeat |         |
+            |        | text         | my-text   | my-text |
+            |        | end_repeat   |           |         |
+            """,
+            warnings=warnings,
+        )
+
+        self.assertTrue(len(warnings) == 1)
+        self.assertTrue("[row : 2] Repeat has no label" in warnings[0])
+
+    def test_unlabeled_repeat_fieldlist(self):
+        warnings = []
+
+        survey = self.md_to_pyxform_survey(
+            """
+            | survey |              |           |         |            |
+            |        | type         | name      | label   | appearance |
+            |        | begin_repeat | my-repeat |         | field-list |
+            |        | text         | my-text   | my-text |            |
+            |        | end_repeat   |           |         |            |
+            """,
+            warnings=warnings,
+        )
+
+        self.assertTrue(len(warnings) == 1)
+        self.assertTrue("[row : 2] Repeat has no label" in warnings[0])

--- a/pyxform/tests_v1/test_xlsform_spec.py
+++ b/pyxform/tests_v1/test_xlsform_spec.py
@@ -16,7 +16,7 @@ class TestWarnings(PyxformTestCase):
         |          | integer                | a_integer               |                           | integer |                    |              |       |       |
         |          | decimal                | a_decimal               |                           | decimal |                    |              |       |       |
         |          | begin repeat           | repeat_test             |                           |         |                    |              |       |       |
-        |          | begin group            | group_test              |                           |         | field-list         |              |       |       |
+        |          | begin group            | group_test              |                           |         |                    |              |       |       |
         |          | text                   | required_text           | required_text             |         |                    |              |       |       |
         |          | select_multiple yes_no | select_multiple_test    | select multiple test      |         | minimal            |              |       |       |
         |          | end group              | adsaf                   |                           |         |                    |              |       |       |

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -906,6 +906,11 @@ def workbook_to_json(
                         row.get("default")
                         and default_is_dynamic(row.get("default"), question_type)
                     )
+                    and not (
+                        control_type is constants.GROUP
+                        and row.get("control", {}).get("appearance")
+                        == constants.FIELD_LIST
+                    )
                 ):
                     # Row number, name, and type probably enough for user message.
                     # Also means the error message text is stable for tests.


### PR DESCRIPTION
Too many warnings make it hard for users to see things they should be actually warned about. In this case, users use field-lists to visually group questions and that grouping really doesn't need a label, so we don't need to warn users.

And while I was looking at the warnings, I wanted to improve them by specifying that the warning was about a group or a repeat.

I also removed the warning for username and start-geopoint. The later, I'm not sure ever threw a warning.

#### Why is this the best possible solution? Were any other approaches considered?
Originally, I wanted to warn on every group and every repeat, but decided to dial it back because...
* Collect uses the repeat label in the UI when asking about what creating repeats
* Groups without a field-list are probably fine to remove a warning, but this current PR feels like a safer first step.

#### What are the regression risks?

There could be some downstream tools that rely on group labels, but since has always been a warning and not an error, it seems likely that those tools can handle missing group labels.

There doesn't seem to be a fixed list of acceptable ways to say "begin group". There is a regex in https://github.com/XLSForm/pyxform/blob/master/pyxform/xls2json.py#L570 that I built my tests around.

Finally, there isn't a lot of test coverage on groups, so that didn't make me feel great.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No, infact https://xlsform.org/en/#multiple-webpage-forms shows an example of a field-list without a label.

#### Before submitting this PR, please make sure you have:
- [X] included test cases for core behavior and edge cases in `tests_v1`
- [X] run `nosetests` and verified all tests pass
- [X] run `black pyxform` to format code
- [X] verified that any code or assets from external sources are properly credited in comments