### PR TITLE
avoid recursion depth error for label with many references

### DIFF
--- a/pyxform/tests_v1/test_survey.py
+++ b/pyxform/tests_v1/test_survey.py
@@ -16,8 +16,7 @@ class TestSurvey(PyxformTestCase):
             |        | note | n    | {n}   |          |
             |        | text | q2   | Q2    | {r}      |
             """.format(
-                n="q1 = ${q1} " * 250,
-                r=" or ".join(["${q1} = 'y'"] * 250)
+                n="q1 = ${q1} " * 250, r=" or ".join(["${q1} = 'y'"] * 250)
             ),
         )
 

--- a/pyxform/tests_v1/test_survey.py
+++ b/pyxform/tests_v1/test_survey.py
@@ -1,0 +1,54 @@
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class TestSurvey(PyxformTestCase):
+    """
+    Tests for the Survey class.
+    """
+
+    def test_many_xpath_references_do_not_hit_64_recursion_limit__one_to_one(self):
+        """Should be able to pipe a question into one note more than 64 times."""
+        self.assertPyxformXform(
+            md="""
+            | survey |      |      |       |          |
+            |        | type | name | label | relevant |
+            |        | text | q1   | Q1    |          |
+            |        | note | n    | {n}   |          |
+            |        | text | q2   | Q2    | {r}      |
+            """.format(
+                n="q1 = ${q1} " * 250,
+                r=" or ".join(["${q1} = 'y'"] * 250)
+            ),
+        )
+
+    def test_many_xpath_references_do_not_hit_64_recursion_limit__many_to_one(self):
+        """Should be able to pipe more than 64 questions into one note."""
+        tmpl_q = "|        | text | q{0}   | Q{0}    |"
+        tmpl_n = "q{0} = ${{q{0}}} "
+        self.assertPyxformXform(
+            md="""
+            | survey |      |      |       |
+            |        | type | name | label |
+            {q}
+            |        | note | n    | {n}  |
+            """.format(
+                q="\n".join((tmpl_q.format(i) for i in range(1, 250))),
+                n=" ".join((tmpl_n.format(i) for i in range(1, 250))),
+            ),
+        )
+
+    def test_many_xpath_references_do_not_hit_64_recursion_limit__many_to_many(self):
+        """Should be able to pipe more than 64 questions into 64 notes."""
+        tmpl_q = "|        | text | q{0} | Q{0}    |"
+        tmpl_n = "|        | note | n{0} | q{0} = ${{q{0}}} |"
+        self.assertPyxformXform(
+            md="""
+            | survey |      |      |       |
+            |        | type | name | label |
+            {q}
+            {n}
+            """.format(
+                q="\n".join((tmpl_q.format(i) for i in range(1, 250))),
+                n="\n".join((tmpl_n.format(i) for i in range(1, 250))),
+            ),
+        )

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -129,7 +129,9 @@ def node(*args, **kwargs):
                 # Move node's children to the result Element
                 # discarding node's root
                 for child in parsed_node.childNodes:
-                    result.appendChild(copy.deepcopy(child))
+                    # No tests seem to involve moving elements with children.
+                    # Deep clone used anyway in case of unknown edge cases.
+                    result.appendChild(child.cloneNode(deep=True))
         else:
             result.setAttribute(k, v)
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -12,7 +12,7 @@ black==19.10b0
 click==7.0                # via black, pip-tools
 entrypoints==0.3          # via flake8
 flake8==3.7.7
-formencode==1.3.1
+formencode==2.0.0
 isort==4.3.20
 lazy-object-proxy==1.4.1  # via astroid
 linecache2==1.0.0         # via traceback2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "xlrd==1.2.0",
     "unicodecsv==0.14.1",
-    "formencode==1.3.1",
+    "formencode==2.0.0",
     "unittest2==1.1.0",
     'functools32==3.2.3.post2 ; python_version < "3.2"',
 ]


### PR DESCRIPTION
Closes #444

The root cause was the call to `copy.deepcopy`. The `child` argument is a minidom Node type which has a reference back to it's parentNode. The parent in turn has references to it's childNodes. So a deepcopy would try to traverse this recursive structure and error out. A copy of the parentNode is unnecessary anyway, since the copy is being made in order to append to a new parent.

#### Why is this the best possible solution? Were any other approaches considered?

The updated call to `child.cloneNode` seems to be the appropriate minidom API method for making a copy of a Node ([docs](https://docs.python.org/3/library/xml.dom.html#xml.dom.Node.cloneNode)). It doesn't copy the parentNode, thus avoiding the recursion issue. It's not clear from the pyxform git history why this wasn't used earlier. The method seems to have been available for at least 15 years. Maybe there was a bug in the implementation or usage in prior Python versions.

Another approach could be to use the child's `__dict__` or `__slots__` to filter out `parentNode` and copy everything else. But that may not work without making new DOM objects for the copied attributes. Then at that point this strategy essentially becomes the same as what `cloneNode` does.

#### What are the regression risks?

Should not be any. In case there is an unknown edge/use case that requires a recursive copy, the `cloneNode` call requests a deep copy of childNodes. As noted in the new inline comment, there did not seem to be any tests which involved copying childNodes which themselves had childNodes. 

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

Probably not. The original bug report was perhaps an extreme use case.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments