### PR TITLE
Add allow-mock-accuracy parameter

### DIFF
--- a/pyxform/tests_v1/test_allow_mock_accuracy.py
+++ b/pyxform/tests_v1/test_allow_mock_accuracy.py
@@ -12,7 +12,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             |        | geopoint  | geopoint    | Geopoint | allow-mock-accuracy=true |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/geopoint" type="geopoint" odk:allow-mock-accuracy="true"/>',
             ],
         )
@@ -25,7 +25,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             |        | geopoint  | geopoint    | Geopoint | allow-mock-accuracy=false |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/geopoint" type="geopoint" odk:allow-mock-accuracy="false"/>',
             ],
         )
@@ -39,7 +39,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             |        | geoshape  | geoshape    | Geoshape | allow-mock-accuracy=true |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/geoshape" type="geoshape" odk:allow-mock-accuracy="true"/>',
             ],
         )
@@ -52,7 +52,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             |        | geoshape  | geoshape    | Geoshape | allow-mock-accuracy=false |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/geoshape" type="geoshape" odk:allow-mock-accuracy="false"/>',
             ],
         )
@@ -66,7 +66,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             |        | geotrace  | geotrace    | Geotrace | allow-mock-accuracy=true |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/geotrace" type="geotrace" odk:allow-mock-accuracy="true"/>',
             ],
         )
@@ -79,7 +79,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             |        | geotrace  | geotrace    | Geotrace | allow-mock-accuracy=false |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/geotrace" type="geotrace" odk:allow-mock-accuracy="false"/>',
             ],
         )

--- a/pyxform/tests_v1/test_allow_mock_accuracy.py
+++ b/pyxform/tests_v1/test_allow_mock_accuracy.py
@@ -30,6 +30,60 @@ class AllowMockAccuracyTest(PyxformTestCase):
             ],
         )
 
+    def test_geoshape(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geoshape  | geoshape    | Geoshape | allow-mock-accuracy=true |
+            """,
+            xml__contains=[
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/data/geoshape" type="geoshape" odk:allow-mock-accuracy="true"/>',
+            ],
+        )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geoshape  | geoshape    | Geoshape | allow-mock-accuracy=false |
+            """,
+            xml__contains=[
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/data/geoshape" type="geoshape" odk:allow-mock-accuracy="false"/>',
+            ],
+        )
+
+    def test_geotrace(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geotrace  | geotrace    | Geotrace | allow-mock-accuracy=true |
+            """,
+            xml__contains=[
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/data/geotrace" type="geotrace" odk:allow-mock-accuracy="true"/>',
+            ],
+        )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geotrace  | geotrace    | Geotrace | allow-mock-accuracy=false |
+            """,
+            xml__contains=[
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/data/geotrace" type="geotrace" odk:allow-mock-accuracy="false"/>',
+            ],
+        )
+
     def test_foo_fails(self):
         self.assertPyxformXform(
             name="data",
@@ -37,6 +91,28 @@ class AllowMockAccuracyTest(PyxformTestCase):
             | survey |           |             |          |                          |
             |        | type      | name        | label    | parameters               |
             |        | geopoint  | geopoint    | Geopoint | allow-mock-accuracy=foo |
+            """,
+            errored=True,
+            error__contains=["Invalid value for allow-mock-accuracy."],
+        )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geoshape  | geoshape    | Geoshape | allow-mock-accuracy=foo |
+            """,
+            errored=True,
+            error__contains=["Invalid value for allow-mock-accuracy."],
+        )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geotrace  | geotrace    | Geotrace | allow-mock-accuracy=foo |
             """,
             errored=True,
             error__contains=["Invalid value for allow-mock-accuracy."],

--- a/pyxform/tests_v1/test_allow_mock_accuracy.py
+++ b/pyxform/tests_v1/test_allow_mock_accuracy.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from pyxform.tests_v1.pyxform_test_case import PyxformTestCase
+
+
+class AllowMockAccuracyTest(PyxformTestCase):
+    def test_geopoint(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geopoint  | geopoint    | Geopoint | allow-mock-accuracy=true |
+            """,
+            xml__contains=[
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/data/geopoint" type="geopoint" odk:allow-mock-accuracy="true"/>',
+            ],
+        )
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geopoint  | geopoint    | Geopoint | allow-mock-accuracy=false |
+            """,
+            xml__contains=[
+                'xmlns:orx="http://openrosa.org/xforms"',
+                '<bind nodeset="/data/geopoint" type="geopoint" odk:allow-mock-accuracy="false"/>',
+            ],
+        )
+
+    def test_foo_fails(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geopoint  | geopoint    | Geopoint | allow-mock-accuracy=foo |
+            """,
+            errored=True,
+            error__contains=["Invalid value for allow-mock-accuracy."],
+        )

--- a/pyxform/tests_v1/test_audio_quality.py
+++ b/pyxform/tests_v1/test_audio_quality.py
@@ -12,7 +12,7 @@ class AudioQualityTest(PyxformTestCase):
             |        | audio  | audio    | Audio | quality=voice-only |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/audio" type="binary" odk:quality="voice-only"/>',
             ],
         )
@@ -26,7 +26,7 @@ class AudioQualityTest(PyxformTestCase):
             |        | audio  | audio    | Audio | quality=low |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/audio" type="binary" odk:quality="low"/>',
             ],
         )
@@ -40,7 +40,7 @@ class AudioQualityTest(PyxformTestCase):
             |        | audio  | audio    | Audio | quality=normal |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/audio" type="binary" odk:quality="normal"/>',
             ],
         )
@@ -54,7 +54,7 @@ class AudioQualityTest(PyxformTestCase):
             |        | audio  | audio    | Audio | quality=external |
             """,
             xml__contains=[
-                'xmlns:orx="http://openrosa.org/xforms"',
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/audio" type="binary" odk:quality="external"/>',
             ],
         )

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1342,7 +1342,7 @@ def workbook_to_json(
             parent_children_array.append(new_dict)
             continue
 
-        if question_type == "geopoint":
+        if question_type in ["geopoint", "geoshape", "geotrace"]:
             new_dict = row.copy()
             parameters = get_parameters(
                 row.get("parameters", ""), ["allow-mock-accuracy"]

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1342,6 +1342,24 @@ def workbook_to_json(
             parent_children_array.append(new_dict)
             continue
 
+        if question_type == "geopoint":
+            new_dict = row.copy()
+            parameters = get_parameters(
+                row.get("parameters", ""), ["allow-mock-accuracy"]
+            )
+
+            if "allow-mock-accuracy" in parameters.keys():
+                if parameters["allow-mock-accuracy"] not in ["true", "false"]:
+                    raise PyXFormError("Invalid value for allow-mock-accuracy.")
+
+                new_dict["bind"] = new_dict.get("bind", {})
+                new_dict["bind"].update(
+                    {"odk:allow-mock-accuracy": parameters["allow-mock-accuracy"]}
+                )
+
+            parent_children_array.append(new_dict)
+            continue
+
         # TODO: Consider adding some question_type validation here.
 
         # Put the row in the json dict as is:


### PR DESCRIPTION
Needed for getodk/collect#4768

#### Why is this the best possible solution? Were any other approaches considered?

#### What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments