### PR TITLE
Fix appveyor errors

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -12,7 +12,7 @@ black==19.10b0
 click==7.0                # via black, pip-tools
 entrypoints==0.3          # via flake8
 flake8==3.7.7
-formencode==1.3.1
+formencode==2.0.0
 isort==4.3.20
 lazy-object-proxy==1.4.1  # via astroid
 linecache2==1.0.0         # via traceback2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 REQUIRES = [
     "xlrd==1.2.0",
     "unicodecsv==0.14.1",
-    "formencode==1.3.1",
+    "formencode==2.0.0",
     "unittest2==1.1.0",
     'functools32==3.2.3.post2 ; python_version < "3.2"',
 ]


### PR DESCRIPTION
The version of formencode we're using seems to be having problems with appveyor. This fix is stolen from https://github.com/XLSForm/pyxform/pull/548.

#### Why is this the best possible solution? Were any other approaches considered?

From looking at the release notes for formencode 2.0.0 ([here](http://www.formencode.org/en/latest/whatsnew-2.0.html)) it looks like it no longer works with Python 2 (or anything under Python 3.6). As far as I understand, pyxform still supports these versions, so I'm not sure if this upgrade actually is the right fix. An alternative might be to downgrade to 1.3.0 if that also works. 

It could also be that there is an entirely different solution! I'm still not quite sure why appveyor is running into problems with formencode 1.3.1.

#### What are the regression risks?

See above.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

Maybe if we're planning to drop support for some Python versions (although just to the README)

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests_v1`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform` to format code
- [x] verified that any code or assets from external sources are properly credited in comments