### PR TITLE
Add warning when `quality` not specified for `audio` question

### DIFF
--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1250,6 +1250,11 @@ def workbook_to_json(
 
                 new_dict["bind"] = new_dict.get("bind", {})
                 new_dict["bind"].update({"odk:quality": parameters["quality"]})
+            else:
+                warnings.append(
+                    (row_format_string % row_number)
+                    + " No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specifiy quality=external."
+                )
 
             parent_children_array.append(new_dict)
             continue

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1253,7 +1253,7 @@ def workbook_to_json(
             else:
                 warnings.append(
                     (row_format_string % row_number)
-                    + " No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specifiy quality=external."
+                    + " No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specify quality=external."
                 )
 
             parent_children_array.append(new_dict)

--- a/tests/pyxform_test_case.py
+++ b/tests/pyxform_test_case.py
@@ -161,8 +161,8 @@ class PyxformTestCase(PyxformMarkdown, TestCase):
           * error__contains: a list of strings which should exist in the error
           * error__not_contains: a list of strings which should not exist in the error
           * odk_validate_error__contains: list of strings; run_odk_validate must be set
-          * warning__contains: a list of strings which should exist in the warnings
-          * warning__not_contains: a list of strings which should not exist in the warnings
+          * warnings__contains: a list of strings which should exist in the warnings
+          * warnings__not_contains: a list of strings which should not exist in the warnings
           * warnings_count: the number of expected warning messages
           * xml__excludes: an array of strings which should not exist in the resulting
                xml. [xml|model|instance|itext]_excludes are also supported.

--- a/tests/test_audio_quality.py
+++ b/tests/test_audio_quality.py
@@ -11,9 +11,8 @@ class AudioQualityTest(PyxformTestCase):
             |        | type   | name     | label | parameters     |
             |        | audio  | audio    | Audio | quality=voice-only |
             """,
-            xml__contains=[
-                'xmlns:odk="http://www.opendatakit.org/xforms"',
-                '<bind nodeset="/data/audio" type="binary" odk:quality="voice-only"/>',
+            xml__xpath_match=[
+                "/h:html/h:head/x:model/x:bind[@nodeset='/data/audio' and @type='binary' and @odk:quality='voice-only']",
             ],
         )
 
@@ -25,9 +24,8 @@ class AudioQualityTest(PyxformTestCase):
             |        | type   | name     | label | parameters     |
             |        | audio  | audio    | Audio | quality=low |
             """,
-            xml__contains=[
-                'xmlns:odk="http://www.opendatakit.org/xforms"',
-                '<bind nodeset="/data/audio" type="binary" odk:quality="low"/>',
+            xml__xpath_match=[
+                "/h:html/h:head/x:model/x:bind[@nodeset='/data/audio' and @type='binary' and @odk:quality='low']",
             ],
         )
 
@@ -39,9 +37,8 @@ class AudioQualityTest(PyxformTestCase):
             |        | type   | name     | label | parameters     |
             |        | audio  | audio    | Audio | quality=normal |
             """,
-            xml__contains=[
-                'xmlns:odk="http://www.opendatakit.org/xforms"',
-                '<bind nodeset="/data/audio" type="binary" odk:quality="normal"/>',
+            xml__xpath_match=[
+                "/h:html/h:head/x:model/x:bind[@nodeset='/data/audio' and @type='binary' and @odk:quality='normal']",
             ],
         )
 
@@ -53,9 +50,8 @@ class AudioQualityTest(PyxformTestCase):
             |        | type   | name     | label | parameters     |
             |        | audio  | audio    | Audio | quality=external |
             """,
-            xml__contains=[
-                'xmlns:odk="http://www.opendatakit.org/xforms"',
-                '<bind nodeset="/data/audio" type="binary" odk:quality="external"/>',
+            xml__xpath_match=[
+                "/h:html/h:head/x:model/x:bind[@nodeset='/data/audio' and @type='binary' and @odk:quality='external']",
             ],
         )
 
@@ -79,9 +75,8 @@ class AudioQualityTest(PyxformTestCase):
             |        | type   | name     | label | parameters     |
             |        | audio  | audio    | Audio |                |
             """,
-            xml__contains=[
-                'xmlns:odk="http://www.opendatakit.org/xforms"',
-                '<bind nodeset="/data/audio" type="binary"/>',
+            xml__xpath_match=[
+                "/h:html/h:head/x:model/x:bind[@nodeset='/data/audio' and @type='binary']",
             ],
             warnings__contains=[
                 "[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specify quality=external."

--- a/tests/test_audio_quality.py
+++ b/tests/test_audio_quality.py
@@ -72,8 +72,6 @@ class AudioQualityTest(PyxformTestCase):
         )
 
     def test_missing(self):
-        actual = []
-
         self.assertPyxformXform(
             name="data",
             md="""
@@ -85,11 +83,5 @@ class AudioQualityTest(PyxformTestCase):
                 'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/audio" type="binary"/>',
             ],
-            warnings=actual,
+            warnings__contains=["[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specify quality=external."]
         )
-
-        expected = [
-            "[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specify quality=external."
-        ]
-
-        self.assertListEqual(expected, actual)

--- a/tests/test_audio_quality.py
+++ b/tests/test_audio_quality.py
@@ -70,3 +70,26 @@ class AudioQualityTest(PyxformTestCase):
             errored=True,
             error__contains=["Invalid value for quality."],
         )
+
+    def test_missing(self):
+        actual = []
+
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                |
+            |        | type   | name     | label | parameters     |
+            |        | audio  | audio    | Audio |                |
+            """,
+            xml__contains=[
+                'xmlns:odk="http://www.opendatakit.org/xforms"',
+                '<bind nodeset="/data/audio" type="binary"/>',
+            ],
+            warnings=actual,
+        )
+
+        expected = [
+            "[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specifiy quality=external."
+        ]
+
+        self.assertListEqual(expected, actual)

--- a/tests/test_audio_quality.py
+++ b/tests/test_audio_quality.py
@@ -83,5 +83,7 @@ class AudioQualityTest(PyxformTestCase):
                 'xmlns:odk="http://www.opendatakit.org/xforms"',
                 '<bind nodeset="/data/audio" type="binary"/>',
             ],
-            warnings__contains=["[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specify quality=external."]
+            warnings__contains=[
+                "[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specify quality=external."
+            ],
         )

--- a/tests/test_audio_quality.py
+++ b/tests/test_audio_quality.py
@@ -89,7 +89,7 @@ class AudioQualityTest(PyxformTestCase):
         )
 
         expected = [
-            "[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specifiy quality=external."
+            "[row : 2] No quality parameter specified for audio. This will soon use an internal recorder in Collect. If you need to use a specific recording app, specify quality=external."
         ]
 
         self.assertListEqual(expected, actual)

--- a/tests/test_xlsform_spec.py
+++ b/tests/test_xlsform_spec.py
@@ -70,6 +70,9 @@ class TestWarnings(PyxformTestCase):
             "[row : 16] Group has no label: {'name': 'name', 'type': 'begin group'}",
             "[row : 27] Use the max-pixels parameter to speed up submission "
             + "sending and save storage space. Learn more: https://xlsform.org/#image",
+            "[row : 28] No quality parameter specified for audio. This will soon"
+            + " use an internal recorder in Collect. If you need to use a specific"
+            + " recording app, specify quality=external.",
         ]
         self.assertListEqual(expected, warnings)
 


### PR DESCRIPTION
Work for getodk/collect#4828

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here. Just duplicated the way other warnings are output as part of `xls2json.py`.

#### What are the regression risks?

Again not a lot here. The only real changes are to `audio` parsing/rendering so that's where any risks would lie.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments