### PR TITLE
Add accuracy parameters for geopoint

### DIFF
--- a/tests/test_allow_mock_accuracy.py
+++ b/tests/test_allow_mock_accuracy.py
@@ -2,8 +2,8 @@
 from tests.pyxform_test_case import PyxformTestCase
 
 
-class AllowMockAccuracyTest(PyxformTestCase):
-    def test_geopoint(self):
+class GeoParameterTest(PyxformTestCase):
+    def test_geopoint_allow_mock_accuracy(self):
         self.assertPyxformXform(
             name="data",
             md="""
@@ -30,7 +30,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             ],
         )
 
-    def test_geoshape(self):
+    def test_geoshape_allow_mock_accuracy(self):
         self.assertPyxformXform(
             name="data",
             md="""
@@ -57,7 +57,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             ],
         )
 
-    def test_geotrace(self):
+    def test_geotrace_allow_mock_accuracy(self):
         self.assertPyxformXform(
             name="data",
             md="""
@@ -84,7 +84,7 @@ class AllowMockAccuracyTest(PyxformTestCase):
             ],
         )
 
-    def test_foo_fails(self):
+    def test_foo_allow_mock_accuracy_value_fails(self):
         self.assertPyxformXform(
             name="data",
             md="""
@@ -116,4 +116,92 @@ class AllowMockAccuracyTest(PyxformTestCase):
             """,
             errored=True,
             error__contains=["Invalid value for allow-mock-accuracy."],
+        )
+
+    def test_numeric_geopoint_capture_accuracy_is_passed_through(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geopoint  | geopoint    | Geopoint | capture-accuracy=2.5     |
+            """,
+            xml__xpath_match=[
+                "/h:html/h:body/x:input[@accuracyThreshold='2.5' and @ref='/data/geopoint']"
+            ],
+        )
+
+    def test_string_geopoint_capture_accuracy_errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geopoint  | geopoint    | Geopoint | capture-accuracy=foo     |
+            """,
+            errored=True,
+            error__contains=["Parameter capture-accuracy must have a numeric value"],
+        )
+
+    def test_geopoint_warning_accuracy_is_passed_through(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+        | survey |           |             |          |                          |
+        |        | type      | name        | label    | parameters               |
+        |        | geopoint  | geopoint    | Geopoint | warning-accuracy=5       |
+        """,
+            xml__xpath_match=[
+                "/h:html/h:body/x:input[@unacceptableAccuracyThreshold='5' and @ref='/data/geopoint']"
+            ],
+        )
+
+    def test_string_geopoint_warning_accuracy_errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geopoint  | geopoint    | Geopoint | warning-accuracy=foo     |
+            """,
+            errored=True,
+            error__contains=["Parameter warning-accuracy must have a numeric value"],
+        )
+
+    def test_geopoint_parameters_combine(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                                                             |
+            |        | type      | name        | label    | parameters                                                  |
+            |        | geopoint  | geopoint    | Geopoint | warning-accuracy=5.5 capture-accuracy=2 allow-mock-accuracy=true |
+            """,
+            xml__xpath_match=[
+                "/h:html/h:body/x:input[@unacceptableAccuracyThreshold='5.5' and @accuracyThreshold='2' and @ref='/data/geopoint']",
+                "/h:html/h:head/x:model/x:bind[@nodeset='/data/geopoint' and @odk:allow-mock-accuracy='true']",
+            ],
+        )
+
+    def test_geoshape_with_accuracy_parameters_errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geoshape  | geoshape    | Geoshape | warning-accuracy=5       |
+            """,
+            errored=True,
+            error__contains=["'warning-accuracy' is an invalid parameter"],
+        )
+
+    def test_geotrace_with_accuracy_parameters_errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |           |             |          |                          |
+            |        | type      | name        | label    | parameters               |
+            |        | geotrace  | geotrace    | Geotrace | warning-accuracy=5       |
+            """,
+            errored=True,
+            error__contains=["'warning-accuracy' is an invalid parameter"],
         )


### PR DESCRIPTION
Closes #579

#### Why is this the best possible solution? Were any other approaches considered?
This is the approach that matches other parameters currently. I feel more and more of a desire to reduce the spaghetti nature of that part of the code but I don't think we should combine that with adding a new parameter.

#### What are the regression risks?
I had to combine this with `allow-mock-accuracy` which also applies to `geopoint` questions. So there's some risk there. I added test to verify that the new attributes aren't allowed with trace/shape and that all of the point parameters combine well.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
https://github.com/XLSForm/xlsform.github.io/issues/222

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments