### PR TITLE
Set the parameters field/column default type to type dict

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -53,7 +53,7 @@ class SurveyElement(dict):
         "default": str,
         "type": str,
         "appearance": str,
-        "parameters": str,
+        "parameters": dict,
         "intent": str,
         "jr:count": str,
         "bind": dict,

--- a/tests/test_external_instances.py
+++ b/tests/test_external_instances.py
@@ -387,6 +387,11 @@ class ExternalInstanceTests(PyxformTestCase):
         xml = survey._to_pretty_xml()
         self.assertEqual(1, xml.count(expected))
 
+        # additional test you can recreate the survey from the survey JSON
+        from pyxform import SurveyElementBuilder
+
+        SurveyElementBuilder().create_survey_element_from_json(survey.to_json()).to_xml()
+
     def test_external_instance_pulldata_constraint(self):
         """
         Checks if instance node for pulldata function is added


### PR DESCRIPTION
Closes https://github.com/XLSForm/pyxform/issues/605

#### Why is this the best possible solution? Were any other approaches considered?

Minimal code change, works. 
See additional context and information on the issue https://github.com/XLSForm/pyxform/issues/605.

#### What are the regression risks?

None

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behaviour and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments