### PR TITLE
fix: survey json->xml round trip not working for some question types

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -53,7 +53,7 @@ class SurveyElement(dict):
         "default": str,
         "type": str,
         "appearance": str,
-        "parameters": str,
+        "parameters": dict,
         "intent": str,
         "jr:count": str,
         "bind": dict,
@@ -128,7 +128,7 @@ class SurveyElement(dict):
         else:
             self.add_child(children)
 
-    binding_conversions = {
+    BINDING_CONVERSIONS = {
         "yes": "true()",
         "Yes": "true()",
         "YES": "true()",
@@ -143,16 +143,16 @@ class SurveyElement(dict):
         "FALSE": "false()",
     }
 
-    CONVERTIBLE_BIND_ATTRIBUTES = [
+    CONVERTIBLE_BIND_ATTRIBUTES = (
         "readonly",
         "required",
         "relevant",
         "constraint",
         "calculate",
-    ]
+    )
 
     # Supported media types for attaching to questions
-    SUPPORTED_MEDIA = ["image", "audio", "video"]
+    SUPPORTED_MEDIA = ("image", "audio", "video")
 
     def validate(self):
         if not is_valid_xml_tag(self.name):
@@ -457,10 +457,10 @@ class SurveyElement(dict):
                 # the xls2json side.
                 if (
                     hashable(v)
-                    and v in self.binding_conversions
+                    and v in self.BINDING_CONVERSIONS
                     and k in self.CONVERTIBLE_BIND_ATTRIBUTES
                 ):
-                    v = self.binding_conversions[v]
+                    v = self.BINDING_CONVERSIONS[v]
                 if k == "jr:constraintMsg" and (
                     type(v) is dict or re.search(BRACKETED_TAG_REGEX, v)
                 ):

--- a/pyxform/validators/pyxform/parameters_generic.py
+++ b/pyxform/validators/pyxform/parameters_generic.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, Sequence
+
+from pyxform.errors import PyXFormError
+
+PARAMETERS_TYPE = Dict[str, Any]
+
+
+def parse(raw_parameters: str) -> PARAMETERS_TYPE:
+    parts = raw_parameters.split(";")
+    if len(parts) == 1:
+        parts = raw_parameters.split(",")
+    if len(parts) == 1:
+        parts = raw_parameters.split()
+
+    params = {}
+    for param in parts:
+        if "=" not in param:
+            raise PyXFormError(
+                "Expecting parameters to be in the form of "
+                "'parameter1=value parameter2=value'."
+            )
+        k, v = param.split("=")[:2]
+        key = k.lower().strip()
+        params[key] = v.lower().strip()
+
+    return params
+
+
+def validate(
+    parameters: PARAMETERS_TYPE,
+    allowed: Sequence[str],
+) -> Dict[str, str]:
+    """
+    Raise an error if 'parameters' includes any keys not named in 'allowed'.
+    """
+    extras = set(parameters.keys()) - (set(allowed))
+    if 0 < len(extras):
+        msg = (
+            "Accepted parameters are '{a}'. "
+            "The following are invalid parameter(s): '{e}'."
+        ).format(a=", ".join(sorted(allowed)), e=", ".join(sorted(extras)))
+        raise PyXFormError(msg)
+    return parameters

--- a/tests/js2x_test_import_from_json.py
+++ b/tests/js2x_test_import_from_json.py
@@ -4,10 +4,13 @@ Testing our ability to import from a JSON text file.
 """
 from unittest import TestCase
 
-from pyxform.builder import create_survey_element_from_dict
+from pyxform.builder import (
+    create_survey_element_from_dict,
+    create_survey_element_from_json,
+)
 
 
-class Json2XformTestJsonImport(TestCase):
+class TestJson2XformJsonImport(TestCase):
     def test_simple_questions_can_be_imported_from_json(self):
         json_text = {
             "type": "survey",
@@ -23,3 +26,25 @@ class Json2XformTestJsonImport(TestCase):
         s = create_survey_element_from_dict(json_text)
 
         self.assertEqual(s.children[0].type, "decimal")
+
+    def test_question_type_that_accepts_parameters__without_parameters__to_xml(self):
+        """Should be able to round-trip survey using a un-parameterised question without error."""
+        # Per https://github.com/XLSForm/pyxform/issues/605
+        # Underlying issue was that the SurveyElement.FIELDS default for "parameters" was
+        # a string, but in MultipleChoiceQuestion.build_xml a dict is assumed, because
+        # xls2json.parse_parameters always returns a dict.
+        js = """
+        {
+            "type": "survey",
+            "name": "ExchangeRate",
+            "children": [
+                {
+                    "itemset": "pain_locations.xml",
+                    "label": "Location of worst pain this week.",
+                    "name": "pweek",
+                    "type": "select one"
+                }
+            ]
+        }
+        """
+        create_survey_element_from_json(str_or_path=js).to_xml()

--- a/tests/test_allow_mock_accuracy.py
+++ b/tests/test_allow_mock_accuracy.py
@@ -191,7 +191,7 @@ class GeoParameterTest(PyxformTestCase):
             |        | geoshape  | geoshape    | Geoshape | warning-accuracy=5       |
             """,
             errored=True,
-            error__contains=["'warning-accuracy' is an invalid parameter"],
+            error__contains=["invalid parameter(s): 'warning-accuracy'"],
         )
 
     def test_geotrace_with_accuracy_parameters_errors(self):
@@ -203,5 +203,5 @@ class GeoParameterTest(PyxformTestCase):
             |        | geotrace  | geotrace    | Geotrace | warning-accuracy=5       |
             """,
             errored=True,
-            error__contains=["'warning-accuracy' is an invalid parameter"],
+            error__contains=["invalid parameter(s): 'warning-accuracy'"],
         )

--- a/tests/test_external_instances_for_selects.py
+++ b/tests/test_external_instances_for_selects.py
@@ -288,7 +288,8 @@ class TestSelectOneExternal(PyxformTestCase):
         |        | select_one_external suburb | suburb | Suburb | value=val, label=lbl |
         """
         err = (
-            "Accepted parameters are 'randomize, seed': 'value' is an invalid parameter."
+            "Accepted parameters are 'randomize, seed'. "
+            "The following are invalid parameter(s): 'label, value'."
         )
         self.assertPyxformXform(
             name="test", md=md + self.all_choices, errored=True, error__contains=[err]
@@ -355,7 +356,8 @@ class TestSelectOneExternal(PyxformTestCase):
         |        | select_one_external suburb | suburb | Suburb | state=${state} and city=${city} | value=val, label=lbl |
         """
         err = (
-            "Accepted parameters are 'randomize, seed': 'value' is an invalid parameter."
+            "Accepted parameters are 'randomize, seed'. "
+            "The following are invalid parameter(s): 'label, value'."
         )
         self.assertPyxformXform(
             name="test", md=md + self.all_choices, errored=True, error__contains=[err]

--- a/tests/test_max_pixels.py
+++ b/tests/test_max_pixels.py
@@ -46,7 +46,7 @@ class MaxPixelsTest(PyxformTestCase):
             |        | image  | my_image | Image | max-pixels=640 foo=bar |
             """,
             error__contains=[
-                "Accepted parameters are 'max-pixels': 'foo' is an invalid parameter."
+                "Accepted parameters are 'max-pixels'. The following are invalid parameter(s): 'foo'."
             ],
         )
 

--- a/tests/test_randomize_itemsets.py
+++ b/tests/test_randomize_itemsets.py
@@ -144,7 +144,8 @@ class RandomizeItemsetsTest(PyxformTestCase):
 
             """,
             error__contains=[
-                "Accepted parameters are 'randomize, seed': 'step' is an invalid parameter."
+                "Accepted parameters are 'randomize, seed'. "
+                "The following are invalid parameter(s): 'step'."
             ],
         )
 


### PR DESCRIPTION
Closes #605

- details of issue noted in new test under js2x_test_import_from_json.py
- xls2json updated to make it easier to be confident that parameters will be a dict (vs. none or a string).
  - moved off params processing to parse/validate step validators package to be consistent with other utils of this nature.
  - updated error message to show all invalid params at once, instead of one at a time (which may have resulted in users to having convert a few times to get a valid params set).

#### Why is this the best possible solution? Were any other approaches considered?

PR #606 also fixes this but I wanted to be a bit more sure that xls2json is really passing in a dict in all cases. Also this PR has a separate test which isolates the issue to the scenario where a question that accepts parameters doesn't have parameters, and that survey is passed in as json and then converted to XML.

#### What are the regression risks?

Hopefully none! The error message for invalid params is updated, maybe some users expect the old message. But I think it is more user friendly to say what all the issues are at once, if possible.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments