### PR TITLE
Release triggers multiple runs, so use published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: [release]
+on:
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
Release seems to trigger 2-3 runs. The first works and the others fail.

* Released: https://github.com/XLSForm/pyxform/actions/runs/3501587001
* Published: https://github.com/XLSForm/pyxform/actions/runs/3501586994

This PR only runs when the release is published.

More at https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

Similar to https://github.com/getodk/pyodk/pull/18