### PR TITLE
Fix linter check for black and isort not failing when changes required

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,8 +30,8 @@ jobs:
           pip list
 
       # Linters.
-      - run: black pyxform tests
-      - run: isort pyxform tests
+      - run: black pyxform tests --check --diff
+      - run: isort pyxform tests --check-only --diff
       - run: flake8 pyxform tests
       - run: pycodestyle pyxform tests
 

--- a/pyxform/xlsparseutils.py
+++ b/pyxform/xlsparseutils.py
@@ -1,7 +1,7 @@
 import re
-from pyxform import constants
 from typing import KeysView, Optional
 
+from pyxform import constants
 from pyxform.utils import levenshtein_distance
 
 # http://www.w3.org/TR/REC-xml/


### PR DESCRIPTION
Noted [here](https://github.com/XLSForm/pyxform/pull/624#issuecomment-1328804968).

Linters `black` and `isort` returncode is 0 when fixes required and applied, so add arguments that make it returncode 1 when fixes required. Linters `flake8 and `pycodestyle` return 1 already.

#### Why is this the best possible solution? Were any other approaches considered?

It's the required arguments

#### What are the regression risks?

None, only relevant for GitHub actions

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments