### PR TITLE
Pass through itemset ref case

### DIFF
--- a/pyxform/validators/pyxform/parameters_generic.py
+++ b/pyxform/validators/pyxform/parameters_generic.py
@@ -4,6 +4,8 @@ from pyxform.errors import PyXFormError
 
 PARAMETERS_TYPE = Dict[str, Any]
 
+CASE_SENSITIVE_VALUES = ["label", "value"]
+
 
 def parse(raw_parameters: str) -> PARAMETERS_TYPE:
     parts = raw_parameters.split(";")
@@ -21,7 +23,7 @@ def parse(raw_parameters: str) -> PARAMETERS_TYPE:
             )
         k, v = param.split("=")[:2]
         key = k.lower().strip()
-        params[key] = v.lower().strip()
+        params[key] = v.strip() if key in CASE_SENSITIVE_VALUES else v.lower().strip()
 
     return params
 

--- a/pyxform/validators/pyxform/parameters_generic.py
+++ b/pyxform/validators/pyxform/parameters_generic.py
@@ -4,6 +4,7 @@ from pyxform.errors import PyXFormError
 
 PARAMETERS_TYPE = Dict[str, Any]
 
+# Label and value are used to match against user-specified files so case should be preserved.
 CASE_SENSITIVE_VALUES = ["label", "value"]
 
 

--- a/tests/test_external_instances_for_selects.py
+++ b/tests/test_external_instances_for_selects.py
@@ -242,6 +242,24 @@ class TestSelectFromFile(PyxformTestCase):
                             error__contains=[msg],
                         )
 
+    def test_param_value_case_preserved(self):
+        """Should find that parameters value/label override the default itemset name/label with case preserved."""
+        md = """
+        | survey |                                        |         |         |                      |
+        |        | type                                   | name    | label   | parameters           |
+        |        | select_one_from_file cities{ext}       | city    | City    | value=VAL, label=lBl |
+        """
+        for ext, xp_city, xp_subs in self.xp_test_args:
+            with self.subTest(msg=ext):
+                self.assertPyxformXform(
+                    name="test",
+                    md=md.format(ext=ext),
+                    xml__xpath_match=[
+                        xp_city.model_external_instance_and_bind(),
+                        xp_city.body_itemset_nodeset_and_refs(value="VAL", label="lBl"),
+                    ],
+                )
+
 
 class TestSelectOneExternal(PyxformTestCase):
     """


### PR DESCRIPTION
Closes #642

#### Why is this the best possible solution? Were any other approaches considered?
I decided to go with an exclude list for case normalization when first parsing parameters. The alternative I considered was to move case normalization to when parameter values are used by `pyxform`. I don't feel strongly between the two. Currently `label` and `value` are the only parameters that get set to user-provided strings. All of the others are numeric or enum values.

I also considered making sure all clients use label and value case-insensitively and leaving `pyxform` as it is. Even if we do choose to go that route, I don't think `pyxform` should be responsible for case normalization.

#### What are the regression risks?
The only risk I can see would be if some client somewhere counts on `label` and `value` references always being lowercase. However, alternate clients are not common.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments