### PR TITLE
646: Detect instance() expressions in notes and make them into outputs

### DIFF
--- a/pyxform/parsing/instance_expression.py
+++ b/pyxform/parsing/instance_expression.py
@@ -1,0 +1,127 @@
+import re
+from typing import TYPE_CHECKING, List, Tuple
+
+from pyxform.utils import BRACKETED_TAG_REGEX, EXPRESSION_LEXER, ExpLexerToken
+
+if TYPE_CHECKING:
+    from pyxform.survey import Survey
+    from pyxform.survey_element import SurveyElement
+
+
+def instance_func_start(token: ExpLexerToken) -> bool:
+    """
+    Determine if the token is the start of an instance expression.
+
+    :param token: The token to examine.
+    :return: If True, the token is the start of an instance expression.
+    """
+    if token is None:
+        return False
+    return token.name == "FUNC_CALL" and token.value == "instance("
+
+
+def find_boundaries(xml_text: str) -> List[Tuple[int, int]]:
+    """
+    Find token boundaries of any instance() expression.
+
+    Presumed:
+    - An instance expression is followed by an XML path expression.
+    - Any token is allowed inside a predicate (e.g. nested paths/preds/funcs).
+    - When not inside a predicate, whitespace terminates a XML path expression.
+    - instance expressions are valid inside predicates of other instance expressions.
+
+    :param xml_text: XML text that may contain an instance expression.
+    :return: Tokens in instance expression, and the string position boundaries.
+    """
+    instance_enter = False
+    path_enter = False
+    pred_enter = False
+    last_token = None
+    tokens, _ = EXPRESSION_LEXER.scan(xml_text)
+    boundaries = []
+
+    for t in tokens:
+        emit = False
+        # If an instance expression had started, note the string position boundary.
+        if instance_func_start(token=t) and not instance_enter:
+            instance_enter = True
+            emit = True
+            boundaries.append(t.start)
+        # Tokens that are part of an instance expression.
+        elif instance_enter:
+            # Tokens that are part of the instance call.
+            if instance_func_start(token=last_token) and t.name == "SYSTEM_LITERAL":
+                emit = True
+            elif last_token.name == "SYSTEM_LITERAL" and t.name == "CLOSE_PAREN":
+                emit = True
+            elif t.name == "PATH_SEP" and last_token.name == "CLOSE_PAREN":
+                emit = True
+                path_enter = True
+            # A XPath path may continue after a predicate.
+            elif t.name == "PATH_SEP" and last_token.name == "XPATH_PRED_END":
+                emit = True
+                path_enter = True
+            # Tokens that are part of a XPath path.
+            elif path_enter:
+                if t.name == "WHITESPACE":
+                    path_enter = False
+                elif t.name != "XPATH_PRED_START":
+                    emit = True
+                elif t.name == "XPATH_PRED_START":
+                    emit = True
+                    path_enter = False
+                    pred_enter = True
+            # Tokens that are part of a XPath predicate.
+            elif pred_enter:
+                if t.name != "XPATH_PRED_END":
+                    emit = True
+                elif t.name == "XPATH_PRED_END":
+                    emit = True
+                    pred_enter = False
+        # Track instance expression tokens, ignore others.
+        if emit:
+            last_token = t
+        # If an instance expression had ended, note the string position boundary.
+        elif instance_enter:
+            instance_enter = False
+            boundaries.append(last_token.end)
+
+    if last_token is not None:
+        boundaries.append(last_token.end)
+
+    # Pair up the boundaries [1, 2, 3, 4] -> [(1, 2), (3, 4)].
+    bounds = iter(boundaries)
+    pos_bounds = [(x, y) for x, y in zip(bounds, bounds)]
+    return pos_bounds
+
+
+def replace_with_output(xml_text: str, context: "SurveyElement", survey: "Survey") -> str:
+    """
+    Find occurrences of instance expressions and replace them with <output/> elements.
+
+    :param xml_text: The text string to search/replace.
+    :param context: The SurveyElement that this string belongs to.
+    :param survey: The Survey that the context is in.
+    :return: The possibly modified string.
+    """
+    boundaries = find_boundaries(xml_text=xml_text)
+    if 0 < len(boundaries):
+        new_strings = []
+        for start, end in boundaries:
+            old_str = xml_text[start:end]
+            # Pass the new string through the pyxform reference replacer.
+            # noinspection PyProtectedMember
+            new_str = re.sub(
+                BRACKETED_TAG_REGEX,
+                lambda m: survey._var_repl_function(m, context),
+                old_str,
+            )
+            new_strings.append((start, end, old_str, f'<output value="{new_str}" />'))
+        # Position-based replacement avoids strings which are substrings of other
+        # replacements being inserted incorrectly. Offset tracking deals with changing
+        # expression positions due to incremental replacement.
+        offset = 0
+        for s, e, o, n in new_strings:
+            xml_text = xml_text[: s + offset] + n + xml_text[e + offset :]
+            offset += len(n) - len(o)
+    return xml_text

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -1073,11 +1073,14 @@ class Survey(Section):
         # need to make sure we have reason to replace
         # since at this point < is &lt,
         # the net effect &lt gets translated again to &amp;lt;
-        if "{" in original_xml:
-            pass_1 = instance_expression.replace_with_output(original_xml, context, self)
-            pass_2 = re.sub(BRACKETED_TAG_REGEX, _var_repl_output_function, pass_1)
-            return pass_2, not pass_2 == original_xml
-        return text, False
+        xml_text = instance_expression.replace_with_output(original_xml, context, self)
+        if "{" in xml_text:
+            xml_text = re.sub(BRACKETED_TAG_REGEX, _var_repl_output_function, xml_text)
+        changed = xml_text != original_xml
+        if changed:
+            return xml_text, True
+        else:
+            return text, False
 
     # pylint: disable=too-many-arguments
     def print_xform_to_file(

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -18,6 +18,7 @@ from pyxform.errors import PyXFormError, ValidationError
 from pyxform.external_instance import ExternalInstance
 from pyxform.instance import SurveyInstance
 from pyxform.instance_info import InstanceInfo
+from pyxform.parsing import instance_expression
 from pyxform.question import Option, Question
 from pyxform.section import Section
 from pyxform.survey_element import SurveyElement
@@ -1067,14 +1068,15 @@ class Survey(Section):
         # variable replacement:
         text_node = PatchedText()
         text_node.data = text
-        xml_text = text_node.toxml()
+        original_xml = text_node.toxml()
 
         # need to make sure we have reason to replace
         # since at this point < is &lt,
         # the net effect &lt gets translated again to &amp;lt;
-        if str(xml_text).find("{") != -1:
-            result = re.sub(BRACKETED_TAG_REGEX, _var_repl_output_function, str(xml_text))
-            return result, not result == xml_text
+        if "{" in original_xml:
+            pass_1 = instance_expression.replace_with_output(original_xml, context, self)
+            pass_2 = re.sub(BRACKETED_TAG_REGEX, _var_repl_output_function, pass_1)
+            return pass_2, not pass_2 == original_xml
         return text, False
 
     # pylint: disable=too-many-arguments

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -432,7 +432,7 @@ class SurveyElement(dict):
                 result.append(self.xml_label())
             result.append(self.xml_hint())
 
-        msg = "The survey element named '%s' " "has no label or hint." % self.name
+        msg = "The survey element named '%s' has no label or hint." % self.name
         if len(result) == 0:
             raise PyXFormError(msg)
 

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -387,7 +387,8 @@ def get_expression_lexer() -> re.Scanner:  # noqa
         "WHITESPACE": r"\s+",
         "PYXFORM_REF": r"\$\{" + ncname_regex + r"(#" + ncname_regex + r")?" + r"\}",
         "FUNC_CALL": ncname_regex + r"\(",
-        "XPATH_PRED": ncname_regex + r"\[",
+        "XPATH_PRED_START": ncname_regex + r"\[",
+        "XPATH_PRED_END": r"\]",
         "URI_SCHEME": ncname_regex + r"://",
         "NAME": ncname_regex,  # Must be after rules containing ncname_regex.
         "OTHER": r".+?",  # Catch any other character so that parsing doesn't stop.

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,124 @@
+"""
+Test the "note" question type.
+"""
+from dataclasses import dataclass
+from typing import Set
+
+from tests.pyxform_test_case import PyxformTestCase
+from tests.xpath_helpers.questions import xpq
+
+
+@dataclass()
+class Case:
+    """
+    A test case spec for note output scenarios.
+    """
+
+    label: str
+    xpath: str
+    match: Set[str]
+
+
+class TestNotes(PyxformTestCase):
+    def test_instance_expression__original_problem_scenario(self):
+        """Should produce expected output for scenario similar to pyxform/#646."""
+        md = """
+        | survey  |               |      |       |
+        |         | type          | name | label |
+        |         | select_one c1 | q1   | Q1    |
+        |         | select_one c2 | q2   | Q2    |
+        |         | text          | text | Text  |
+        |         | note          | note | This is a note with a reference to ${text}. And a reference to a secondary instance: instance('c1')/root/item[name = ${q1}]/label is here, and another instance('c2')/root/item[contains(name, ${q2})]/label is here. |
+        | choices |
+        |         | list_name | name | label |
+        |         | c1        | y    | Yes   |
+        |         | c1        | n    | No    |
+        |         | c2        | b    | Big   |
+        |         | c2        | s    | Small |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                """
+                /h:html/h:body/x:input[@ref='/test_name/note']/x:label[
+                  contains(., 'This is a note with a reference to')
+                    and contains(., '. And a reference to a secondary instance: ')
+                    and contains(., 'is here, and another')
+                    and contains(., 'is here.')
+                ]
+                """,
+            ],
+            # Value contains single quote so need to use xpath_exact.
+            xml__xpath_exact=[
+                (
+                    xpq.body_input_label_output_value("note"),
+                    {
+                        " /test_name/text ",
+                        "instance('c1')/root/item[name =  /test_name/q1 ]/label",
+                        "instance('c2')/root/item[contains(name,  /test_name/q2 )]/label",
+                    },
+                ),
+            ],
+        )
+
+    def test_instance_expression__permutations(self):
+        """Should produce expected output for various combinations of instance usages."""
+        md = """
+        | survey  |               |      |       |
+        |         | type          | name | label |
+        |         | select_one c1 | q1   | Q1    |
+        |         | select_one c2 | q2   | Q2    |
+        |         | text          | text | Text  |
+        |         | note          | note | {note} |
+        | choices |
+        |         | list_name | name | label |
+        |         | c1        | y    | Yes   |
+        |         | c1        | n    | No    |
+        |         | c2        | b    | Big   |
+        |         | c2        | s    | Small |
+        """
+        cases = [
+            # A pyxform token.
+            Case(
+                "${text}",
+                xpq.body_input_label_output_value("note"),
+                {" /test_name/text "},
+            ),
+            # Instance expression with predicate using pyxform token and equals.
+            Case(
+                "instance('c1')/root/item[name = ${q1}]/label",
+                xpq.body_input_label_output_value("note"),
+                {"instance('c1')/root/item[name =  /test_name/q1 ]/label"},
+            ),
+            # Instance expression with predicate using pyxform token and function.
+            Case(
+                "instance('c2')/root/item[contains(name, ${q2})]/label",
+                xpq.body_input_label_output_value("note"),
+                {"instance('c2')/root/item[contains(name,  /test_name/q2 )]/label"},
+            ),
+            # Instance expression with predicate using pyxform token and equals.
+            Case(
+                "instance('c2')/root/item[contains(name, instance('c1')/root/item[name = ${q1}]/label)]/label",
+                xpq.body_input_label_output_value("note"),
+                {
+                    "instance('c2')/root/item[contains(name, instance('c1')/root/item[name =  /test_name/q1 ]/label)]/label"
+                },
+            ),
+        ]
+        wrap_scenarios = ("{}", "Text {}", "{} text", "Text {} text")
+        # All cases together in one.
+        combo_case = Case(
+            " ".join(c.label for c in cases),
+            xpq.body_input_label_output_value("note"),
+            {m for c in cases for m in c.match},
+        )
+        cases.append(combo_case)
+        for c in cases:
+            for fmt in wrap_scenarios:
+                note_text = fmt.format(c.label)
+                with self.subTest(msg=(c.label, fmt)):
+                    self.assertPyxformXform(
+                        md=md.format(note=note_text),
+                        xml__xpath_exact=[(c.xpath, c.match)],
+                        warnings_count=0,
+                    )

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -104,6 +104,12 @@ class TestNotes(PyxformTestCase):
                     "instance('c2')/root/item[contains(name, instance('c1')/root/item[name =  /test_name/q1 ]/label)]/label"
                 },
             ),
+            # Instance expression with predicate not using a pyxform token.
+            Case(
+                "instance('c1')/root/item[name = 'y']/label",
+                xpq.body_input_label_output_value("note"),
+                {"instance('c1')/root/item[name = 'y']/label"},
+            ),
         ]
         wrap_scenarios = ("{}", "Text {}", "{} text", "Text {} text")
         # All cases together in one.

--- a/tests/xpath_helpers/questions.py
+++ b/tests/xpath_helpers/questions.py
@@ -42,5 +42,12 @@ class XPathHelper:
         ]
         """
 
+    @staticmethod
+    def body_input_label_output_value(q_name: str):
+        """Body has an input (note) with output reference in the label."""
+        return fr"""
+        /h:html/h:body/x:input[@ref='/test_name/{q_name}']/x:label/x:output/@value
+        """
+
 
 xpq = XPathHelper()


### PR DESCRIPTION
Closes #646

#### Why is this the best possible solution? Were any other approaches considered?
In a note label, users can show values or metadata for other form items using pyxform reference syntax e.g. ${q1}. If that reference was inside an instance call (e.g. to get the value of a secondary instance label), then the conversion would convert the pyxform token, but it should convert the whole expression.

New implementation works for pyxform references, and (nested) instance expressions with or without a pyxform reference (e.g. in a XPath predicate). It uses a similar approach to the detection of dynamic labels, where an expression lexer looks for certain grammar tokens or sequences. The lexer approach is useful here because a regex to accurately parse instance expressions is either quite complicated or not possible. Particularly considering the wide variety of XPath expressions that some users likely employ now via the workaround or will plan to after this fix.

Maybe at some stage this element of pyxform should be upgraded to use something like `pyparsing`. There is a fair amount of parsing in pyxform which could be consolidated. It may also allow for warning users of potentially invalid expressions. Example XPath parsing code with pyparsing found in projects [arelle](https://github.com/Arelle/Arelle/blob/4ac12d4999c596e7292a338eaa5b53d90a194ba5/arelle/formula/XPathParser.py) and [xpyth_parser](https://github.com/ekaats/xpyth_parser) which both happen to target XPath for XBRL purposes (no significance to XLSForm, just a coincidence).

#### What are the regression risks?
This slots in to `survey.py` as an extra text processing layer within the existing pyxform reference replacement code, so the risk should be minimal. Obviously if there is a bug in this new code it may prevent form conversion.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
It would probably be welcome news on the forum. It seems like it's something that otherwise users would assume should work.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments