### PR TITLE
Alias list_name to dataset in entities sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,14 @@ tests/test_output
 build
 dist
 pyxform.egg-info
+pip-wheel-metadata
 
 # By having build ignored above, this ignores documents created by
 # sphinx. Overall, I think this is a good thing.
 
 # a virtual environment
 env
+venv
 
 # ignore pypi manifest
 MANIFEST

--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -108,6 +108,9 @@ survey_header = {
     "parameters": "parameters",
     constants.ENTITIES_SAVETO: "bind::entities:saveto",
 }
+
+entities_header = {"list_name": "dataset"}
+
 # Key is the pyxform internal name, Value is the name used in error/warning messages.
 TRANSLATABLE_SURVEY_COLUMNS = {
     constants.LABEL: constants.LABEL,

--- a/pyxform/entities/entities_parsing.py
+++ b/pyxform/entities/entities_parsing.py
@@ -25,12 +25,12 @@ def get_entity_declaration(
 
     if dataset.startswith(constants.ENTITIES_RESERVED_PREFIX):
         raise PyXFormError(
-            f"Invalid dataset name: '{dataset}' starts with reserved prefix {constants.ENTITIES_RESERVED_PREFIX}."
+            f"Invalid entity list name: '{dataset}' starts with reserved prefix {constants.ENTITIES_RESERVED_PREFIX}."
         )
 
     if "." in dataset:
         raise PyXFormError(
-            f"Invalid dataset name: '{dataset}'. Dataset names may not include periods."
+            f"Invalid entity list name: '{dataset}'. Names may not include periods."
         )
 
     if not is_valid_xml_tag(dataset):
@@ -38,7 +38,7 @@ def get_entity_declaration(
             dataset = dataset.encode("utf-8")
 
         raise PyXFormError(
-            f"Invalid dataset name: '{dataset}'. Dataset names must begin with a letter, colon, or underscore. Other characters can include numbers or dashes."
+            f"Invalid entity list name: '{dataset}'. Names must begin with a letter, colon, or underscore. Other characters can include numbers or dashes."
         )
 
     if not ("label" in entity):

--- a/pyxform/entities/entities_parsing.py
+++ b/pyxform/entities/entities_parsing.py
@@ -83,7 +83,7 @@ def validate_entity_saveto(
 
     error_start = f"{constants.ROW_FORMAT_STRING % row_number} Invalid save_to name:"
 
-    if save_to == "name" or save_to == "label":
+    if save_to.lower() == "name" or save_to.lower() == "label":
         raise PyXFormError(
             f"{error_start} the entity property name '{save_to}' is reserved."
         )

--- a/pyxform/entities/entities_parsing.py
+++ b/pyxform/entities/entities_parsing.py
@@ -5,9 +5,9 @@ from pyxform.errors import PyXFormError
 from pyxform.xlsparseutils import find_sheet_misspellings, is_valid_xml_tag
 
 
-def get_entity_declaration(workbook_dict: Dict, warnings: List) -> Dict:
-    entities_sheet = workbook_dict.get(constants.ENTITIES, [])
-
+def get_entity_declaration(
+    entities_sheet: Dict, workbook_dict: Dict, warnings: List
+) -> Dict:
     if len(entities_sheet) == 0:
         similar = find_sheet_misspellings(
             key=constants.ENTITIES, keys=workbook_dict.keys()

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -538,7 +538,11 @@ def workbook_to_json(
                             )  # noqa
 
     # ########## Entities sheet ###########
-    entity_declaration = get_entity_declaration(workbook_dict, warnings)
+    entities_sheet = workbook_dict.get(constants.ENTITIES, [])
+    entities_sheet = dealias_and_group_headers(
+        entities_sheet, aliases.entities_header, False
+    )
+    entity_declaration = get_entity_declaration(entities_sheet, workbook_dict, warnings)
 
     # ########## Survey sheet ###########
     survey_sheet = workbook_dict[constants.SURVEY]

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -232,6 +232,23 @@ class EntitiesTest(PyxformTestCase):
             ],
         )
 
+    def test_naMe_in_saveto_column__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | naMe    |
+            | entities |         |       |       |         |
+            |          | dataset | label |       |         |
+            |          | trees   | a     |       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 2] Invalid save_to name: the entity property name 'naMe' is reserved."
+            ],
+        )
+
     def test_label_in_saveto_column__errors(self):
         self.assertPyxformXform(
             name="data",
@@ -246,6 +263,23 @@ class EntitiesTest(PyxformTestCase):
             errored=True,
             error__contains=[
                 "[row : 2] Invalid save_to name: the entity property name 'label' is reserved."
+            ],
+        )
+
+    def test_lAbEl_in_saveto_column__errors(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |         |       |       |         |
+            |          | type    | name  | label | save_to |
+            |          | text    | a     | A     | lAbEl   |
+            | entities |         |       |       |         |
+            |          | dataset | label |       |         |
+            |          | trees   | a     |       |         |
+            """,
+            errored=True,
+            error__contains=[
+                "[row : 2] Invalid save_to name: the entity property name 'lAbEl' is reserved."
             ],
         )
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -60,7 +60,7 @@ class EntitiesTest(PyxformTestCase):
             """,
             errored=True,
             error__contains=[
-                "Invalid dataset name: '__sweet' starts with reserved prefix __."
+                "Invalid entity list name: '__sweet' starts with reserved prefix __."
             ],
         )
 
@@ -77,7 +77,7 @@ class EntitiesTest(PyxformTestCase):
             """,
             errored=True,
             error__contains=[
-                "Invalid dataset name: '$sweet'. Dataset names must begin with a letter, colon, or underscore. Other characters can include numbers or dashes."
+                "Invalid entity list name: '$sweet'. Names must begin with a letter, colon, or underscore. Other characters can include numbers or dashes."
             ],
         )
 
@@ -94,7 +94,7 @@ class EntitiesTest(PyxformTestCase):
             """,
             errored=True,
             error__contains=[
-                "Invalid dataset name: 's.w.eet'. Dataset names may not include periods."
+                "Invalid entity list name: 's.w.eet'. Names may not include periods."
             ],
         )
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -6,7 +6,6 @@ class EntitiesTest(PyxformTestCase):
     def test_basic_entity_creation_building_blocks(self):
         self.assertPyxformXform(
             name="data",
-            debug=True,
             md="""
             | survey   |         |       |       |
             |          | type    | name  | label |
@@ -335,4 +334,21 @@ class EntitiesTest(PyxformTestCase):
             |          | trees       | ${size}|       |         |
             """,
             errored=False,
+        )
+
+    def test_list_name_alias_to_dataset(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey   |           |       |       |
+            |          | type      | name  | label |
+            |          | text      | a     | A     |
+            | entities |           |       |       |
+            |          | list_name | label |       |
+            |          | trees     | a     |       |
+            """,
+            xml__xpath_match=[
+                "/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity",
+                '/h:html/h:head/x:model/x:instance/x:data/x:meta/x:entity[@dataset = "trees"]',
+            ],
         )


### PR DESCRIPTION
Closes https://github.com/XLSForm/pyxform/issues/652

#### Why is this the best possible solution? Were any other approaches considered?
The intent is to match the user-facing language of "Entity List". We discussed some alternative column names but decided that `list_name` has the advantage of being consistent with the `choices` sheet. The meanings are slightly different but very much related.

I went back and forth on the text of error messages. At first I made them generic ("Invalid name") but then I thought that would be too hard to use. I think using "entity list" in the messages is friendlier. People who have existing forms with `dataset` are early adopters so hopefully are in a better position to figure out the issue if they run into the message.

I also added on case-sensitive checking of reserved entity property names.

#### What are the regression risks?
This area is well-tested and the change is small so I don't think there are any.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
https://github.com/getodk/docs/pull/1651

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments