### PR TITLE
Prepare for point release off of 1.12.x branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 Pyxform Changelog
 
+v1.12.2, 2023-09-15
+* Alias list_name to dataset in entities sheet by @lognaturel in https://github.com/XLSForm/pyxform/pull/654
+
 v1.12.1, 2023-05-16
 * Pass through itemset ref case by @lognaturel in https://github.com/XLSForm/pyxform/pull/644
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,11 @@
-===============
-pyxform v1.12.1
-===============
+========
+pyxform
+========
 
-|python| |black|
+|pypi| |python| |black|
+
+.. |pypi| image:: https://badge.fury.io/py/pyxform.svg
+    :target: https://badge.fury.io/py/pyxform
 
 .. |python| image:: https://img.shields.io/badge/python-3.7,3.8,3.9-blue.svg
     :target: https://www.python.org/downloads
@@ -124,7 +127,7 @@ Releasing pyxform
 3. Draft a new GitHub release with the list of merged PRs. Follow the title and description pattern of the previous release.
 4. Checkout a release branch from latest upstream master.
 5. Update ``CHANGES.txt`` with the text of the draft release.
-6. Update ``README.rst``, ``setup.py``, ``pyxform/__init__.py`` with the new release version number.
+6. Update ``setup.py``, ``pyxform/__init__.py`` with the new release version number.
 7. Commit, push the branch, and initiate a pull request. Wait for tests to pass, then merge the PR.
 8. Tag the release and it will automatically be published
 


### PR DESCRIPTION
We have some changes in the `master` branch that we want to exercise just a little bit more before releasing. We also have some small changes we'd like to release now. We're going to release off of the 1.12.x branch and update the changelog here so it's consistent with the PyPi released version.