### PR TITLE
Add rows to parameters column for text type 

### DIFF
--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1306,6 +1306,21 @@ def workbook_to_json(
             parent_children_array.append(new_dict)
             continue
 
+        if question_type == "text":
+            new_dict = row.copy()
+
+            if "rows" in parameters.keys():
+                try:
+                    int(parameters["rows"])
+                except ValueError:
+                    raise PyXFormError("Parameter rows must have an integer value.")
+
+                new_dict["control"] = new_dict.get("control", {})
+                new_dict["control"].update({"rows": parameters["rows"]})
+
+            parent_children_array.append(new_dict)
+            continue
+
         if question_type == "photo":
             new_dict = row.copy()
 

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1308,6 +1308,7 @@ def workbook_to_json(
 
         if question_type == "text":
             new_dict = row.copy()
+            parameters_generic.validate(parameters=parameters, allowed=("rows",))
 
             if "rows" in parameters.keys():
                 try:

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1314,7 +1314,10 @@ def workbook_to_json(
                 try:
                     int(parameters["rows"])
                 except ValueError:
-                    raise PyXFormError("Parameter rows must have an integer value.")
+                    raise PyXFormError(
+                        (ROW_FORMAT_STRING % row_number)
+                        + " Parameter rows must have an integer value."
+                    )
 
                 new_dict["control"] = new_dict.get("control", {})
                 new_dict["control"].update({"rows": parameters["rows"]})

--- a/tests/test_parameters_rows.py
+++ b/tests/test_parameters_rows.py
@@ -19,6 +19,19 @@ class TestParametersRows(PyxformTestCase):
             xml__xpath_match=["/h:html/h:body/x:input[@ref='/data/name' and @rows='7']"],
         )
 
+    def test_using_the_number_of_rows_specified_in_parameters_if_it_is_set_in_both_its_own_column_and_the_parameters_column(
+        self,
+    ):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                |                |
+            |        | type   | name     | label | body::rows     | parameters     |
+            |        | text   | name     | Name  | 7              | rows=8         |
+            """,
+            xml__xpath_match=["/h:html/h:body/x:input[@ref='/data/name' and @rows='8']"],
+        )
+
     def test_adding_rows_to_the_body_if_set_in_parameters(
         self,
     ):

--- a/tests/test_parameters_rows.py
+++ b/tests/test_parameters_rows.py
@@ -5,7 +5,7 @@ Test text rows parameter.
 from tests.pyxform_test_case import PyxformTestCase
 
 
-class TestRows(PyxformTestCase):
+class TestParametersRows(PyxformTestCase):
     def test_adding_rows_to_the_body_if_set_in_its_own_column(
         self,
     ):

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -47,5 +47,7 @@ class TestRows(PyxformTestCase):
                     name="data",
                     md=md.format(case=case),
                     errored=True,
-                    error__contains=["Parameter rows must have an integer value."],
+                    error__contains=[
+                        "[row : 2] Parameter rows must have an integer value."
+                    ],
                 )

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+Test text rows parameter.
+"""
+from tests.pyxform_test_case import PyxformTestCase
+
+
+class TestRows(PyxformTestCase):
+    def test_adding_rows_to_the_body_if_set_in_its_own_column(
+        self,
+    ):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                |
+            |        | type   | name     | label | body::rows     |
+            |        | text   | name     | Name  | 7              |
+            """,
+            xml__xpath_match=["/h:html/h:body/x:input[@ref='/data/name' and @rows='7']"],
+        )
+
+    def test_adding_rows_to_the_body_if_set_in_parameters(
+        self,
+    ):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |        |          |       |                |
+            |        | type   | name     | label | parameters     |
+            |        | text   | name     | Name  | rows=7         |
+            """,
+            xml__xpath_match=["/h:html/h:body/x:input[@ref='/data/name' and @rows='7']"],
+        )
+
+    def test_throwing_error_if_rows_set_in_parameters_but_the_value_is_not_an_integer(
+        self,
+    ):
+        parameters = ("rows=", "rows=foo", "rows=7.5")
+        md = """
+        | survey |        |          |       |                 |
+        |        | type   | name     | label | parameters      |
+        |        | text   | name     | Name  | {case}          |
+        """
+        for case in parameters:
+            with self.subTest(msg=case):
+                self.assertPyxformXform(
+                    name="data",
+                    md=md.format(case=case),
+                    errored=True,
+                    error__contains=["Parameter rows must have an integer value."],
+                )


### PR DESCRIPTION
Closes #616 

#### Why is this the best possible solution? Were any other approaches considered?
The solution is consistent with how we handle other parameters in other question types. In My previous pull request, I added a new parameter for image questions (see https://github.com/XLSForm/pyxform/pull/659) and this one solves the problem in the same way. I haven't considered any other approaches. I know there is a plan to [Create a framework for adding parameters](https://github.com/XLSForm/pyxform/issues/592) and then the solution would be different but for now we should follow the existing patterns.

#### What are the regression risks?
This is not a risky change. It's isolated and touches only reading parameters used in text questions.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
Yes: https://github.com/XLSForm/xlsform.github.io/issues/254

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments