### PR TITLE
602: preserve order of columns when building secondary instance

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -296,7 +296,7 @@ class Survey(Section):
                 itext_id = "-".join([list_name, str(idx)])
                 choice_element_list.append(node("itextId", itext_id))
 
-            for name, value in sorted(choice.items()):
+            for name, value in choice.items():
                 if isinstance(value, str) and name != "label":
                     choice_element_list.append(node(name, str(value)))
                 if (

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -80,10 +80,8 @@ def node(*args, **kwargs) -> DetachableElement:
     assert len(unicode_args) <= 1
     parsed_string = False
 
-    # Convert the kwargs xml attribute dictionary to a xml.dom.minidom.Element. Sort the
-    # attributes to guarantee a consistent order across Python versions.
-    # See pyxform_test_case.reorder_attributes for details.
-    for k, v in iter(sorted(kwargs.items())):
+    # Convert the kwargs xml attribute dictionary to a xml.dom.minidom.Element.
+    for k, v in iter(kwargs.items()):
         if k in blocked_attributes:
             continue
         if k == "toParseString":

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -58,19 +58,22 @@ def merge_dicts(dict_a, dict_b, default_key="default"):
     if dict_b is None or dict_b == {}:
         return dict_a
 
-    if type(dict_a) is not dict:
+    if not isinstance(dict_a, dict):
         if default_key in dict_b:
             return dict_b
         dict_a = {default_key: dict_a}
-    if type(dict_b) is not dict:
+    if not isinstance(dict_b, dict):
         if default_key in dict_a:
             return dict_a
         dict_b = {default_key: dict_b}
 
-    all_keys = set(dict_a.keys()).union(set(dict_b.keys()))
+    # Union keys but retain order (as opposed to set()), preferencing dict_a then dict_b.
+    # E.g. {"a": 1, "b": 2} + {"c": 3, "a": 4} -> {"a": None, "b": None, "c": None}
+    all_keys = {k: None for k in dict_a.keys()}
+    all_keys.update({k: None for k in dict_b.keys()})
 
     out_dict = dict()
-    for key in all_keys:
+    for key in all_keys.keys():
         out_dict[key] = merge_dicts(dict_a.get(key), dict_b.get(key), default_key)
     return out_dict
 

--- a/tests/fixtures/strings.ini
+++ b/tests/fixtures/strings.ini
@@ -11,8 +11,6 @@ test_simple_integer_question_type_multilingual_control = <input ref="/test/integ
 test_simple_integer_question_type_multilingual_binding = <bind nodeset="/test/integer_q" type="int"/>
 test_simple_date_question_type_multilingual_control = <input ref="/test/date_q"><label ref="jr:itext('/test/date_q:label')"/></input>
 test_simple_date_question_type_multilingual_binding = <bind nodeset="/test/date_q" type="date"/>
-test_simple_phone_number_question_type_multilingual_control = <input ref="/test/phone_number_q"><label ref="jr:itext('/test/phone_number_q:label')"/><hint>Enter numbers only.</hint></input>
-test_simple_phone_number_question_type_multilingual_binding = <bind constraint="regex(., '^\d*$')" nodeset="/test/phone_number_q" type="string"/>
 test_simple_select_all_question_multilingual_control = <select ref="/test/select_all_q"><label ref="jr:itext('/test/select_all_q:label')"/><item><label ref="jr:itext('/test/select_all_q/f:label')"/><value>f</value></item><item><label ref="jr:itext('/test/select_all_q/g:label')"/><value>g</value></item><item><label ref="jr:itext('/test/select_all_q/h:label')"/><value>h</value></item></select>
 test_simple_select_all_question_multilingual_binding = <bind nodeset="/test/select_all_q" type="string"/>
 test_simple_decimal_question_multilingual_control = <input ref="/test/decimal_q"><label ref="jr:itext('/test/decimal_q:label')"/></input>

--- a/tests/j2x_question_tests.py
+++ b/tests/j2x_question_tests.py
@@ -154,20 +154,31 @@ class Json2XformQuestionValidationTests(TestCase):
             "name": "phone_number_q",
         }
 
-        expected_phone_number_control_xml = self.config.get(
-            self.cls_name, "test_simple_phone_number_question_type_multilingual_control"
-        )
-
-        expected_phone_number_binding_xml = self.config.get(
-            self.cls_name, "test_simple_phone_number_question_type_multilingual_binding"
-        )
-
         q = create_survey_element_from_dict(simple_phone_number_question)
         self.s.add_child(q)
-        self.assertEqual(ctw(q.xml_control()), expected_phone_number_control_xml)
 
-        if TESTING_BINDINGS:
-            self.assertEqual(ctw(q.xml_bindings()), expected_phone_number_binding_xml)
+        # Inspect XML Control
+        observed = q.xml_control()
+        self.assertEqual("input", observed.nodeName)
+        self.assertEqual("/test/phone_number_q", observed.attributes["ref"].nodeValue)
+        observed_label = observed.childNodes[0]
+        self.assertEqual("label", observed_label.nodeName)
+        self.assertEqual(
+            "jr:itext('/test/phone_number_q:label')",
+            observed_label.attributes["ref"].nodeValue,
+        )
+        observed_hint = observed.childNodes[1]
+        self.assertEqual("hint", observed_hint.nodeName)
+        self.assertEqual("Enter numbers only.", observed_hint.childNodes[0].nodeValue)
+
+        # Inspect XML Binding
+        expected = {
+            "nodeset": "/test/phone_number_q",
+            "type": "string",
+            "constraint": r"regex(., '^\d*$')",
+        }
+        observed = {k: v for k, v in q.xml_bindings()[0].attributes.items()}
+        self.assertDictEqual(expected, observed)
 
     def test_simple_select_all_question_multilingual(self):
         """

--- a/tests/test_choices_sheet.py
+++ b/tests/test_choices_sheet.py
@@ -106,3 +106,32 @@ class ChoicesSheetTest(PyxformTestCase):
                 """,
             ],
         )
+
+    def test_choices_extra_columns_output_order_matches_xlsform(self):
+        """Should find that element order matches column order."""
+        md = """
+        | survey   |                    |      |       |
+        |          | type               | name | label |
+        |          | select_one choices | a    | A     |
+        | choices  |                    |      |       |
+        |          | list_name          | name | label | geometry                 |
+        |          | choices            | 1    |       | 46.5841618 7.0801379 0 0 |
+        |          | choices            | 2    |       | 35.8805082 76.515057 0 0 |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_contains=[
+                """
+                /h:html/h:head/x:model/x:instance[@id='choices']/x:root/x:item[
+                  ./x:name[position() = 1 and text() = '1']
+                  and ./x:geometry[position() = 2]
+                ]
+                """
+                """
+                /h:html/h:head/x:model/x:instance[@id='choices']/x:root/x:item[
+                  ./x:name[position() = 1 and text() = '2']
+                  and ./x:geometry[position() = 2]
+                ]
+                """
+            ],
+        )

--- a/tests/test_external_instances.py
+++ b/tests/test_external_instances.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 
 from pyxform.errors import PyXFormError
 from tests.pyxform_test_case import PyxformTestCase, PyxformTestError
+from tests.xpath_helpers.choices import xpc
 
 
 class ExternalInstanceTests(PyxformTestCase):
@@ -229,21 +230,10 @@ class ExternalInstanceTests(PyxformTestCase):
                 '<instance id="city1" src="jr://file/city1.xml"/>',
                 '<instance id="cities" src="jr://file-csv/cities.csv"/>',
                 '<instance id="fruits" src="jr://file-csv/fruits.csv"/>',
-                """
-      <instance id="states">
-        <root>
-          <item>
-            <label>Pass</label>
-            <name>1</name>
-          </item>
-          <item>
-            <label>Fail</label>
-            <name>2</name>
-          </item>
-        </root>
-      </instance>
-""",
             ],  # noqa
+            xml__xpath_match=[
+                xpc.model_instance_choices_label("states", (("1", "Pass"), ("2", "Fail")))
+            ],
         )
 
     def test_cannot__use_different_src_same_id__select_then_internal(self):

--- a/tests/test_whitespace.py
+++ b/tests/test_whitespace.py
@@ -27,9 +27,16 @@ class WhitespaceTest(PyxformTestCase):
             |                | id_string          | public_key | submission_url                                    |
             |                | tutorial_encrypted | MIIB       | https://odk.ona.io/random_person/submission       |
           """
-
-        survey = self.md_to_pyxform_survey(md_raw=md)
-        expected = """<submission action="https://odk.ona.io/random_person/submission" base64RsaPublicKey="MIIB" method="post"/>"""
-        xml = survey._to_pretty_xml()
-        self.assertEqual(1, xml.count(expected))
-        self.assertPyxformXform(md=md, xml__contains=expected, run_odk_validate=True)
+        self.assertPyxformXform(
+            md=md,
+            run_odk_validate=True,
+            xml__xpath_contains=[
+                """
+                /h:html/h:head/x:model/x:submission[
+                  @action='https://odk.ona.io/random_person/submission'
+                  and @method='post'
+                  and @base64RsaPublicKey='MIIB'
+                ]
+                """
+            ],
+        )


### PR DESCRIPTION
Closes #602

#### Why is this the best possible solution? Were any other approaches considered?

Seems like main reason for sorting in the first place was to help satisfy string-based matching for XML output tests. Since there are XPath test facilities now, it's not necessary. These changes remove explicit sorting in `survey.py` and `utils.py`, and remove order randomisation in `xls2json.py` that happened via conversion of keys to set objects - it now uses dicts instead so that order is preserved. 

There is still a bit of sorting going on in `pyxform_test_case.py` and `xform_test_case.py` but since that's purely for testing it would not affect #602.

#### What are the regression risks?

If XForm consumers (such as Collect or Enketo or other tools) expected the sorted behaviour, those consumers would have to sort elements instead of expecting the form elements to be pre-sorted. Similarly, pyxform library users would need to apply a sort if needed e.g. in the survey choices dict.

It's possible that some tests might randomly fail either in CI or later on, because of the string matching thing. In which case it would only be a failure related to element or attribute order. I ran the test suite about a dozen times to try and catch them all.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No I would say this is an internal implementation detail. The spec doesn't say the elements should be sorted.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments