### PR TITLE
660: nicer error about choices sheet when extension omitted in select_.._from_file

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -18,6 +18,12 @@ control = {
     "loop": constants.LOOP,
     "looped group": constants.REPEAT,
 }
+select_from_file = {
+    "select_one_from_file": constants.SELECT_ONE,
+    "select_multiple_from_file": constants.SELECT_ALL_THAT_APPLY,
+    "select one from file": constants.SELECT_ONE,
+    "select multiple from file": constants.SELECT_ALL_THAT_APPLY,
+}
 select = {
     "add select one prompt using": constants.SELECT_ONE,
     "add select multiple prompt using": constants.SELECT_ALL_THAT_APPLY,
@@ -29,10 +35,7 @@ select = {
     "select_multiple": constants.SELECT_ALL_THAT_APPLY,
     "select all that apply": constants.SELECT_ALL_THAT_APPLY,
     "select_one_external": constants.SELECT_ONE_EXTERNAL,
-    "select_one_from_file": constants.SELECT_ONE,
-    "select_multiple_from_file": constants.SELECT_ALL_THAT_APPLY,
-    "select one from file": constants.SELECT_ONE,
-    "select multiple from file": constants.SELECT_ALL_THAT_APPLY,
+    **select_from_file,
     "rank": constants.RANK,
 }
 cascading = {

--- a/pyxform/entities/entities_parsing.py
+++ b/pyxform/entities/entities_parsing.py
@@ -125,11 +125,9 @@ def validate_entity_saveto(
 
 
 def validate_entities_columns(row: Dict):
-    expected = set(EC.value_list())
-    observed = set(row.keys())
-    extra = observed.difference(expected)
+    extra = {k: None for k in row.keys() if k not in EC.value_list()}
     if 0 < len(extra):
-        fmt_extra = ", ".join((f"'{k}'" for k in extra))
+        fmt_extra = ", ".join((f"'{k}'" for k in extra.keys()))
         msg = (
             f"The entities sheet included the following unexpected column(s): {fmt_extra}. "
             f"These columns are not supported by this version of pyxform. Please either: "

--- a/pyxform/validators/pyxform/select_from_file.py
+++ b/pyxform/validators/pyxform/select_from_file.py
@@ -1,6 +1,8 @@
 import re
+from pathlib import Path
 
-from pyxform.constants import ROW_FORMAT_STRING
+from pyxform import aliases
+from pyxform.constants import EXTERNAL_INSTANCE_EXTENSIONS, ROW_FORMAT_STRING
 from pyxform.errors import PyXFormError
 
 VALUE_OR_LABEL_TEST_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9\-_\.]*$")
@@ -42,3 +44,20 @@ def value_or_label_check(name: str, value: str, row_number: int) -> None:
         msg = value_or_label_format_msg(name=name, row_number=row_number)
         raise PyXFormError(msg)
     return None
+
+
+def validate_list_name_extension(
+    select_command: str, list_name: str, row_number: int
+) -> None:
+    """For select_from_file types, the list_name should end with a supported extension."""
+    list_path = Path(list_name)
+    if select_command in aliases.select_from_file and (
+        1 != len(list_path.suffixes)
+        or list_path.suffix not in EXTERNAL_INSTANCE_EXTENSIONS
+    ):
+        exts = ", ".join((f"'{e}'" for e in EXTERNAL_INSTANCE_EXTENSIONS))
+        raise PyXFormError(
+            ROW_FORMAT_STRING % row_number
+            + f" File name for '{select_command} {list_name}' should end with one of "
+            + f"the supported file extensions: {exts}"
+        )

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -23,7 +23,7 @@ from pyxform.entities.entities_parsing import (
 )
 from pyxform.errors import PyXFormError
 from pyxform.utils import PYXFORM_REFERENCE_REGEX, default_is_dynamic
-from pyxform.validators.pyxform import parameters_generic, select_from_file_params
+from pyxform.validators.pyxform import parameters_generic, select_from_file
 from pyxform.validators.pyxform.android_package_name import validate_android_package_name
 from pyxform.validators.pyxform.translations_checks import SheetTranslations
 from pyxform.xls2json_backends import csv_to_dict, xls_to_dict, xlsx_to_dict
@@ -1120,6 +1120,11 @@ def workbook_to_json(
                         + "List name not in external choices sheet: "
                         + list_name
                     )
+                select_from_file.validate_list_name_extension(
+                    select_command=parse_dict["select_command"],
+                    list_name=list_name,
+                    row_number=row_number,
+                )
                 if (
                     list_name not in choices
                     and select_type != constants.SELECT_ONE_EXTERNAL
@@ -1209,13 +1214,13 @@ def workbook_to_json(
                     )
 
                 if "value" in parameters.keys():
-                    select_from_file_params.value_or_label_check(
+                    select_from_file.value_or_label_check(
                         name="value",
                         value=parameters["value"],
                         row_number=row_number,
                     )
                 if "label" in parameters.keys():
-                    select_from_file_params.value_or_label_check(
+                    select_from_file.value_or_label_check(
                         name="label",
                         value=parameters["label"],
                         row_number=row_number,

--- a/tests/test_entities_create.py
+++ b/tests/test_entities_create.py
@@ -418,7 +418,7 @@ class EntitiesCreationTest(PyxformTestCase):
             |          | trees     | a     | !     |
             """,
             errored=True,
-            error_contains=[
+            error__contains=[
                 "The entities sheet included the following unexpected column(s): 'what'"
             ],
         )
@@ -434,7 +434,9 @@ class EntitiesCreationTest(PyxformTestCase):
             |          | trees     | a     | !     | ?   |
             """,
             errored=True,
-            error_contains=[
-                "The entities sheet included the following unexpected column(s): 'what', 'why'"
+            error__contains=[
+                "The entities sheet included the following unexpected column(s):",
+                "'what'",
+                "'why'",
             ],
         )


### PR DESCRIPTION
Closes #660

#### Why is this the best possible solution? Were any other approaches considered?

Previously, an error about a missing sheet name may be thrown, e.g.  if the form didn't contain any regular choices. This change explicitly checks for file extension, in order to show a nicer error message. The existing constants, aliases, and validation pattern are used.

#### What are the regression risks?

I think this is just an enhancement, since the old behaviour was confusing, and in both cases an error is raised.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No it's already documented in the template, just an easy mistake to make

![image](https://github.com/XLSForm/pyxform/assets/6345269/ea0225fb-172c-4d3c-9224-0972551614f0)

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments