### PR TITLE
576: fix _count suffix name clash with repeats targeting another item

### DIFF
--- a/pyxform/parsing/expression.py
+++ b/pyxform/parsing/expression.py
@@ -1,0 +1,14 @@
+from typing import Iterable
+
+from pyxform.utils import parse_expression
+
+
+def is_single_token_expression(expression: str, token_types: Iterable[str]) -> bool:
+    """
+    Does the expression contain single token of one of the provided token types?
+    """
+    tokens, _ = parse_expression(text=expression.strip())
+    if 1 == len(tokens) and tokens[0].name in token_types:
+        return True
+    else:
+        return False

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -22,6 +22,7 @@ from pyxform.entities.entities_parsing import (
     validate_entity_saveto,
 )
 from pyxform.errors import PyXFormError
+from pyxform.parsing.expression import is_single_token_expression
 from pyxform.utils import PYXFORM_REFERENCE_REGEX, default_is_dynamic
 from pyxform.validators.pyxform import parameters_generic, select_from_file_params
 from pyxform.validators.pyxform.android_package_name import validate_android_package_name
@@ -1017,24 +1018,29 @@ def workbook_to_json(
                         )
                     new_json_dict[constants.COLUMNS] = choices[list_name]
 
-                # Generate a new node for the jr:count column so
-                # xpath expressions can be used.
+                # Generate a new node for the jr:count column so xpath expressions can be used.
                 repeat_count_expression = new_json_dict.get("control", {}).get("jr:count")
                 if repeat_count_expression:
-                    generated_node_name = new_json_dict["name"] + "_count"
-                    parent_children_array.append(
-                        {
-                            "name": generated_node_name,
-                            "bind": {
-                                "readonly": "true()",
-                                "calculate": repeat_count_expression,
-                            },
-                            "type": "calculate",
-                        }
+                    # Simple expressions don't require a new node, they can reference directly.
+                    simple_expression = is_single_token_expression(
+                        expression=repeat_count_expression, token_types=["PYXFORM_REF"]
                     )
-                    new_json_dict["control"]["jr:count"] = (
-                        "${" + generated_node_name + "}"
-                    )
+                    if not simple_expression:
+                        generated_node_name = new_json_dict["name"] + "_count"
+                        parent_children_array.append(
+                            {
+                                "name": generated_node_name,
+                                "bind": {
+                                    "readonly": "true()",
+                                    "calculate": repeat_count_expression,
+                                },
+                                "type": "calculate",
+                            }
+                        )
+                        # This re-directs the body/repeat ref to the above generated node.
+                        new_json_dict["control"]["jr:count"] = (
+                            "${" + generated_node_name + "}"
+                        )
 
                 # Code to deal with table_list appearance flags
                 # (for groups of selects)

--- a/tests/test_expected_output/repeat_date_test.xml
+++ b/tests/test_expected_output/repeat_date_test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:odk="http://www.opendatakit.org/xforms">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <h:head>
     <h:title>repeat_date_test</h:title>
     <model odk:xforms-version="1.0.0">
@@ -7,7 +7,6 @@
         <repeat_date_test id="repeat_date_test">
           <generated_note_name_2/>
           <repeat_count/>
-          <repeat_test_count/>
           <repeat_test jr:template="">
             <table_list_3/>
             <table_list_4/>
@@ -36,7 +35,6 @@
       </instance>
       <bind nodeset="/repeat_date_test/generated_note_name_2" readonly="true()" type="string"/>
       <bind calculate="1" nodeset="/repeat_date_test/repeat_count" type="string"/>
-      <bind calculate=" /repeat_date_test/repeat_count " nodeset="/repeat_date_test/repeat_test_count" readonly="true()" type="string"/>
       <bind nodeset="/repeat_date_test/repeat_test/table_list_3" type="string"/>
       <bind nodeset="/repeat_date_test/repeat_test/table_list_4" type="string"/>
       <bind nodeset="/repeat_date_test/generated_note_name_8" readonly="true()" type="string"/>
@@ -49,7 +47,7 @@
     </input>
     <group ref="/repeat_date_test/repeat_test">
       <label></label>
-      <repeat jr:count=" /repeat_date_test/repeat_test_count " nodeset="/repeat_date_test/repeat_test">
+      <repeat jr:count=" /repeat_date_test/repeat_count " nodeset="/repeat_date_test/repeat_test">
         <select1 ref="/repeat_date_test/repeat_test/table_list_3">
           <label>Q1</label>
           <itemset nodeset="instance('yes_no')/root/item">


### PR DESCRIPTION
Closes #576

#### Why is this the best possible solution? Were any other approaches considered?

Given a form with an item named "a_count" that holds the desired repeat count, and a repeat called "a", when pyxform injects an internal item suffixed with "_count" to hold the repeat count for "a", then pyxform emits a duplicate survey element error (2x "a_count"). This PR adds new condition to existing logic, where if the expression parses to a single pyxform reference, then the item injection is skipped.

As described in #435 (case 1), when the repeat count is just a reference to another item, then that item could be used directly, instead of injecting an item with a calculate item, thereby causing a name clash and thus the error. I tried also satisfying #435 case 3 by allowing single number expressions, but a few test failed with "something broke the parser!" which I think would be due to https://github.com/getodk/javarosa/issues/399

For future reference, the section of code in `xls2json.py` around repeats is a bit confusing but the dict structure of json["control"]["jr:count"] is a result of processing in dealias_and_group_headers (repeat_count -> control::jr:count -> dict).

#### What are the regression risks?

ODK Validate seems OK with this, but I have not tested it with Collect or Enketo. If they or any other XForms tool expects there to always be an injected instance item to hold the count, then I expect there would be an error.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No, it's an internal form structure issue, which addresses a user-facing bug.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments