### PR TITLE
653: tidy up is_label_dynamic to return condition directly

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -172,14 +172,11 @@ def share_same_repeat_parent(survey, xpath, context_xpath, reference_parent=Fals
 
 @lru_cache(maxsize=65536)  # 2^16
 def is_label_dynamic(label: str) -> bool:
-    if (
+    return (
         label is not None
         and isinstance(label, str)
         and re.search(BRACKETED_TAG_REGEX, label) is not None
-    ):
-        return True
-    else:
-        return False
+    )
 
 
 def recursive_dict():


### PR DESCRIPTION
Follow-up to PR #666 [comment](https://github.com/XLSForm/pyxform/pull/666#discussion_r1412552492)

#### Why is this the best possible solution? Were any other approaches considered?

Old way: 5/10, works but looks gross. New way: 10/10

#### What are the regression risks?

None

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

None

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments