### PR TITLE
597: Refactor PyxformTestCase to use explicit keyword arguments

### DIFF
--- a/tests/builder_tests.py
+++ b/tests/builder_tests.py
@@ -50,7 +50,8 @@ class BuilderTests(TestCase):
             self.survey_out_dict, utils.path_to_text_fixture("how_old_are_you.json")
         )
 
-    def test_create_from_file_object(self):
+    @staticmethod
+    def test_create_from_file_object():
         path = utils.path_to_text_fixture("yes_or_no_question.xls")
         with open(path, "rb") as f:
             create_survey_from_xls(f)

--- a/tests/test_choices_sheet.py
+++ b/tests/test_choices_sheet.py
@@ -90,7 +90,6 @@ class ChoicesSheetTest(PyxformTestCase):
             |          | choices            | 1    |       |
             |          | choices            | 2    |       |
             """,
-            run_odk_validate=False,
             xml__xpath_match=[
                 xpq.body_select1_itemset("a"),
                 """
@@ -120,18 +119,18 @@ class ChoicesSheetTest(PyxformTestCase):
         """
         self.assertPyxformXform(
             md=md,
-            xml__xpath_contains=[
+            xml__xpath_match=[
                 """
                 /h:html/h:head/x:model/x:instance[@id='choices']/x:root/x:item[
-                  ./x:name[position() = 1 and text() = '1']
-                  and ./x:geometry[position() = 2]
+                  ./x:name = ./x:*[position() = 1 and text() = '1']
+                  and ./x:geometry = ./x:*[position() = 2 and text() = '46.5841618 7.0801379 0 0']
                 ]
-                """
+                """,
                 """
                 /h:html/h:head/x:model/x:instance[@id='choices']/x:root/x:item[
-                  ./x:name[position() = 1 and text() = '2']
-                  and ./x:geometry[position() = 2]
+                  ./x:name = ./x:*[position() = 1 and text() = '2']
+                  and ./x:geometry = ./x:*[position() = 2 and text() = '35.8805082 76.515057 0 0']
                 ]
-                """
+                """,
             ],
         )

--- a/tests/test_entities_create.py
+++ b/tests/test_entities_create.py
@@ -372,7 +372,6 @@ class EntitiesCreationTest(PyxformTestCase):
             |          | dataset     | label  |       |         |
             |          | trees       | ${size}|       |         |
             """,
-            errored=False,
         )
 
     def test_list_name_alias_to_dataset(self):
@@ -404,7 +403,6 @@ class EntitiesCreationTest(PyxformTestCase):
             |          | dataset      | label | update_if  | create_if  | entity_id |
             |          | trees        | a     | id != ''   | id = ''    | ${a}      |
             """,
-            errored=False,
             warnings_count=0,
         )
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -177,5 +177,4 @@ class FieldsTests(PyxformTestCase):
             |         | date        | date     | Observation date  |
             |         | text        | activity | Describe activity |
             """,
-            errored=False,
         )

--- a/tests/test_form_name.py
+++ b/tests/test_form_name.py
@@ -19,7 +19,6 @@ class FormNameTest(PyxformTestCase):
             |          | id_string | name |
             |          | some-id   | data |
             """,
-            kwargs={},
             autoname=False,
         )
 

--- a/tests/test_pyxformtestcase.py
+++ b/tests/test_pyxformtestcase.py
@@ -47,7 +47,6 @@ class PyxformTestCaseNonMarkdownSurveyAlternatives(PyxformTestCase):
         """
         self.assertPyxformXform(
             ss_structure={"survey": [{"type": "note", "name": "n1", "label": "Note 1"}]},
-            errored=False,
         )
 
 
@@ -63,7 +62,6 @@ class XlsFormPyxformSurveyTest(PyxformTestCase):
             |        | type | name | label |
             |        | note | q    | Q     |
             """,
-            {},
             autoname=True,
         )
 

--- a/tests/test_randomize_itemsets.py
+++ b/tests/test_randomize_itemsets.py
@@ -132,7 +132,7 @@ class RandomizeItemsetsTest(PyxformTestCase):
     def test_randomized_select_one_bad_param(self):
         self.assertPyxformXform(
             name="data",
-            errored="true",
+            errored=True,
             md="""
             | survey |                    |         |       |                |
             |        | type               | name    | label | parameters     |
@@ -152,7 +152,7 @@ class RandomizeItemsetsTest(PyxformTestCase):
     def test_randomized_select_one_bad_randomize(self):
         self.assertPyxformXform(
             name="data",
-            errored="true",
+            errored=True,
             md="""
             | survey |                    |         |       |                  |
             |        | type               | name    | label | parameters       |
@@ -171,7 +171,7 @@ class RandomizeItemsetsTest(PyxformTestCase):
     def test_randomized_select_one_bad_seed(self):
         self.assertPyxformXform(
             name="data",
-            errored="true",
+            errored=True,
             md="""
             | survey |                    |         |       |                             |
             |        | type               | name    | label | parameters                  |
@@ -190,7 +190,7 @@ class RandomizeItemsetsTest(PyxformTestCase):
     def test_randomized_select_one_seed_without_randomize(self):
         self.assertPyxformXform(
             name="data",
-            errored="true",
+            errored=True,
             md="""
             | survey |                    |         |       |                  |
             |        | type               | name    | label | parameters       |

--- a/tests/test_repeat.py
+++ b/tests/test_repeat.py
@@ -376,7 +376,6 @@ class TestRepeat(PyxformTestCase):
                 '<itemset nodeset="/data/rep[starts-with( ./name , &quot;b&quot;)]">',
                 '<itemset nodeset="/data/rep[ ./demographics/age  &gt; 18]">',
             ],
-            run_odk_validate=False,
         )
 
     def test_choice_from_previous_repeat_answers_in_child_repeat(self):
@@ -997,7 +996,6 @@ class TestRepeat(PyxformTestCase):
         """
         self.assertPyxformXform(
             md=md,
-            debug=True,
             xml__xpath_match=[
                 # repeat references existing count element directly.
                 """

--- a/tests/test_secondary_instance_translations.py
+++ b/tests/test_secondary_instance_translations.py
@@ -139,8 +139,6 @@ class TestSecondaryInstanceTest(PyxformTestCase):
             name="data",
             id_string="some-id",
             md=xform_md,
-            errored=False,
-            debug=False,
             itext__contains=[
                 '<text id="list-0">',
                 '<text id="list-1">',
@@ -171,7 +169,6 @@ class TestSecondaryInstanceTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md=xform_md,
-            debug=False,
             itext__contains=[
                 '<text id="choices-0">',
                 '<value> One - <output value=" /data/txt "/>',

--- a/tests/test_settings_auto_send_delete.py
+++ b/tests/test_settings_auto_send_delete.py
@@ -18,7 +18,6 @@ class SettingsAutoSendDelete(PyxformTestCase):
             |          | auto_send    |           |           |
             |          | true         |           |           |
             """,
-            debug=False,
             xml__contains=['<submission orx:auto-send="true"/>'],
         )
 
@@ -34,7 +33,6 @@ class SettingsAutoSendDelete(PyxformTestCase):
             |          | auto_delete  |           |           |
             |          | true         |           |           |
             """,
-            debug=False,
             xml__contains=['<submission orx:auto-delete="true"/>'],
         )
 
@@ -50,7 +48,6 @@ class SettingsAutoSendDelete(PyxformTestCase):
             |          | auto_delete  | auto_send |           |
             |          | false        | false     |           |
             """,
-            debug=False,
             xml__contains=['<submission orx:auto-delete="false" orx:auto-send="false"/>'],
         )
 
@@ -72,7 +69,6 @@ class SettingsAutoSendDelete(PyxformTestCase):
             |          | bRHBG7TQm+Afnx0s5E2bGIT5jB5cj9YaX6BqZSeodpafQjpXEJg6uufxF1Ni3Btv   |           |           |
             |          |  4wIDAQAB                                                          |           |           |
             """,
-            debug=False,
             xml__contains=[
                 '<submission base64RsaPublicKey="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwOHPJWD9zc8JPBZj/UtC" orx:auto-send="false"/>'
             ],
@@ -90,7 +86,6 @@ class SettingsAutoSendDelete(PyxformTestCase):
             |          | submission_url                                        | auto_send |           |
             |          | https://odk.ona.io/random_person/submission           | false     |           |
             """,
-            debug=False,
             xml__contains=[
                 '<submission action="https://odk.ona.io/random_person/submission" method="post" orx:auto-send="false"/>'
             ],

--- a/tests/test_sheet_columns.py
+++ b/tests/test_sheet_columns.py
@@ -28,7 +28,6 @@ class InvalidSurveyColumnsTests(PyxformTestCase):
         self.assertPyxformXform(
             name="invalidcols",
             ss_structure={"survey": [{"value": "q1", "type": "text", "label": "label"}]},
-            errored=False,
         )
 
     def test_label_or_hint__must_be_provided(self):
@@ -101,8 +100,6 @@ class InvalidSurveyColumnsTests(PyxformTestCase):
             |        | integer | age     | the age       |
             |        | text    | gender  | the gender    |
             """,
-            errored=False,
-            debug=False,
         )
 
 
@@ -111,7 +108,8 @@ class InvalidChoiceSheetColumnsTests(PyxformTestCase):
     Invalid choice sheet column tests
     """
 
-    def _simple_choice_ss(self, choice_sheet=None):
+    @staticmethod
+    def _simple_choice_ss(choice_sheet=None):
         """
         Return simple choices sheet
         """
@@ -142,7 +140,6 @@ class InvalidChoiceSheetColumnsTests(PyxformTestCase):
                     {"list_name": "l1", "name": "c2", "label": "choice 2"},
                 ]
             ),
-            errored=False,
         )
 
     def test_invalid_choices_sheet_fails(self):
@@ -175,7 +172,6 @@ class InvalidChoiceSheetColumnsTests(PyxformTestCase):
                     {"bad_column": "l1", "name": "l1c1", "label": "choice 2"},
                 ]
             ),
-            debug=False,
             errored=True,
             # some basic keywords that should be in the error:
             error__contains=["choices", "name", "list_name"],

--- a/tests/test_table_list.py
+++ b/tests/test_table_list.py
@@ -41,5 +41,4 @@ class TableListTest(PyxformTestCase):
             name="table-list-appearance-mod",
             md=MD,
             xml__contains=[XML_CONTAINS],
-            debug=False,
         )

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -522,7 +522,6 @@ class TestTranslations(PyxformTestCase):
         """
         self.assertPyxformXform(
             md=md,
-            debug=True,
             xml__xpath_match=[
                 xpq.body_select1_itemset("f"),
                 xpq.body_label_inline("select1", "f", "f"),

--- a/tests/test_typed_calculates.py
+++ b/tests/test_typed_calculates.py
@@ -185,6 +185,5 @@ class TypedCalculatesTest(PyxformTestCase):
         |        | type       | name | label       | calculation | default  |
         |        | calculate  | a    |             |             | random() |
         """,
-            errored=False,
             instance__contains=["<a/>"],
         )

--- a/tests/test_unicode_rtl.py
+++ b/tests/test_unicode_rtl.py
@@ -13,7 +13,6 @@ class UnicodeStrings(PyxformTestCase):
             |        | type | name    | label |
             |        | text | snowman | ☃     |
             """,
-            errored=False,
             xml__contains=["<label>☃</label>"],
         )
 
@@ -49,8 +48,6 @@ class UnicodeStrings(PyxformTestCase):
                 ],
                 "settings": [{"version": "q(‘-’)p"}],
             },
-            errored=False,
-            validate=False,
             name="quoth",
             xml__contains=[
                 "'single-quoted",

--- a/tests/test_upload_question.py
+++ b/tests/test_upload_question.py
@@ -13,7 +13,6 @@ class UploadTest(PyxformTestCase):
             |        | type | name    | label |
             |        | image | photo | Take a photo: |
             """,
-            errored=False,
             xml__contains=[
                 '<bind nodeset="/data/photo" type="binary"/>',
                 '<upload mediatype="image/*" ref="/data/photo">',
@@ -30,7 +29,6 @@ class UploadTest(PyxformTestCase):
             |        | type | name    | label |
             |        | audio | recording1 | Record a sound: |
             """,
-            errored=False,
             xml__contains=[
                 '<bind nodeset="/data/recording1" type="binary"/>',
                 '<upload mediatype="audio/*" ref="/data/recording1">',
@@ -47,7 +45,6 @@ class UploadTest(PyxformTestCase):
             |        | type | name    | label |
             |        | file | file1 | Upload a file: |
             """,
-            errored=False,
             xml__contains=[
                 '<bind nodeset="/data/file1" type="binary"/>',
                 '<upload mediatype="application/*" ref="/data/file1">',
@@ -64,7 +61,6 @@ class UploadTest(PyxformTestCase):
             |        | type | name    | label | body::accept |
             |        | file | upload_a_pdf | Upload a PDF: | application/pdf |
             """,
-            errored=False,
             xml__contains=['<upload accept="application/pdf"'],
         )
 
@@ -78,6 +74,5 @@ class UploadTest(PyxformTestCase):
             |        | text  | text1            | Text            |                               |
             |        | image | image1           | Take a Photo:   | watermark=${watermark_phrase} |
             """,  # noqa
-            errored=False,
             xml__contains=["watermark= /data/watermark_phrase "],
         )

--- a/tests/test_whitespace.py
+++ b/tests/test_whitespace.py
@@ -29,7 +29,7 @@ class WhitespaceTest(PyxformTestCase):
           """
         self.assertPyxformXform(
             md=md,
-            xml__xpath_contains=[
+            xml__xpath_match=[
                 """
                 /h:html/h:head/x:model/x:submission[
                   @action='https://odk.ona.io/random_person/submission'

--- a/tests/test_xform2json.py
+++ b/tests/test_xform2json.py
@@ -30,11 +30,7 @@ class TestXForm2JSON(PyxformTestCase):
         |         | fruits                 | 3     | Apple      | Pomme    |
         """
 
-        survey = self.md_to_pyxform_survey(
-            md_raw=md,
-            kwargs={"id_string": "id", "name": "multi-language", "title": "some-title"},
-            autoname=False,
-        )
+        survey = self.md_to_pyxform_survey(md_raw=md)
         expected = survey.to_xml()
         generated_json = survey.to_json()
 

--- a/tests/test_xls2json.py
+++ b/tests/test_xls2json.py
@@ -59,7 +59,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             self.assertPyxformXform(
                 name="test",
                 md=CHOICES.format(name=n),
-                errored=False,
                 warnings_count=0,
             )
 
@@ -70,7 +69,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             self.assertPyxformXform(
                 name="test",
                 md=EXTERNAL_CHOICES.format(name=n),
-                errored=False,
                 warnings_count=0,
             )
 
@@ -81,7 +79,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             self.assertPyxformXform(
                 name="test",
                 md=SETTINGS.format(name=n),
-                errored=False,
                 warnings_count=0,
             )
 
@@ -92,7 +89,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             self.assertPyxformXform(
                 name="test",
                 md=SURVEY.format(name=n),
-                errored=False,
                 warnings_count=0,
             )
 
@@ -127,7 +123,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             self.assertPyxformXform(
                 name="test",
                 md=SETTINGS.format(name=n),
-                errored=False,
                 warnings_count=0,
             )
 
@@ -173,7 +168,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             |          | list_name     | name      | label |
             |          | l1            | 1         | C1    |
             """,
-            errored=False,
             warnings_count=0,
         )
 
@@ -234,7 +228,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             |          | l1                     | 1         | 1     |               |
             |          | l1                     | 2         | 2     |               |
             """,
-            errored=False,
             warnings_count=0,
         )
 
@@ -272,7 +265,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             self.assertPyxformXform(
                 name="test",
                 md=SETTINGS.format(name=n),
-                errored=False,
                 warnings__contains=[self.err_similar_found, "'{}'".format(n)],
             )
 
@@ -291,7 +283,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             |          | id_string | title     |       |
             |          | my_id     | My Survey |       |
             """,
-            errored=False,
             warnings_count=0,
         )
 
@@ -310,7 +301,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             |          | id_string | title     |       |
             |          | my_id     | My Survey |       |
             """,
-            errored=False,
             warnings__contains=[self.err_similar_found, "'setting'", "'stetings'"],
         )
 
@@ -341,7 +331,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             |         | type      | name      | label |
             |         | text      | q1        | Q1    |
             """,
-            errored=False,
             warnings_count=0,
         )
 
@@ -395,7 +384,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             self.assertPyxformXform(
                 name="test",
                 md=SETTINGS.format(name=n),
-                errored=False,
                 warnings_count=0,
             )
 
@@ -430,7 +418,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             |          | id_string     | title     |
             |          | my_id         | My Survey |
             """,
-            errored=False,
             warnings_count=0,
         )
 
@@ -600,7 +587,6 @@ class TestXLS2JSONSheetNameHeuristics(PyxformTestCase):
             |          | list_name | name      | label |
             |          | l1        | c1        | One   |
             """,
-            errored=False,
             warnings_count=0,
         )
 

--- a/tests/test_xlsform_headers.py
+++ b/tests/test_xlsform_headers.py
@@ -36,8 +36,6 @@ class XlsFormHeadersTest(PyxformTestCase):
             |        | decimal   | amount  | Counter |               |
             |        | calculate | doubled | Doubled | ${amount} * 2 |
             """,
-            errored=False,
-            debug=False,
         )
 
     def test_form_id_variant(self):
@@ -49,9 +47,9 @@ class XlsFormHeadersTest(PyxformTestCase):
 |              | id_string                         | version                | form_id     |
 |              | get_option_from_two_repeat_answer | vWvvk3GYzjXcJQyvTWELej | AUTO-v2-jef |
 """
-        kwargs = {"name": "None", "title": "AUTO-v2-jef", "id_string": "AUTO-v2-jef"}
-
-        survey = self.md_to_pyxform_survey(md, kwargs=kwargs, autoname=False)
+        survey = self.md_to_pyxform_survey(
+            md_raw=md, title="AUTO-v2-jef", id_string="AUTO-v2-jef", autoname=False
+        )
 
         self.assertEqual(survey.id_string, "AUTO-v2-jef")
         self.assertEqual(survey.version, "vWvvk3GYzjXcJQyvTWELej")

--- a/tests/test_xlsform_spec.py
+++ b/tests/test_xlsform_spec.py
@@ -56,6 +56,7 @@ class TestWarnings(PyxformTestCase):
         """  # noqa
         warnings = []
         self.assertPyxformXform(
+            debug=True,
             name="spec_test",
             md=md,
             warnings=warnings,

--- a/tests/tutorial_test.py
+++ b/tests/tutorial_test.py
@@ -9,6 +9,7 @@ from tests import utils
 
 
 class TutorialTests(TestCase):
-    def test_create_from_path(self):
+    @staticmethod
+    def test_create_from_path():
         path = utils.path_to_text_fixture("tutorial.xls")
         create_survey_from_path(path)

--- a/tests/xform_test_case/bug_tests.py
+++ b/tests/xform_test_case/bug_tests.py
@@ -151,7 +151,8 @@ class DefaultTimeTest(XFormTestCase):
 class ValidateWrapper(unittest.TestCase):
     maxDiff = None
 
-    def runTest(self):
+    @staticmethod
+    def runTest():
         filename = "ODKValidateWarnings.xlsx"
         path_to_excel_file = os.path.join(bug_example_xls.PATH, filename)
         # Get the xform output path:


### PR DESCRIPTION
Closes #597

Also removed any test calls that use the default keyword value, if it seemed like that was not intentional. For example debug=False.

#### Why is this the best possible solution? Were any other approaches considered?

Could have maybe added a kwarg key check, but there was some of that already and it didn't catch everything.

#### What are the regression risks?

This is changing a test function used by many (most?) tests, so if the changes are not correct then pyxform won't be tested properly. Assuming they are correct, it would only be a problem if a fork or other library used PyxformTestCase.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments