### PR TITLE
678: itextId node not added to instance items for choice list names with dashes in multilingual forms

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -319,7 +319,7 @@ class Survey(Section):
                 for items in self._translations.values()
                 for k, v in items.items()
                 if v.get(constants.TYPE, "") == constants.CHOICE
-                and k.split("-")[0] == list_name
+                and "-".join(k.split("-")[:-1]) == list_name
             )
             if 0 < len(choices):
                 multi_language = True

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1737,7 +1737,7 @@ class TestTranslationsChoices(PyxformTestCase):
         )
 
     def test_specify_other__choice_filter(self):
-        """Should raise an error since these featuers are unsupported together."""
+        """Should raise an error since these features are unsupported together."""
         md = """
         | survey  |                        |       |            |
         |         | type                   | name  | label      | choice_filter |
@@ -1752,4 +1752,36 @@ class TestTranslationsChoices(PyxformTestCase):
             md=md,
             errored=True,
             error__contains=["[row : 3] Choice filter not supported with or_other."],
+        )
+
+    def test_choice_name_containing_dash_output_itext(self):
+        """Should output itext when list_name contains a dash (itextId separator)."""
+        md = """
+        | survey  |                      |       |            |
+        |         | type                 | name  | label:en   | label:fr |
+        |         | select_one with_us   | q0    | Q1 EN      | Q1 FR    |
+        |         | select_one with-dash | q1    | Q2 EN      | Q2 FR    |
+        | choices |           |      |          |
+        |         | list name | name | label:en | label:fr |
+        |         | with_us   | na   | l1a-en   | l1a-fr   |
+        |         | with_us   | nb   | l1b-en   | l1b-fr   |
+        |         | with-dash | na   | l2a-en   | l2a-fr   |
+        |         | with-dash | nb   | l2b-en   | l2b-fr   |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                xpc.model_itext_choice_text_label_by_pos(
+                    "en", "with_us", ("l1a-en", "l1b-en")
+                ),
+                xpc.model_itext_choice_text_label_by_pos(
+                    "en", "with-dash", ("l2a-en", "l2b-en")
+                ),
+                xpc.model_itext_choice_text_label_by_pos(
+                    "fr", "with_us", ("l1a-fr", "l1b-fr")
+                ),
+                xpc.model_itext_choice_text_label_by_pos(
+                    "fr", "with-dash", ("l2a-fr", "l2b-fr")
+                ),
+            ],
         )


### PR DESCRIPTION
Closes #678

#### Why is this the best possible solution? Were any other approaches considered?

In survey.py, _generate_static_instances has a check for multi_lang, which involves matching the list_name to the translations dict. That split the list_name on the itextId separator (a dash) but a dash can also appear in the list_name, so it was broken when a list_name contained a dash.

The fix is to still split the string, but chop off the last group (the number) to do the list_name match. Another way could be to not use a string internally (e.g. a tuple) to avoid parsing issues, then output a string when necessary.

#### What are the regression risks?

This fixes a regression.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments