### PR TITLE
585: add test for allowed duplicate choices with translations

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -126,6 +126,39 @@ class FieldsTests(PyxformTestCase):
             ],
         )
 
+    def test_duplicate_choices_with_allow_choice_duplicates_setting_and_translations(
+        self,
+    ):
+        md = """
+            | survey  |                 |      |       |
+            |         | type            | name | label::en | label::ko |
+            |         | select_one list | S1   | s1        | 질문 1     |
+            | choices |                 |      |                |
+            |         | list name       | name | label::en      | label::ko |
+            |         | list            | a    | Pass           | 패스       |
+            |         | list            | b    | Fail           | 실패       |
+            |         | list            | c    | Skipped        | 건너뛴     |
+            |         | list            | c    | Not Applicable | 해당 없음  |
+            | settings |                |                         |
+            |          | id_string      | allow_choice_duplicates |
+            |          | Duplicates     | Yes                     |
+            """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                xpc.model_itext_choice_text_label_by_pos(
+                    "en",
+                    "list",
+                    ("Pass", "Fail", "Skipped", "Not Applicable"),
+                ),
+                xpc.model_itext_choice_text_label_by_pos(
+                    "ko",
+                    "list",
+                    ("패스", "실패", "건너뛴", "해당 없음"),
+                ),
+            ],
+        )
+
     def test_choice_list_without_duplicates_is_successful(self):
         md = """
             | survey  |                 |      |       |


### PR DESCRIPTION
Closes #585

Prior to always generating secondary instances, this scenario would have not output the duplicate choices, even if allowed. Now, itext are identified by choice position so it's not a problem. This test adds to the existing suite by using translations with the duplicates.

#### Why is this the best possible solution? Were any other approaches considered?

Since no code changes are needed, this test is just to improve coverage and verify the fix.

#### What are the regression risks?

None

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments