### PR TITLE
689: translations not generated for choice list used with search()

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -166,6 +166,12 @@ class Option(SurveyElement):
     def xml_control(self):
         raise NotImplementedError()
 
+    def _translation_path(self, display_element):
+        choice_itext_id = self.get("_choice_itext_id")
+        if choice_itext_id is not None:
+            return choice_itext_id
+        return super()._translation_path(display_element=display_element)
+
 
 class MultipleChoiceQuestion(Question):
     def __init__(self, **kwargs):

--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -272,7 +272,8 @@ class SurveyElement(dict):
             and self.to_json_dict() == y.to_json_dict()
         )
 
-    def _translation_path(self, display_element):
+    def _translation_path(self, display_element: str) -> str:
+        """Get an itextId based on the element XPath and display type."""
         return self.get_xpath() + ":" + display_element
 
     def get_translations(self, default_language):

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -31,7 +31,6 @@ from pyxform.xls2json_backends import csv_to_dict, xls_to_dict, xlsx_to_dict
 from pyxform.xlsparseutils import find_sheet_misspellings, is_valid_xml_tag
 
 SMART_QUOTES = {"\u2018": "'", "\u2019": "'", "\u201c": '"', "\u201d": '"'}
-SEARCH_APPEARANCE_REGEX = re.compile(r"search\(.*?\)")
 
 
 def print_pyobj_to_json(pyobj, path=None):
@@ -362,19 +361,8 @@ def add_choices_info_to_question(
         choice_filter = ""
     if file_extension is None:
         file_extension = ""
-    try:
-        is_search = bool(
-            SEARCH_APPEARANCE_REGEX.search(
-                question[constants.CONTROL][constants.APPEARANCE]
-            )
-        )
-    except (KeyError, TypeError):
-        is_search = False
 
-    # External selects from a "search" appearance alone don't work in Enketo. In Collect
-    # they must have the "item" elements in the body, rather than in an "itemset".
-    if not is_search:
-        question[constants.ITEMSET] = list_name
+    question[constants.ITEMSET] = list_name
 
     if choice_filter:
         # External selects e.g. type = "select_one_external city".

--- a/tests/test_expected_output/search_and_select.xml
+++ b/tests/test_expected_output/search_and_select.xml
@@ -12,6 +12,14 @@
           </meta>
         </search_and_select>
       </instance>
+      <instance id="fruits">
+        <root>
+          <item>
+            <name>name_key</name>
+            <label>name</label>
+          </item>
+        </root>
+      </instance>
       <bind nodeset="/search_and_select/fruit" type="string"/>
       <bind nodeset="/search_and_select/note_fruit" readonly="true()" type="string"/>
       <bind jr:preload="uid" nodeset="/search_and_select/meta/instanceID" readonly="true()" type="string"/>

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1553,6 +1553,75 @@ class TestTranslationsChoices(PyxformTestCase):
         )
 
 
+class TestTranslationsSearchAppearance(PyxformTestCase):
+    """Translations behaviour with the search() appearance."""
+
+    def test_shared_choice_list(self):
+        """Should include translation for search() items, sharing the choice list"""
+        md = """
+        | survey  |               |       |            |           |                    |
+        |         | type          | name  | label::en  | label::fr | appearance         |
+        |         | select_one c1 | q1    | Question 1 | Chose 1   | search('my_file')  |
+        |         | select_one c2 | q2    | Question 2 | Chose 2   |                    |
+        | choices |               |       |            |           |
+        |         | list_name     | name  | label::en  | label::fr |
+        |         | c1            | na    | la-e       | la-f      |
+        |         | c1            | nb    | lb-e       | lb-f      |
+        |         | c2            | na    | la-e       | la-f      |
+        """
+        self.assertPyxformXform(
+            md=md,
+            run_odk_validate=True,
+            xml__xpath_match=[
+                "/h:html/h:body/x:select1/x:item[./x:value/text()='na']",
+                xpc.model_itext_choice_text_label_by_pos("en", "c1", ("la-e", "lb-e")),
+                xpc.model_itext_choice_text_label_by_pos("fr", "c1", ("la-f", "lb-f")),
+                xpc.model_itext_choice_text_label_by_pos("en", "c2", ("la-e",)),
+                xpc.model_itext_choice_text_label_by_pos("fr", "c2", ("la-f",)),
+            ],
+        )
+
+    def test_single_question_single_choice(self):
+        """Should include translation for search() items, edge case of single elements"""
+        md = """
+        | survey  |               |       |            |           |                    |
+        |         | type          | name  | label::en  | label::fr | appearance         |
+        |         | select_one c1 | q1    | Question 1 | Chose 1   | search('my_file')  |
+        | choices |               |       |            |           |
+        |         | list_name     | name  | label::en  | label::fr |
+        |         | c1            | na    | la-e       | la-f      |
+        """
+        self.assertPyxformXform(
+            md=md,
+            run_odk_validate=True,
+            xml__xpath_match=[
+                "/h:html/h:body/x:select1/x:item[./x:value/text()='na']",
+                xpc.model_itext_choice_text_label_by_pos("en", "c1", ("la-e",)),
+                xpc.model_itext_choice_text_label_by_pos("fr", "c1", ("la-f",)),
+            ],
+        )
+
+    def test_name_clashes(self):
+        """Should include translation for search() items, avoids any name clashes."""
+        md = """
+        | survey  |                 |       |            |           |                    |
+        |         | type            | name  | label::en  | label::fr | appearance         |
+        |         | select_one c1-0 | c1-0  | Question 1 | Chose 1   | search('my_file')  |
+        | choices |               |       |            |           |
+        |         | list_name     | name  | label::en  | label::fr |
+        |         | c1-0          | na    | la-e       | la-f      |
+        """
+        self.assertPyxformXform(
+            md=md,
+            run_odk_validate=True,
+            xml__xpath_match=[
+                "/h:html/h:body/x:select1/x:item[./x:value/text()='na']",
+                xpc.model_itext_choice_text_label_by_pos("en", "c1-0", ("la-e",)),
+                xpc.model_itext_choice_text_label_by_pos("fr", "c1-0", ("la-f",)),
+            ],
+        )
+
+
 class TestTranslationsOrOther(PyxformTestCase):
     """Translations behaviour with or_other."""
 


### PR DESCRIPTION
- existing test case search_and_select didn't cover the multi-language case, which requires that itext is emitted for the inline selects.
- approach and details described in Survey._redirect_is_search_itext.

Closes #689

#### Why is this the best possible solution? Were any other approaches considered?

#### What are the regression risks?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] included test cases for core behavior and edge cases in `tests`
- [ ] run `nosetests` and verified all tests pass
- [ ] run `black pyxform tests` to format code
- [ ] verified that any code or assets from external sources are properly credited in comments