### PR TITLE
Prevent instance name conflicts with search and pulldata

### DIFF
--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -30,6 +30,7 @@ from pyxform.utils import (
     PatchedText,
     get_languages_with_bad_tags,
     has_dynamic_label,
+    has_search_appearance_function,
     node,
 )
 from pyxform.validators import enketo_validate, odk_validate
@@ -42,7 +43,8 @@ RE_INSTANCE_SECONDARY_REF = re.compile(
     r"(instance\(.*\)\/root\/item\[.*?(\$\{.*\})\]\/.*?)\s"
 )
 RE_PULLDATA = re.compile(r"(pulldata\s*\(\s*)(.*?),")
-SEARCH_APPEARANCE_REGEX = re.compile(r"search\(.*?\)")
+RE_XML_OUTPUT = re.compile(r"\n.*(<output.*>)\n(\s\s)*")
+RE_XML_TEXT = re.compile(r"(>)\n\s*(\s[^<>\s].*?)\n\s*(\s</)", re.DOTALL)
 
 
 class InstanceInfo:
@@ -686,16 +688,7 @@ class Survey(Section):
         :param element: A select type question.
         :return: None, the question/children are modified in-place.
         """
-        try:
-            is_search = bool(
-                SEARCH_APPEARANCE_REGEX.search(
-                    element[constants.CONTROL][constants.APPEARANCE]
-                )
-            )
-        except (KeyError, TypeError):
-            is_search = False
-        if is_search:
-            element[constants.ITEMSET] = ""
+        if has_search_appearance_function(element):
             for i, opt in enumerate(element.get(constants.CHILDREN, [])):
                 opt["_choice_itext_id"] = f"{element['list_name']}-{i}"
 

--- a/pyxform/utils.py
+++ b/pyxform/utils.py
@@ -10,12 +10,13 @@ import os
 import re
 from collections import namedtuple
 from json.decoder import JSONDecodeError
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 from xml.dom import Node
 from xml.dom.minidom import Element, Text, _write_data, parseString
 
 import openpyxl
 import xlrd
+from pyxform import constants
 
 from pyxform.xls2json_backends import is_empty, xls_value_to_unicode, xlsx_value_to_str
 
@@ -28,7 +29,6 @@ BRACKETED_TAG_REGEX = re.compile(r"\${(last-saved#)?(.*?)}")
 LAST_SAVED_REGEX = re.compile(r"\${last-saved#(.*?)}")
 PYXFORM_REFERENCE_REGEX = re.compile(r"\$\{(.*?)\}")
 NODE_TYPE_TEXT = (Node.TEXT_NODE, Node.CDATA_SECTION_NODE)
-
 
 NSMAP = {
     "xmlns": "http://www.w3.org/2002/xforms",
@@ -325,6 +325,20 @@ def has_dynamic_label(choice_list: "List[Dict[str, str]]") -> bool:
         ):
             return True
     return False
+
+
+def has_search_appearance_function(question: Dict[str, Any]) -> bool:
+    """
+    The search() appearance can be applied to selects to use a Collect-only database-backed select implementation.
+    """
+    try:
+        return bool(
+            re.compile(r"search\(.*?\)").search(
+                question[constants.CONTROL][constants.APPEARANCE]
+            )
+        )
+    except (KeyError, TypeError):
+        return False
 
 
 def levenshtein_distance(a: str, b: str) -> int:

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -23,7 +23,11 @@ from pyxform.entities.entities_parsing import (
 )
 from pyxform.errors import PyXFormError
 from pyxform.parsing.expression import is_single_token_expression
-from pyxform.utils import PYXFORM_REFERENCE_REGEX, default_is_dynamic
+from pyxform.utils import (
+    PYXFORM_REFERENCE_REGEX,
+    default_is_dynamic,
+    has_search_appearance_function,
+)
 from pyxform.validators.pyxform import parameters_generic, select_from_file
 from pyxform.validators.pyxform.android_package_name import validate_android_package_name
 from pyxform.validators.pyxform.translations_checks import SheetTranslations
@@ -362,7 +366,8 @@ def add_choices_info_to_question(
     if file_extension is None:
         file_extension = ""
 
-    question[constants.ITEMSET] = list_name
+    if not has_search_appearance_function(question):
+        question[constants.ITEMSET] = list_name
 
     if choice_filter:
         # External selects e.g. type = "select_one_external city".

--- a/tests/test_external_instances.py
+++ b/tests/test_external_instances.py
@@ -610,3 +610,20 @@ class ExternalInstanceTests(PyxformTestCase):
                 '<instance id="instance4" src="jr://file-csv/instance4.csv"/>',
             ],
         )
+
+    def test_search_and_pulldata(self):
+        """Should not generate secondary instance for choice list used to configure search()"""
+        md = """
+        | survey  |                   |         |             |                    |             |
+        |         | type              | name    | label       | appearance         | calculation |
+        |         | select_one fruits | fruit   | Question 1  | search('fruits')   |             |
+        |         | calculate         | calc    |             |                    | pulldata('fruits', 'this', 'that', ${fruit}) |
+        | choices |               |       |        |
+        |         | list_name     | name  | label  |
+        |         | fruits        | na    | la     |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=["/h:html/h:body/x:select1/x:item[./x:value/text()='na']"],
+            xml__excludes=['<instance id="fruits">']
+        )


### PR DESCRIPTION
Closes #694

#### Why is this the best possible solution? Were any other approaches considered?
It's easy to follow and brings back some logic that existed previously. I think pulling the regex into a function in utils makes usage easier to understand.

#### What are the regression risks?
This is a response to an unexpected regression. It feels very low-risk to me. Any possible risk is limited to the `search()` functionality.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `nosetests` and verified all tests pass
- [x] run `black pyxform tests` to format code
- [x] verified that any code or assets from external sources are properly credited in comments