### PR TITLE
Add Dockerfile and compose config for testing

### DIFF
--- a/contrib/images/Dockerfile
+++ b/contrib/images/Dockerfile
@@ -1,0 +1,32 @@
+ARG PYTHON_IMG_TAG
+FROM python:${PYTHON_IMG_TAG}-slim-bookworm as base
+
+
+FROM base as build
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends \
+        "build-essential" \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /code
+COPY ../../ ./
+# Install with dev dependencies for tests
+RUN pip install .[dev] \
+    --user --no-warn-script-location --no-cache-dir
+
+
+FROM base as runtime
+ENV PATH="/root/.local/bin:$PATH"
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends \
+        "openjdk-17-jdk" \
+    && rm -rf /var/lib/apt/lists/*
+# Copy Python deps from build to runtime
+COPY --from=build \
+    /root/.local \
+    /root/.local
+WORKDIR /code
+ENTRYPOINT ["xlsform"]

--- a/contrib/images/docker-compose.yml
+++ b/contrib/images/docker-compose.yml
@@ -1,0 +1,19 @@
+
+version: "3"
+
+name: pyxform
+
+services:
+  pyxform:
+    image: "ghcr.io/xlsform/pyxform:ci"
+    build:
+      context: ../../
+      dockerfile: contrib/images/Dockerfile
+      target: runtime
+      args:
+        PYTHON_IMG_TAG: "${PYTHON_IMG_TAG:-3.10}"
+    volumes:
+      - ../../tests:/code/tests
+      - ../../pyxform:/root/.local/lib/python3.10/site-packages/pyxform
+    entrypoint: ["python", "-m", "unittest", "--verbose"]
+    restart: "unless-stopped"


### PR DESCRIPTION
#### Included

- I didn't want to install Java on my system, so created a quick docker setup for running the tests.
- I added to the `contrib` dir to make it clear that this is not maintained by the authors, but thought it could be useful to some (perhaps included in the docs?).
- The included dockerfile installs all dev dependencies, but could be easily extended to only install production dependencies in a stage, then used for a repository image to distribute pyxform: e.g. `ghcr.io/xlsform/pyxform`.
- I used this setup for testing in PR #698

#### Why is this the best possible solution? Were any other approaches considered?

- A did base this on Python 3.10, while the repo only states 3.7-3.9 are supported.
- I use pyxform without issues in a project based on Python 3.10.
- Python 3.7 is EOL, 3.8 will be EOL in about 0.5yr and 3.9 EOL in about 1.5yr.

#### What are the regression risks?

- None

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

- Could possibly be included in the docs about testing, if useful.
- Simply run `docker compose -f contrib/images/docker-compose.yml run --rm pyxform` to run the tests.
- Or `docker compose -f contrib/images/docker-compose.yml run --rm pyxform -k test_xls2form_convert_via_api` for a specific test.
- Or `docker run -i ghcr.io/xlsform/pyxform:ci --help` to use the `xlsform` CLI tool.

#### Before submitting this PR, please make sure you have:
- [ ] included test cases for core behavior and edge cases in `tests`
- [ ] run `python -m unittest` and verified all tests pass
- [ ] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [ ] verified that any code or assets from external sources are properly credited in comments