### PR TITLE
707: Detect instance expressions with double quotes

### DIFF
--- a/pyxform/parsing/instance_expression.py
+++ b/pyxform/parsing/instance_expression.py
@@ -1,7 +1,7 @@
 import re
 from typing import TYPE_CHECKING
 
-from pyxform.utils import BRACKETED_TAG_REGEX, EXPRESSION_LEXER, ExpLexerToken
+from pyxform.utils import BRACKETED_TAG_REGEX, EXPRESSION_LEXER, ExpLexerToken, node
 
 if TYPE_CHECKING:
     from pyxform.survey import Survey
@@ -116,7 +116,10 @@ def replace_with_output(xml_text: str, context: "SurveyElement", survey: "Survey
                 lambda m: survey._var_repl_function(m, context),
                 old_str,
             )
-            new_strings.append((start, end, old_str, f'<output value="{new_str}" />'))
+            # Generate a node so that character escapes are applied.
+            new_strings.append(
+                (start, end, old_str, node("output", value=new_str).toxml())
+            )
         # Position-based replacement avoids strings which are substrings of other
         # replacements being inserted incorrectly. Offset tracking deals with changing
         # expression positions due to incremental replacement.


### PR DESCRIPTION
Closes #707 

Like other functions, argument value(s) (instance name) should be allowed to be wrapped in single or double quotes. Previously only singles quotes worked.

#### Why is this the best possible solution? Were any other approaches considered?

Uses existing XML generation function. Not sure why there was an f-string used before, maybe some kind of conflict with something else that has since been resolved.

#### What are the regression risks?

It's more consistent with the rest of pyxform now, but maybe some users don't want XML escapes here. As shown in the updated tests, other characters that will be escaped now are `<>&`.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments