### PR TITLE
713: support offline entities spec v2024.1.0 via opt-in setting

### DIFF
--- a/pyxform/constants.py
+++ b/pyxform/constants.py
@@ -114,7 +114,8 @@ CURRENT_XFORMS_VERSION = "1.0.0"
 
 # The ODK entities spec version that generated forms comply to
 ENTITIES_CREATE_VERSION = "2022.1.0"
-CURRENT_ENTITIES_VERSION = "2023.1.0"
+ENTITIES_UPDATE_VERSION = "2023.1.0"
+ENTITIES_OFFLINE_VERSION = "2024.1.0"
 ENTITY = "entity"
 ENTITY_FEATURES = "entity_features"
 ENTITIES_RESERVED_PREFIX = "__"
@@ -126,6 +127,7 @@ class EntityColumns(StrEnum):
     CREATE_IF = "create_if"
     UPDATE_IF = "update_if"
     LABEL = "label"
+    OFFLINE = "offline"
 
 
 DEPRECATED_DEVICE_ID_METADATA_FIELDS = ["subscriberid", "simserial"]

--- a/pyxform/entities/entities_parsing.py
+++ b/pyxform/entities/entities_parsing.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pyxform import constants as const
+from pyxform.aliases import yes_no
 from pyxform.errors import PyXFormError
 from pyxform.xlsparseutils import find_sheet_misspellings, is_valid_xml_tag
 
@@ -28,6 +29,7 @@ def get_entity_declaration(
     create_condition = entity_row.get(EC.CREATE_IF, None)
     update_condition = entity_row.get(EC.UPDATE_IF, None)
     entity_label = entity_row.get(EC.LABEL, None)
+    offline = yes_no.get(entity_row.get(EC.OFFLINE, None), None)
 
     if update_condition and not entity_id:
         raise PyXFormError(
@@ -53,6 +55,7 @@ def get_entity_declaration(
             EC.CREATE_IF: create_condition,
             EC.UPDATE_IF: update_condition,
             EC.LABEL: entity_label,
+            EC.OFFLINE: offline,
         },
     }
 

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -586,9 +586,13 @@ class Survey(Section):
 
         entity_features = getattr(self, constants.ENTITY_FEATURES, [])
         if len(entity_features) > 0:
-            if "update" in entity_features:
+            if "offline" in entity_features:
                 model_kwargs["entities:entities-version"] = (
-                    constants.CURRENT_ENTITIES_VERSION
+                    constants.ENTITIES_OFFLINE_VERSION
+                )
+            elif "update" in entity_features:
+                model_kwargs["entities:entities-version"] = (
+                    constants.ENTITIES_UPDATE_VERSION
                 )
             else:
                 model_kwargs["entities:entities-version"] = (

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1538,9 +1538,13 @@ def workbook_to_json(
 
     if len(entity_declaration) > 0:
         json_dict[constants.ENTITY_FEATURES] = ["create"]
+        entity_parameters = entity_declaration.get(constants.PARAMETERS, {})
 
-        if entity_declaration.get("parameters", {}).get("entity_id", None):
+        if entity_parameters.get(constants.EntityColumns.ENTITY_ID, None):
             json_dict[constants.ENTITY_FEATURES].append("update")
+
+        if entity_parameters.get(constants.EntityColumns.OFFLINE, None):
+            json_dict[constants.ENTITY_FEATURES].append("offline")
 
         meta_children.append(entity_declaration)
 

--- a/tests/test_entities_create.py
+++ b/tests/test_entities_create.py
@@ -1,3 +1,5 @@
+from pyxform import constants as co
+
 from tests.pyxform_test_case import PyxformTestCase
 
 
@@ -436,5 +438,45 @@ class EntitiesCreationTest(PyxformTestCase):
                 "The entities sheet included the following unexpected column(s):",
                 "'what'",
                 "'why'",
+            ],
+        )
+
+    def test_entities_offline_opt_in__yes(self):
+        """Should find offline spec version, if opted-in."""
+        self.assertPyxformXform(
+            md="""
+            | survey   |
+            |          | type | name | label |
+            |          | text | a    | A     |
+            | entities |
+            |          | dataset | label | offline |
+            |          | trees   | a     | yes     |
+            """,
+            xml__xpath_match=[
+                f"""
+                  /h:html/h:head/x:model[
+                    @entities:entities-version = "{co.ENTITIES_OFFLINE_VERSION}"
+                  ]
+                """,
+            ],
+        )
+
+    def test_entities_offline_opt_in__no(self):
+        """Should find create spec version, if not opted-in."""
+        self.assertPyxformXform(
+            md="""
+            | survey   |
+            |          | type      | name  | label |
+            |          | text      | a     | A     |
+            | entities |
+            |          | dataset   | label | offline |
+            |          | trees     | a     | no      |
+            """,
+            xml__xpath_match=[
+                f"""
+                  /h:html/h:head/x:model[
+                    @entities:entities-version = "{co.ENTITIES_CREATE_VERSION}"
+                  ]
+                """,
             ],
         )


### PR DESCRIPTION
Closes #713

#### Why is this the best possible solution? Were any other approaches considered?

Implements #713: opt-in via a new entities setting `offline` with a value `yes`. If not opted-in, retain all current behaviour. If opted-in, for the create case, use the new spec version. If opted-in, for the update case, use the new spec version and emit trunkVersion/branchId properties and bindings.

Deviations to the requirements:

1. Bindings readonly property. I used the existing function in `entity_declaration.py`, `EntityDeclaration._get_bind_node()`, which sets the attribute `readonly="true()"`, which presumably is correct since this function is used for the existing `baseVersion` property with a similar structure.
2. Opt-in behaviour. Like other yes/no settings, the exact value `yes` is accepted, or it's aliases e.g. `Yes`, `true`, etc.
3. Opt-out behaviour. A user can opt out either by omitting the `offline` column, or by providing a value other than an alias for `yes` (such as `no`, `bananas`, or anything else). This seemed more consistent with the requirements than raising an error if the column is present but the value is not an alias for `yes`, although an error may make sense too.

#### What are the regression risks?

Low risk, should be backwards compatible as per the tests suite.

In future when the new spec version is the default, presumably the `offline` setting will be removed, meaning that from then on forms will have to remove that setting or else get an error about an unexpected column. This would be a minor point of friction but beneficial in that the setting would do nothing (all forms would use spec `2024.1.0`) which may be confusing it were kept/allowed.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

Updates to the entities spec and ODK docs are already in progress. The new `offline` setting is intended to be kept for only a few months, so I'm not sure if that's worth an update to the XLSForm template, especially if the intended audience during that period is insiders/advanced users. The xlsform.org page doesn't mention entities at all.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments