### PR TITLE
721: fix installed script name typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Homepage = "https://pypi.python.org/pypi/pyxform/"
 Repository = "https://github.com/XLSForm/pyxform/"
 
 [project.scripts]
-xlsform = "pyxform.xls2xform:main_cli"
+xls2xform = "pyxform.xls2xform:main_cli"
 pyxform_validator_update = "pyxform.validators.updater:main_cli"
 
 [build-system]


### PR DESCRIPTION
Closes #721

#### Why is this the best possible solution? Were any other approaches considered?

Fixes a typo introduced about 6 months ago in #685, released in v2.0.3. The name is used for running XLS form conversion from the command line, per the readme.

#### What are the regression risks?

If some users had swapped to `xlsform` they would need to swap back to the proper `xls2xform` command.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No, it's per the documentation.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments