### PR TITLE
Add `background-geopoint` question type which exposes `xforms-value-changed` event with `odk:setgeopoint` action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       # Install dependencies.
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Python cache with dependencies.
         id: python-cache
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       # Install dependencies.
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Python cache with dependencies.
         id: python-cache
         with:
@@ -52,7 +52,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       # Install dependencies.
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Python cache with dependencies.
         id: python-cache
         with:
@@ -76,7 +76,7 @@ jobs:
           flit --debug build --no-use-vcs
       - name: Upload sdist and wheel.
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pyxform--on-${{ matrix.os }}--py${{ matrix.python }}
           path: ${{ github.workspace }}/dist/pyxform*

--- a/pyxform/builder.py
+++ b/pyxform/builder.py
@@ -85,6 +85,8 @@ class SurveyElementBuilder:
 
         # dictionary of setvalue target and value tuple indexed by triggering element
         self.setvalues_by_triggering_ref = {}
+        # dictionary of setgeopoint target and value tuple indexed by triggering element
+        self.setgeopoint_by_triggering_ref = {}
         # For tracking survey-level choices while recursing through the survey.
         self._choices: dict[str, Any] = {}
 
@@ -117,6 +119,7 @@ class SurveyElementBuilder:
 
             if d[const.TYPE] == const.SURVEY:
                 section.setvalues_by_triggering_ref = self.setvalues_by_triggering_ref
+                section.setgeopoint_by_triggering_ref = self.setgeopoint_by_triggering_ref
                 section.choices = self._choices
 
             return section
@@ -137,28 +140,27 @@ class SurveyElementBuilder:
             return ExternalInstance(**d)
         elif d[const.TYPE] == "entity":
             return EntityDeclaration(**d)
+        elif d[const.TYPE] == "background-geopoint":
+            self._save_trigger_and_remove_calculate(d, self.setgeopoint_by_triggering_ref)
+            return self._create_question_from_dict(
+                d, copy_json_dict(QUESTION_TYPE_DICT), self._add_none_option
+            )
         else:
-            self._save_trigger_as_setvalue_and_remove_calculate(d)
-
+            self._save_trigger_and_remove_calculate(d, self.setvalues_by_triggering_ref)
             return self._create_question_from_dict(
                 d, copy_json_dict(QUESTION_TYPE_DICT), self._add_none_option
             )
 
-    def _save_trigger_as_setvalue_and_remove_calculate(self, d):
+    def _save_trigger_and_remove_calculate(self, d, target_dict):
         if "trigger" in d:
             triggering_ref = re.sub(r"\s+", "", d["trigger"])
             value = ""
             if const.BIND in d and "calculate" in d[const.BIND]:
                 value = d[const.BIND]["calculate"]
-
-            if triggering_ref in self.setvalues_by_triggering_ref:
-                self.setvalues_by_triggering_ref[triggering_ref].append(
-                    (d[const.NAME], value)
-                )
+            if triggering_ref in target_dict:
+                target_dict[triggering_ref].append((d[const.NAME], value))
             else:
-                self.setvalues_by_triggering_ref[triggering_ref] = [
-                    (d[const.NAME], value)
-                ]
+                target_dict[triggering_ref] = [(d[const.NAME], value)]
 
     @staticmethod
     def _create_question_from_dict(

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -34,10 +34,17 @@ class Question(SurveyElement):
         # question type dictionary.
         if self.type not in QUESTION_TYPE_DICT:
             raise PyXFormError(f"Unknown question type '{self.type}'.")
+        # ensure that background-geopoint questions have non-null triggers that correspond to an exsisting questions
         if self.type == "background-geopoint":
             if not self.trigger:
                 raise PyXFormError(
                     f"background-geopoint question '{self.name}' must have a non-null trigger."
+                )
+            trigger_cleaned = self.trigger.strip("${}")
+            if not self.get_root().question_exists(trigger_cleaned):
+                raise PyXFormError(
+                    f"Trigger '{trigger_cleaned}' for background-geopoint question '{self.name}' "
+                    "does not correspond to an existing question."
                 )
 
     def xml_instance(self, **kwargs):

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -34,12 +34,8 @@ class Question(SurveyElement):
         # question type dictionary.
         if self.type not in QUESTION_TYPE_DICT:
             raise PyXFormError(f"Unknown question type '{self.type}'.")
-        # ensure that background-geopoint questions have non-null triggers that correspond to an exsisting questions
+        # ensure that background-geopoint questions have triggers that correspond to an existing questions
         if self.type == "background-geopoint":
-            if not self.trigger:
-                raise PyXFormError(
-                    f"background-geopoint question '{self.name}' must have a non-null trigger."
-                )
             trigger_cleaned = self.trigger.strip("${}")
             if not self.get_root().question_exists(trigger_cleaned):
                 raise PyXFormError(

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -34,13 +34,6 @@ class Question(SurveyElement):
         # question type dictionary.
         if self.type not in QUESTION_TYPE_DICT:
             raise PyXFormError(f"Unknown question type '{self.type}'.")
-        # ensure that background-geopoint questions have triggers that correspond to an existing questions
-        if self.type == "background-geopoint":
-            trigger_cleaned = self.trigger.strip("${}")
-            if not self.get_root().question_exists(trigger_cleaned):
-                raise PyXFormError(
-                    f"background-geopoint question '{self.name}' must have a trigger corresponding to an existing question."
-                )
 
     def xml_instance(self, **kwargs):
         survey = self.get_root()

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -43,8 +43,7 @@ class Question(SurveyElement):
             trigger_cleaned = self.trigger.strip("${}")
             if not self.get_root().question_exists(trigger_cleaned):
                 raise PyXFormError(
-                    f"Trigger '{trigger_cleaned}' for background-geopoint question '{self.name}' "
-                    "does not correspond to an existing question."
+                    f"background-geopoint question '{self.name}' must have a trigger corresponding to an existing question."
                 )
 
     def xml_instance(self, **kwargs):
@@ -65,7 +64,7 @@ class Question(SurveyElement):
             if self.type == "background-geopoint":
                 if "calculate" in self.bind:
                     raise PyXFormError(
-                        f"'{self.name}' is triggered by a geopoint action, so the calculation must be null."
+                        f"'{self.name}' is triggered by a geopoint action, please remove the calculation from this question."
                     )
 
             nested_setvalues = self.get_root().get_trigger_values_for_question_name(

--- a/pyxform/question_type_dictionary.py
+++ b/pyxform/question_type_dictionary.py
@@ -382,4 +382,8 @@ QUESTION_TYPE_DICT = {
         "bind": {"type": "binary"},
         "action": {"name": "odk:recordaudio", "event": "odk-instance-load"},
     },
+    "background-geopoint": {
+        "control": {"tag": "trigger"},
+        "bind": {"type": "geopoint"},
+    },
 }

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -192,6 +192,7 @@ class Survey(Section):
             "_xpath": dict,
             "_created": datetime.now,  # This can't be dumped to json
             "setvalues_by_triggering_ref": dict,
+            "setgeopoint_by_triggering_ref": dict,
             "title": str,
             "id_string": str,
             "sms_keyword": str,
@@ -297,8 +298,13 @@ class Survey(Section):
             **nsmap,
         )
 
-    def get_setvalues_for_question_name(self, question_name):
-        return self.setvalues_by_triggering_ref.get(f"${{{question_name}}}")
+    def get_trigger_values_for_question_name(self, question_name, trigger_type):
+        trigger_map = {
+            "setvalue": self.setvalues_by_triggering_ref,
+            "setgeopoint": self.setgeopoint_by_triggering_ref,
+        }
+
+        return trigger_map.get(trigger_type, {}).get(f"${{{question_name}}}")
 
     def _generate_static_instances(self, list_name, choice_list) -> InstanceInfo:
         """

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -306,6 +306,15 @@ class Survey(Section):
 
         return trigger_map.get(trigger_type, {}).get(f"${{{question_name}}}")
 
+    def question_exists(self, question_name: str) -> bool:
+        """
+        Check if a question with the given name exists in the survey.
+        """
+        for element in self.iter_descendants():
+            if isinstance(element, Question) and element.name == question_name:
+                return True
+        return False
+
     def _generate_static_instances(self, list_name, choice_list) -> InstanceInfo:
         """
         Generate <instance> elements for static data (e.g. choices for selects)

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -224,21 +224,12 @@ class Survey(Section):
         if self.id_string in [None, "None"]:
             raise PyXFormError("Survey cannot have an empty id_string")
         super().validate()
-        self._validate_section_and_trigger_names()
+        self._validate_uniqueness_of_section_names()
 
-    def _validate_section_and_trigger_names(self):
+    def _validate_uniqueness_of_section_names(self):
         root_node_name = self.name
-        section_names = []
-        existing_question_names = set()
-        bg_geopoint_elements = []
-
+        section_names = set()
         for element in self.iter_descendants():
-            if "name" in element:
-                existing_question_names.add(element["name"])
-
-            if element["type"] == "background-geopoint":
-                bg_geopoint_elements.append(element)
-
             if isinstance(element, Section):
                 if element.name in section_names:
                     if element.name == root_node_name:
@@ -252,15 +243,7 @@ class Survey(Section):
                         raise PyXFormError(msg)
                     msg = f"There are two sections with the name {element.name}."
                     raise PyXFormError(msg)
-                section_names.append(element.name)
-
-        # Ensure that background-geopoint questions have triggers that correspond to an existing questions
-        for bg_geo in bg_geopoint_elements:
-            trigger_cleaned = bg_geo.get("trigger", "").strip("${}")
-            if trigger_cleaned not in existing_question_names:
-                raise PyXFormError(
-                    f"background-geopoint question '{bg_geo['name']}' must have a trigger corresponding to an existing question."
-                )
+                section_names.add(element.name)
 
     def get_nsmap(self):
         """Add additional namespaces"""

--- a/pyxform/validators/pyxform/question_types.py
+++ b/pyxform/validators/pyxform/question_types.py
@@ -1,0 +1,45 @@
+"""
+Validations for question types.
+"""
+
+import re
+
+from pyxform.errors import PyXFormError
+from pyxform.parsing.expression import is_single_token_expression
+from pyxform.utils import PYXFORM_REFERENCE_REGEX
+
+BACKGROUND_GEOPOINT_CALCULATION = "[row : {r}] For 'background-geopoint' questions, the 'calculation' column must be empty."
+TRIGGER_INVALID = (
+    "[row : {r}] For '{t}' questions, the 'trigger' column must be a reference to another "
+    "question that exists, in the format ${{question_name_here}}."
+)
+
+
+def validate_background_geopoint_calculation(row: dict, row_num: int) -> bool:
+    """A background-geopoint must not have a calculation."""
+    try:
+        row["bind"]["calculate"]
+    except KeyError:
+        return True
+    else:
+        raise PyXFormError(BACKGROUND_GEOPOINT_CALCULATION.format(r=row_num))
+
+
+def validate_background_geopoint_trigger(row: dict, row_num: int) -> bool:
+    """A background-geopoint must have a trigger."""
+    if not row.get("trigger", False) or not is_single_token_expression(
+        expression=row["trigger"], token_types=["PYXFORM_REF"]
+    ):
+        raise PyXFormError(TRIGGER_INVALID.format(r=row_num, t=row["type"]))
+    return True
+
+
+def validate_references(referrers: list[tuple[dict, int]], questions: set[str]) -> bool:
+    """Triggers must refer to a question that exists."""
+    for row, row_num in referrers:
+        matches = re.match(PYXFORM_REFERENCE_REGEX, row["trigger"])
+        if matches is not None:
+            trigger = matches.groups()[0]
+            if trigger not in questions:
+                raise PyXFormError(TRIGGER_INVALID.format(r=row_num, t=row["type"]))
+    return True

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1493,6 +1493,14 @@ def workbook_to_json(
             continue
         # TODO: Consider adding some question_type validation here.
 
+        # Ensure that background-geopoint questions have non-null triggers
+        if question_type == "background-geopoint":
+            new_dict = row.copy()
+            if "trigger" not in new_dict or not new_dict["trigger"]:
+                raise PyXFormError(
+                    f"background-geopoint question '{new_dict['name']}' must have a non-null trigger."
+                )
+
         # Put the row in the json dict as is:
         parent_children_array.append(row)
 

--- a/tests/test_background_geopoint.py
+++ b/tests/test_background_geopoint.py
@@ -8,15 +8,15 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |                    |             |                |
-            |        | type               | name        | label          | trigger   |
-            |        | integer            | temp        | Enter the current temperature |        |
-            |        | background-geopoint| temp_geo    |                | ${temp}   |
-            |        | note               | show_temp_geo | location: ${temp_geo} |        |
+            | survey |                    |               |                               |
+            |        | type               | name          | label                         | trigger   |
+            |        | integer            | temp          | Enter the current temperature |           |
+            |        | background-geopoint| temp_geo      |                               | ${temp}   |
+            |        | note               | show_temp_geo | location: ${temp_geo}         |           |
             """,
-            xml__contains=[
-                '<bind nodeset="/data/temp_geo" type="geopoint"/>',
-                '<odk:setgeopoint event="xforms-value-changed" ref="/data/temp_geo"/>',
+            xml__xpath_match=[
+                '/h:html/h:head/x:model/x:bind[@nodeset="/data/temp_geo" and @type="geopoint"]',
+                '/h:html/h:body//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/temp_geo"]',
             ],
         )
 
@@ -25,11 +25,11 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |                    |             |                |
-            |        | type               | name        | label          | trigger   |
-            |        | integer            | temp        | Enter the current temperature |        |
-            |        | background-geopoint| temp_geo    |                |  |
-            |        | note               | show_temp_geo | location: ${temp_geo} |        |
+            | survey |                    |               |                               |
+            |        | type               | name          | label                         | trigger   |
+            |        | integer            | temp          | Enter the current temperature |           |
+            |        | background-geopoint| temp_geo      |                               |           |
+            |        | note               | show_temp_geo | location: ${temp_geo}         |           |
             """,
             errored=True,
             error__contains=[
@@ -41,15 +41,15 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-                | survey |                    |             |                |
-                |        | type               | name        | label          | trigger   |
-                |        | integer            | temp        | Enter the current temperature |        |
-                |        | background-geopoint| temp_geo    |                | ${invalid_trigger} |
-                |        | note               | show_temp_geo | location: ${temp_geo} |        |
+                | survey |                    |               |                               |
+                |        | type               | name          | label                         | trigger            |
+                |        | integer            | temp          | Enter the current temperature |                    |
+                |        | background-geopoint| temp_geo      |                               | ${invalid_trigger} |
+                |        | note               | show_temp_geo | location: ${temp_geo}         |                    |
                 """,
             errored=True,
             error__contains=[
-                "Trigger 'invalid_trigger' for background-geopoint question 'temp_geo' does not correspond to an existing question"
+                "background-geopoint question 'temp_geo' must have a trigger corresponding to an existing question"
             ],
         )
 
@@ -58,14 +58,14 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |                    |             |                |  |
-            |        | type               | name        | label          | trigger     | calculation |
-            |        | integer            | temp        | Enter the current temperature |        |             |
-            |        | background-geopoint| temp_geo    |                | ${temp}     | 5 * temp |
-            |        | note               | show_temp_geo | location: ${temp_geo} |        |             |
+            | survey |                    |               |                               |             |
+            |        | type               | name          | label                         | trigger     | calculation |
+            |        | integer            | temp          | Enter the current temperature |             |             |
+            |        | background-geopoint| temp_geo      |                               | ${temp}     | 5 * temp    |
+            |        | note               | show_temp_geo | location: ${temp_geo}         |             |             |
             """,
             errored=True,
             error__contains=[
-                "'temp_geo' is triggered by a geopoint action, so the calculation must be null."
+                "'temp_geo' is triggered by a geopoint action, please remove the calculation from this question."
             ],
         )

--- a/tests/test_background_geopoint.py
+++ b/tests/test_background_geopoint.py
@@ -1,0 +1,71 @@
+from tests.pyxform_test_case import PyxformTestCase
+
+
+class BackgroundGeopointTest(PyxformTestCase):
+    """Test background-geopoint question type."""
+
+    def test_background_geopoint(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                    |             |                |
+            |        | type               | name        | label          | trigger   |
+            |        | integer            | temp        | Enter the current temperature |        |
+            |        | background-geopoint| temp_geo    |                | ${temp}   |
+            |        | note               | show_temp_geo | location: ${temp_geo} |        |
+            """,
+            xml__contains=[
+                '<bind nodeset="/data/temp_geo" type="geopoint"/>',
+                '<odk:setgeopoint event="xforms-value-changed" ref="/data/temp_geo"/>',
+            ],
+        )
+
+    def test_background_geopoint_missing_trigger(self):
+        """Test that background-geopoint question raises error when trigger is empty."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                    |             |                |
+            |        | type               | name        | label          | trigger   |
+            |        | integer            | temp        | Enter the current temperature |        |
+            |        | background-geopoint| temp_geo    |                |  |
+            |        | note               | show_temp_geo | location: ${temp_geo} |        |
+            """,
+            errored=True,
+            error__contains=[
+                "background-geopoint question 'temp_geo' must have a non-null trigger"
+            ],
+        )
+
+    def test_invalid_trigger_background_geopoint(self):
+        self.assertPyxformXform(
+            name="data",
+            md="""
+                | survey |                    |             |                |
+                |        | type               | name        | label          | trigger   |
+                |        | integer            | temp        | Enter the current temperature |        |
+                |        | background-geopoint| temp_geo    |                | ${invalid_trigger} |
+                |        | note               | show_temp_geo | location: ${temp_geo} |        |
+                """,
+            errored=True,
+            error__contains=[
+                "Trigger 'invalid_trigger' for background-geopoint question 'temp_geo' does not correspond to an existing question"
+            ],
+        )
+
+    def test_background_geopoint_requires_null_calculation(self):
+        """Test that background-geopoint raises an error if there is a calculation."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                    |             |                |  |
+            |        | type               | name        | label          | trigger     | calculation |
+            |        | integer            | temp        | Enter the current temperature |        |             |
+            |        | background-geopoint| temp_geo    |                | ${temp}     | 5 * temp |
+            |        | note               | show_temp_geo | location: ${temp_geo} |        |             |
+            """,
+            errored=True,
+            error__contains=[
+                "'temp_geo' is triggered by a geopoint action, so the calculation must be null."
+            ],
+        )

--- a/tests/test_background_geopoint.py
+++ b/tests/test_background_geopoint.py
@@ -8,11 +8,11 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |                    |               |                               |
-            |        | type               | name          | label                         | trigger   |
-            |        | integer            | temp          | Enter the current temperature |           |
-            |        | background-geopoint| temp_geo      |                               | ${temp}   |
-            |        | note               | show_temp_geo | location: ${temp_geo}         |           |
+            | survey |                     |               |                               |
+            |        | type                | name          | label                         | trigger   |
+            |        | integer             | temp          | Enter the current temperature |           |
+            |        | background-geopoint | temp_geo      |                               | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}         |           |
             """,
             xml__xpath_match=[
                 '/h:html/h:head/x:model/x:bind[@nodeset="/data/temp_geo" and @type="geopoint"]',
@@ -25,11 +25,11 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |                    |               |                               |
-            |        | type               | name          | label                         | trigger   |
-            |        | integer            | temp          | Enter the current temperature |           |
-            |        | background-geopoint| temp_geo      |                               |           |
-            |        | note               | show_temp_geo | location: ${temp_geo}         |           |
+            | survey |                     |               |                               |
+            |        | type                | name          | label                         | trigger   |
+            |        | integer             | temp          | Enter the current temperature |           |
+            |        | background-geopoint | temp_geo      |                               |           |
+            |        | note                | show_temp_geo | location: ${temp_geo}         |           |
             """,
             errored=True,
             error__contains=[
@@ -41,12 +41,12 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-                | survey |                    |               |                               |
-                |        | type               | name          | label                         | trigger            |
-                |        | integer            | temp          | Enter the current temperature |                    |
-                |        | background-geopoint| temp_geo      |                               | ${invalid_trigger} |
-                |        | note               | show_temp_geo | location: ${temp_geo}         |                    |
-                """,
+            | survey |                     |               |                               |
+            |        | type                | name          | label                         | trigger            |
+            |        | integer             | temp          | Enter the current temperature |                    |
+            |        | background-geopoint | temp_geo      |                               | ${invalid_trigger} |
+            |        | note                | show_temp_geo | location: ${temp_geo}         |                    |
+            """,
             errored=True,
             error__contains=[
                 "background-geopoint question 'temp_geo' must have a trigger corresponding to an existing question"
@@ -58,14 +58,186 @@ class BackgroundGeopointTest(PyxformTestCase):
         self.assertPyxformXform(
             name="data",
             md="""
-            | survey |                    |               |                               |             |
-            |        | type               | name          | label                         | trigger     | calculation |
-            |        | integer            | temp          | Enter the current temperature |             |             |
-            |        | background-geopoint| temp_geo      |                               | ${temp}     | 5 * temp    |
-            |        | note               | show_temp_geo | location: ${temp_geo}         |             |             |
+            | survey |                     |               |                               |             |
+            |        | type                | name          | label                         | trigger     | calculation |
+            |        | integer             | temp          | Enter the current temperature |             |             |
+            |        | background-geopoint | temp_geo      |                               | ${temp}     | 5 * temp    |
+            |        | note                | show_temp_geo | location: ${temp_geo}         |             |             |
             """,
             errored=True,
             error__contains=[
                 "'temp_geo' is triggered by a geopoint action, please remove the calculation from this question."
+            ],
+        )
+
+    def test_combined_background_geopoint_and_setvalue(self):
+        """Test a form with both a background-geopoint and setvalue triggered by the same question."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                |           |
+            |        | type                | name          | label                          | trigger   | calculation |
+            |        | integer             | temp          | Enter the current temperature  |           |             |
+            |        | background-geopoint | temp_geo      |                                | ${temp}   |             |
+            |        | calculate           | temp_doubled  |                                | ${temp}   | ${temp} * 2 |
+            |        | note                | show_temp_geo | location: ${temp_geo}          |           |             |
+            |        | note                | show_temp     | doubled temp: ${temp_doubled}  |           |             |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/temp_geo"]',
+                '/h:html/h:body//x:setvalue[@event="xforms-value-changed" and @ref="/data/temp_doubled" and normalize-space(@value)="/data/temp * 2"]',
+            ],
+        )
+
+    def test_setgeopoint_trigger_target_outside_group(self):
+        """Verify the correct structure for a setgeopoint trigger and target when neither is in a group."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                |
+            |        | type                | name          | label                          | trigger   |
+            |        | integer             | temp          | Enter the current temperature  |           |
+            |        | background-geopoint | temp_geo      |                                | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}          |           |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/temp_geo"]',
+                '/h:html/h:body//x:input[@ref="/data/show_temp_geo"]/x:label[contains(text(), "location:")]/x:output[@value=" /data/temp_geo "]',
+            ],
+        )
+
+    def test_setgeopoint_trigger_target_in_non_repeating_group(self):
+        """Verify the correct structure for a setgeopoint trigger and target in a non-repeating group."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                 |
+            |        | type                | name          | label                           | trigger   |
+            |        | begin_group         | groupA        |                                 |           |
+            |        | integer             | temp          | Enter the current temperature   |           |
+            |        | background-geopoint | temp_geo      |                                 | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}           |           |
+            |        | end_group           |               |                                 |           |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body/x:group[@ref="/data/groupA"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:input[@ref="/data/groupA/temp"]//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/groupA/temp_geo"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:input[@ref="/data/groupA/show_temp_geo"]/x:label[contains(text(), "location:")]/x:output[@value=" /data/groupA/temp_geo "]',
+            ],
+        )
+
+    def test_setgeopoint_trigger_target_separate_groups(self):
+        """Verify the correct structure for a setgeopoint trigger and target in two separate groups."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                 |
+            |        | type                | name          | label                           | trigger   |
+            |        | begin_group         | groupA        |                                 |           |
+            |        | integer             | temp          | Enter the current temperature   |           |
+            |        | end_group           |               |                                 |           |
+            |        | begin_group         | groupB        |                                 |           |
+            |        | background-geopoint | temp_geo      |                                 | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}           |           |
+            |        | end_group           |               |                                 |           |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body/x:group[@ref="/data/groupA"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:input[@ref="/data/groupA/temp"]//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/groupB/temp_geo"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]/x:input[@ref="/data/groupB/show_temp_geo"]/x:label/x:output[@value=" /data/groupB/temp_geo "]',
+            ],
+        )
+
+    def test_setgeopoint_trigger_target_in_same_repeating_group(self):
+        """Verify the correct structure for a setgeopoint trigger and target in the same repeating group."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                 |
+            |        | type                | name          | label                           | trigger   |
+            |        | begin_repeat        | groupA        |                                 |           |
+            |        | integer             | temp          | Enter the current temperature   |           |
+            |        | background-geopoint | temp_geo      |                                 | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}           |           |
+            |        | end_repeat          |               |                                 |           |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:repeat[@nodeset="/data/groupA"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:repeat[@nodeset="/data/groupA"]/x:input[@ref="/data/groupA/temp"]//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/groupA/temp_geo"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:repeat[@nodeset="/data/groupA"]/x:input[@ref="/data/groupA/show_temp_geo"]/x:label/x:output[@value=" ../temp_geo "]',
+            ],
+        )
+
+    def test_setgeopoint_trigger_target_in_separate_repeating_groups(self):
+        """Verify the correct structure for a setgeopoint trigger and target in separate repeating groups."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                 |
+            |        | type                | name          | label                           | trigger   |
+            |        | begin_repeat        | groupA        |                                 |           |
+            |        | integer             | temp          | Enter the current temperature   |           |
+            |        | end_repeat          |               |                                 |           |
+            |        | begin_repeat        | groupB        |                                 |           |
+            |        | background-geopoint | temp_geo      |                                 | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}           |           |
+            |        | end_repeat          |               |                                 |           |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:repeat[@nodeset="/data/groupA"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:repeat[@nodeset="/data/groupA"]/x:input[@ref="/data/groupA/temp"]//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/groupB/temp_geo"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]/x:repeat[@nodeset="/data/groupB"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]/x:repeat[@nodeset="/data/groupB"]/x:input[@ref="/data/groupB/show_temp_geo"]/x:label/x:output[@value=" ../temp_geo "]',
+            ],
+        )
+
+    def test_setgeopoint_trigger_in_repeating_group_target_in_non_repeating_groups(
+        self,
+    ):
+        """Verify the correct structure for a setgeopoint trigger in a repeating group and a target in a non-repeating group."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                 |
+            |        | type                | name          | label                           | trigger   |
+            |        | begin_repeat        | groupA        |                                 |           |
+            |        | integer             | temp          | Enter the current temperature   |           |
+            |        | end_repeat          |               |                                 |           |
+            |        | begin_group         | groupB        |                                 |           |
+            |        | background-geopoint | temp_geo      |                                 | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}           |           |
+            |        | end_group           |               |                                 |           |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:repeat[@nodeset="/data/groupA"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:repeat[@nodeset="/data/groupA"]/x:input[@ref="/data/groupA/temp"]//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/groupB/temp_geo"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]/x:input[@ref="/data/groupB/show_temp_geo"]/x:label/x:output[@value=" /data/groupB/temp_geo "]',
+            ],
+        )
+
+    def test_setgeopoint_trigger_in_non_repeating_group_target_in_repeating_group(
+        self,
+    ):
+        """Verify the correct structure for a setgeopoint trigger in a non-repeating group and a target in a repeating group."""
+        self.assertPyxformXform(
+            name="data",
+            md="""
+            | survey |                     |               |                                 |
+            |        | type                | name          | label                           | trigger   |
+            |        | begin_group         | groupA        |                                 |           |
+            |        | integer             | temp          | Enter the current temperature   |           |
+            |        | end_group           |               |                                 |           |
+            |        | begin_repeat        | groupB        |                                 |           |
+            |        | background-geopoint | temp_geo      |                                 | ${temp}   |
+            |        | note                | show_temp_geo | location: ${temp_geo}           |           |
+            |        | end_repeat          |               |                                 |           |
+            """,
+            xml__xpath_match=[
+                '/h:html/h:body/x:group[@ref="/data/groupA"]',
+                '/h:html/h:body/x:group[@ref="/data/groupA"]/x:input[@ref="/data/groupA/temp"]//odk:setgeopoint[@event="xforms-value-changed" and @ref="/data/groupB/temp_geo"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]/x:repeat[@nodeset="/data/groupB"]',
+                '/h:html/h:body/x:group[@ref="/data/groupB"]/x:repeat[@nodeset="/data/groupB"]/x:input[@ref="/data/groupB/show_temp_geo"]/x:label/x:output[@value=" ../temp_geo "]',
             ],
         )


### PR DESCRIPTION
Closes https://github.com/XLSForm/pyxform/issues/716

#### Why is this the best possible solution? Were any other approaches considered?
This solution introduces a new `background-geopoint` question type that triggers the `odk:setgeopoint` action when the `xforms-value-changed` event occurs. The design and implementation were based on discussions from this [forum post](https://forum.getodk.org/t/spec-proposal-expose-xforms-value-changed-event-with-odk-setgeopoint-action-in-xlsform/48655). The solution followed the proposal and was straightforward to implement based on the details in the issue.

#### What are the regression risks?
Because this introduces a new question type and modifies how `setvalue` triggers are handled, there is a risk of breaking existing workflows that rely on the current `setvalue` behavior. I refactored some functions to handle both `setvalue` and the new `setgeopoint` triggers, however, this needs to be tested thoroughly to ensure that the changes don’t break any of the existing `setvalue` functionality.

#### Does this change require updates to documentation? 
Yes: https://github.com/XLSForm/xlsform.github.io/issues/277

#### Before submitting this PR, please make sure you have:
- [X] included test cases for core behavior and edge cases in `tests`
- [X] run `python -m unittest` and verified all tests pass
- [X] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [X] verified that any code or assets from external sources are properly credited in comments