### PR TITLE
fix: return default with get

### DIFF
--- a/pyxform/survey_element.py
+++ b/pyxform/survey_element.py
@@ -53,6 +53,13 @@ class SurveyElement(Mapping):
     def __getitem__(self, key):
         return self.__getattribute__(key)
 
+    def get(self, key, default=None):
+        # override `get` to catch AttributeErrors instead of KeyErrors
+        try:
+            return self.__getattribute__(key)
+        except AttributeError:
+            return default
+
     @staticmethod
     def get_slot_names() -> tuple[str, ...]:
         """Each subclass must provide a list of slots from itself and all parents."""


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?

Mapping classes have a default `get` method that accepts a default and returns it if the key requested is not found. Though SurveyElement has been updated to rely more on attributes than keys, it breaks the Mapping contract to have `get` not work as expected with a default (it will currently return an AttributeError if the attribute is not found). 

The alternative would be to update __getitem__ to turn an AttributeError into a KeyError so it could be properly caught by the default `get` method. However, `element[key]` may still be called in several places and I do not want to risk undermining any assumptions about how it currently works.

#### What are the regression risks?
There shouldn't be any, this is a return to expected behavior.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [ ] verified that any code or assets from external sources are properly credited in comments