### PR TITLE
fix: ensure choices/option parent is set correctly

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -2,6 +2,7 @@
 XForm Survey element classes for different question types.
 """
 
+import copy
 import os.path
 from collections.abc import Callable, Generator, Iterable
 from itertools import chain
@@ -372,7 +373,7 @@ class MultipleChoiceQuestion(Question):
         kw_children = kwargs.pop(constants.CHILDREN, None)
         choices = coalesce(kw_choices, kw_children)
         if isinstance(choices, tuple) and isinstance(next(iter(choices)), Option):
-            self.children = choices
+            self.children = copy.deepcopy(choices)
         elif choices:
             self.children = tuple(
                 Option(**c) for c in combine_lists(kw_choices, kw_children)


### PR DESCRIPTION
Closes https://github.com/XLSForm/pyxform/issues/749

#### Why is this the best possible solution? Were any other approaches considered?

Restores the previous behaviour where traversing choices always point to the parent they are assigned to. 
The deep copy is at the last possible place when the choices are assigned to a question before the parent is set.

#### What are the regression risks?



#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments