### PR TITLE
748: handle obj.get(k, default) call pattern for backward compatibility

### DIFF
--- a/tests/test_survey_element.py
+++ b/tests/test_survey_element.py
@@ -1,0 +1,67 @@
+import warnings
+from unittest import TestCase
+
+from pyxform.survey_element import SurveyElement
+
+
+class TestSurveyElementMappingBehaviour(TestCase):
+    def tearDown(self):
+        # Undo the warnings filter set in the below test.
+        warnings.resetwarnings()
+
+    def test_get_call_patterns_equivalent_to_base_dict(self):
+        """Should find that, except for deprecated usage, SurveyElement is dict-like."""
+        # To demonstrate how dict normally works using same test cases.
+        _dict = {"name": "test", "label": None}
+        # getattr
+        self.assertEqual("default", getattr(_dict, "foo", "default"))
+        # defined key, no default
+        self.assertEqual("test", _dict.get("name"))
+        # defined key, with default
+        self.assertEqual("test", _dict.get("name", "default"))
+        # defined key, with None value
+        self.assertEqual(None, _dict.get("label"))
+        # defined key, with None value, with default
+        self.assertEqual(None, _dict.get("label", "default"))
+        # undefined key, with default
+        self.assertEqual("default", _dict.get("foo", "default"))
+        # undefined key, with default None
+        self.assertEqual(None, _dict.get("foo", None))
+        # other access patterns for undefined key
+        self.assertEqual(None, _dict.get("foo"))
+        with self.assertRaises(AttributeError):
+            _ = _dict.foo
+        with self.assertRaises(KeyError):
+            _ = _dict["foo"]
+
+        elem = SurveyElement(name="test")
+        # getattr
+        self.assertEqual("default", getattr(elem, "foo", "default"))
+        # defined key, no default
+        self.assertEqual("test", elem.get("name"))
+        # defined key, with default
+        self.assertEqual("test", elem.get("name", "default"))
+        # defined key, with None value
+        self.assertEqual(None, elem.get("label"))
+        # defined key, with None value, with default
+        self.assertEqual(None, elem.get("label", "default"))
+        # undefined key, with default
+        with self.assertWarns(DeprecationWarning) as warned:
+            self.assertEqual("default", elem.get("foo", "default"))
+        # Warning points to caller, rather than survey_element or collections.abc.
+        self.assertEqual(__file__, warned.filename)
+        # undefined key, with default None
+        with self.assertWarns(DeprecationWarning) as warned:
+            self.assertEqual(None, elem.get("foo", None))
+        # Callers can disable warnings at module-level.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with warnings.catch_warnings(record=True) as warned:
+            elem.get("foo", "default")
+        self.assertEqual(0, len(warned))
+        # other access patterns for undefined key
+        with self.assertRaises(AttributeError):
+            _ = elem.get("foo")
+        with self.assertRaises(AttributeError):
+            _ = elem.foo
+        with self.assertRaises(AttributeError):
+            _ = elem["foo"]


### PR DESCRIPTION
Closes #748

#### Why is this the best possible solution? Were any other approaches considered?

- Allows external libs to continue using `obj.get(key, default)` with SurveyElement if needed
- Encourages migration to new (or alternative) call patterns with ignorable DeprecationWarning
- Tests demonstrate expected behaviour for range of call patterns, for clarification

Alternatives

The original code in #748 meant that `elem.get("foo")` would return None. This seemed seemed like it would be confusing for pyxform maintenance since a) there is still some `elem.get("foo")` code, and b) its easier to only be concerned about AttributeErrors (as would be expected for a non-dict class) rather than a mix of None, KeyError, AttributeError. If calling code like `elem.get("foo")` expects None then it can be adapted to use an explicit `None` default e.g. `elem.get("foo", None)` - otherwise it will raise an AttributeError as before. The `SurveyElement` also differs from `dict` in `elem["foo"]` (AttributeError not KeyError, respectively) so it didn't seem appropriate to fully replicate `dict` behaviour in this custom Mapping class.

Other alternatives mentioned in #748 and the warning message, for external libs to implement:

- find-and-replace to swap obj.get(key, default) to getattr(obj, key, default)
- checking the type with isinstance before accessing a potentially non-existent attribute
- try/catch for AttributeError if the attribute doesn't exist
- create a custom subclass that implements get in the preferred way

#### What are the regression risks?

There are no internal calls like `obj.get(key, default)`. External code should work as before, except for the DeprecationWarning which can be ignored as shown in the tests, i.e. add:

```
warnings.simplefilter("ignore", DeprecationWarning)
```

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x]  run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments