### PR TITLE
fix: no labels visible for randomized selects with translations

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -370,6 +370,11 @@ class MultipleChoiceQuestion(Question):
             raise PyXFormError("""Invalid value for `self.bind["type"]`.""")
 
         result = self._build_xml(survey=survey)
+        choices = None
+        if survey.choices:
+            choices = survey.choices.get(self.itemset, None)
+        if not choices:
+            choices = self.choices
 
         # itemset are only supposed to be strings,
         # check to prevent the rare dicts that show up
@@ -390,7 +395,7 @@ class MultipleChoiceQuestion(Question):
 
             if file_extension in EXTERNAL_INSTANCE_EXTENSIONS:
                 pass
-            elif self.choices and self.choices.requires_itext:
+            elif choices and choices.requires_itext:
                 itemset = self.itemset
                 itemset_label_ref = "jr:itext(itextId)"
             else:
@@ -448,13 +453,12 @@ class MultipleChoiceQuestion(Question):
                     nodeset=nodeset,
                 )
             )
-        elif self.choices:
+        elif choices:
             # Options processing specific to XLSForms using the "search()" function.
             # The _choice_itext_ref is prepared by Survey._redirect_is_search_itext.
-            itemset = self.choices
-            if itemset.used_by_search:
-                for option in itemset.options:
-                    if itemset.requires_itext:
+            if choices.used_by_search:
+                for option in choices.options:
+                    if choices.requires_itext:
                         label_node = node("label", ref=option._choice_itext_ref)
                     elif self.label:
                         label, output_inserted = survey.insert_output_values(

--- a/pyxform/survey.py
+++ b/pyxform/survey.py
@@ -783,12 +783,16 @@ class Survey(Section):
                 )
                 raise PyXFormError(msg)
 
+            choices = None
+            if self.choices:
+                choices = self.choices.get(element.itemset, None)
+            if not choices:
+                choices = element.choices
             element.itemset = ""
-            itemset = element.choices
-            if not itemset.used_by_search:
-                itemset.used_by_search = True
-                for i, opt in enumerate(itemset.options):
-                    opt._choice_itext_ref = f"jr:itext('{itemset.name}-{i}')"
+            if not choices.used_by_search:
+                choices.used_by_search = True
+                for i, opt in enumerate(choices.options):
+                    opt._choice_itext_ref = f"jr:itext('{choices.name}-{i}')"
         return is_search
 
     def _setup_translations(self):


### PR DESCRIPTION
Per report in https://forum.getodk.org/t/54492

- regression seems to be from #746 where the choices may be referenced by the survey only and the select question does not have a reference. This happens if the question is randomized, or external select, or search appearance.
  - this would suggest that maybe the choices should be in-line for randomized choices - however the existing tests for randomize expect an itemset in the body. Also, these new tests pass on tag 3.0.1 (prior to #746), and fail on master (e0b350b5)
  - since the user noticed this via https://getodk.org/xlsform/ and it seems that the converter uses https://staging.getodk.cloud I assume that means master is deployed to staging (i.e. not just tagged releases)
  - The form posted in the forum converts as expected (choice labels shown in enketo preview) without warnings/errors when uploaded to a project on https://staging.getodk.cloud

#### Why is this the best possible solution? Were any other approaches considered?

As mentioned above I wasn't totally sure that these combinations are supported, considering https://github.com/enketo/enketo/issues/322 but it seems like it works in Collect (per https://forum.getodk.org/t/42506/4) and presumably will in Webforms too. Also I wasn't able to locally reproduce the ODK Validate warnings mentioned in the reporting forum thread but maybe the Validate version on xlsform-online is out of sync?

#### What are the regression risks?

This should be a fix since the existing tests pass and the new code satisfies tests that worked on earlier code (as described above), and the code committed in between didn't intend to change randomize or choice_filter behaviour for users.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments