### PR TITLE
Prepare v3.1.0 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 Pyxform Changelog
 
+v3.1.0, 2025-06-10
+* Add client_editable setting by @lindsay-stevens in https://github.com/XLSForm/pyxform/pull/766
+
 v3.0.1, 2025-02-25
 * More performance improvements by @lindsay-stevens in https://github.com/XLSForm/pyxform/pull/743
 * Handle obj.get(k, default) call pattern for backward compatibility by @lindsay-stevens in https://github.com/XLSForm/pyxform/pull/755

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyxform"
-version = "3.0.1"
+version = "3.1.0"
 authors = [
   {name = "github.com/xlsform", email = "support@getodk.org"},
 ]

--- a/pyxform/__init__.py
+++ b/pyxform/__init__.py
@@ -4,7 +4,7 @@ pyxform is a Python library designed to make authoring XForms for ODK
 Collect easy.
 """
 
-__version__ = "3.0.1"
+__version__ = "3.1.0"
 
 from pyxform.builder import (
     SurveyElementBuilder,


### PR DESCRIPTION
Prepares for a 3.1.0 release off of a release branch.

#### Why is this the best possible solution? Were any other approaches considered?
We have found that https://github.com/XLSForm/pyxform/pull/768 does affect some forms. We think https://github.com/XLSForm/pyxform/pull/746 may still have subtle regressions. So to make `client_editable` available with minimal risk, we're releasing it on the 3.x line.

We also considered reverting https://github.com/XLSForm/pyxform/pull/768 but we want to take some time to understand it better first.

#### What are the regression risks?
Very low -- this is a purely additive change that is easy to inspect.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments