### PR TITLE
779: process triggers for all question types

### DIFF
--- a/pyxform/errors.py
+++ b/pyxform/errors.py
@@ -58,6 +58,14 @@ class ErrorCode(Enum):
             "Reference variables must refer to a question name. Could not find '{q}'."
         ),
     )
+    INTERNAL_001: _Detail = _Detail(
+        name="Internal error: Incorrectly Processed Question Trigger Data",
+        msg=(
+            "Internal error: "
+            "PyXForm expected processed trigger data as a tuple, but received a "
+            "type '{type}' with value '{value}'."
+        ),
+    )
 
 
 class PyXFormError(Exception):
@@ -83,6 +91,8 @@ class PyXFormError(Exception):
             if self.context:
                 return self.code.value.format(**self.context)
             else:
+                # If there's somehow no context for creating a helpful message, at least
+                # try to give some kind of normal-looking indication of the type of issue.
                 return self.code.value.name
         elif self.args[0]:
             return self.args[0]


### PR DESCRIPTION
Closes #779
Addresses test coverage feedback in #776

#### Why is this the best possible solution? Were any other approaches considered?

In xls2json there are some code blocks that process specific question types, with a `continue` to the next row at the end of most blocks. But since the trigger processing code was placed after those blocks, it wasn't being done for question types with a block. Now the trigger processing is placed before those blocks. The issue resulted in the nested setvalue element not being added to the body control.

Also adds test coverage for parsing comma + space scenarios

#### What are the regression risks?

Fixes a regression. It's possible that external code is calling the builder class without providing processed trigger references, so for that scenario a check/error was added to avoid iterating the unprocessed string (as occurred for the #779 bug).

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments