### PR TITLE
781: handle None from fullmatch reference regex

### DIFF
--- a/pyxform/validators/pyxform/pyxform_reference.py
+++ b/pyxform/validators/pyxform/pyxform_reference.py
@@ -59,7 +59,11 @@ def _parse(
         return None
 
     if match_full:
-        outer_matches = (RE_PYXFORM_REF_OUTER.fullmatch(value),)
+        outer_matches = RE_PYXFORM_REF_OUTER.fullmatch(value)
+        if not outer_matches:
+            # Expression may contain a reference but has other characters e.g. func call.
+            return None
+        outer_matches = (outer_matches,)
     else:
         outer_matches = RE_PYXFORM_REF_OUTER.finditer(value)
 

--- a/tests/test_randomize_itemsets.py
+++ b/tests/test_randomize_itemsets.py
@@ -63,6 +63,26 @@ class RandomizeItemsetsTest(PyxformTestCase):
             ],
         )
 
+    def test_randomized_seeded_select_one_nameset_seed_expression__error(self):
+        md = """
+        | survey |
+        | | type               | name   | label  | parameters                       | calculation                    |
+        | | calculate          | seed   |        |                                  | once(decimal-date-time(now())) |
+        | | select_one choices | select | Select | randomize=true,seed=int(${seed}) |                                |
+
+        | choices |
+        | | list_name | name | label |
+        | | choices   | a    | opt_a |
+        | | choices   | b    | opt_b |
+        """
+        self.assertPyxformXform(
+            md=md,
+            errored=True,
+            error__contains=[
+                "seed value must be a number or a reference to another field."
+            ],
+        )
+
     def test_randomized_seeded_filtered_select_one(self):
         self.assertPyxformXform(
             name="data",

--- a/tests/test_repeat.py
+++ b/tests/test_repeat.py
@@ -1,5 +1,5 @@
 """
-Test reapeat structure.
+Test repeat structure.
 """
 
 from tests.pyxform_test_case import PyxformTestCase
@@ -941,44 +941,5 @@ class TestRepeat(PyxformTestCase):
             md=xlsform_md,
             xml__contains=[
                 """<bind calculate="concat(instance('item')/root/item[index = current()/../pos5 ]/label,  ../pos5  + 1)" nodeset="/test_name/rep5/item5" type="string"/>""",  # pylint: disable=line-too-long
-            ],
-        )
-
-    def test_repeat_count_item_with_same_suffix_as_repeat_is_ok(self):
-        """Should not have a name clash, the referenced item should be used directly."""
-        md = """
-        | survey |              |         |       |              |
-        |        | type         | name    | label | repeat_count |
-        |        | integer      | a_count | 1     |              |
-        |        | begin repeat | a       | 2     | ${a_count}   |
-        |        | text         | b       | 3     |              |
-        |        | end repeat   | a       |       |              |
-        """
-        self.assertPyxformXform(
-            md=md,
-            xml__xpath_match=[
-                # repeat references existing count element directly.
-                """
-                /h:html/h:body/x:group[@ref='/test_name/a']/x:repeat[
-                  @jr:count=' /test_name/a_count '
-                  and @nodeset='/test_name/a'
-                  and ./x:input[@ref='/test_name/a/b']
-                ]
-                """,
-                # binding for existing count element but no calculate binding.
-                """
-                /h:html/h:head/x:model[
-                  ./x:bind[@nodeset='/test_name/a_count' and @type='int']
-                  and not(./x:bind[
-                    @calculate=' /test_name/a_count'
-                    and @nodeset='/test_name/a_count'
-                    and @readonly='true()'
-                  ])
-                ]
-                """,
-                # no duplicated element in the instance.
-                """
-                /h:html/h:head/x:model/x:instance/x:test_name/x:a_count
-                """,
             ],
         )

--- a/tests/test_repeat_count.py
+++ b/tests/test_repeat_count.py
@@ -1,0 +1,243 @@
+from tests.pyxform_test_case import PyxformTestCase
+from tests.xpath_helpers.questions import xpq
+
+
+class TestRepeatCount(PyxformTestCase):
+    """
+    Test usages of the survey repeat_count column.
+    """
+
+    def test_single_reference__generated_element_same_name__ok(self):
+        """Should not have a name clash, the referenced item should be used directly."""
+        md = """
+        | survey |
+        | | type         | name     | label | repeat_count |
+        | | integer      | q1_count | Q1    |              |
+        | | begin repeat | r1       | R1    | ${q1_count}  |
+        | | text         | q2       | Q2    |              |
+        | | end repeat   |          |       |              |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                # repeat_count target output as normal
+                xpq.model_instance_item("q1_count"),
+                xpq.model_instance_bind("q1_count", "int"),
+                xpq.body_control("q1_count", "input"),
+                # no instance element for generated *_count item
+                """
+                /h:html/h:head/x:model/x:instance/x:test_name[not(./x:r1_count)]
+                """,
+                # no binding for generated *_count item
+                """
+                /h:html/h:head/x:model[not(./x:bind[@nodeset='/test_name/r1_count'])]
+                """,
+                # repeat references existing count element directly.
+                """
+                /h:html/h:body/x:group[@ref='/test_name/r1']/x:repeat[
+                  @nodeset='/test_name/r1'
+                  and @jr:count=' /test_name/q1_count '
+                ]
+                """,
+            ],
+        )
+
+    def test_single_reference__generated_element_different_name__ok(self):
+        """Should find that a {repeat_name}_count element is generated for the calculation."""
+        md = """
+        | survey |
+        | | type         | name | label | repeat_count |
+        | | integer      | q1   | Q1    |              |
+        | | begin repeat | r1   | R1    | ${q1}        |
+        | | text         | q2   | Q2    |              |
+        | | end repeat   |      |       |              |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                # repeat_count target output as normal
+                xpq.model_instance_item("q1"),
+                xpq.model_instance_bind("q1", "int"),
+                xpq.body_control("q1", "input"),
+                # no instance element for generated *_count item
+                """
+                /h:html/h:head/x:model/x:instance/x:test_name[not(./x:r1_count)]
+                """,
+                # no binding for generated *_count item
+                """
+                /h:html/h:head/x:model[not(./x:bind[@nodeset='/test_name/r1_count'])]
+                """,
+                # repeat references existing count element directly.
+                """
+                /h:html/h:body/x:group[@ref='/test_name/r1']/x:repeat[
+                  @nodeset='/test_name/r1'
+                  and @jr:count=' /test_name/q1 '
+                ]
+                """,
+            ],
+        )
+
+    def test_expression__generated_element_same_name__error(self):
+        """Should find that a duplicate {repeat_name}_count element raises an error."""
+        md = """
+        | survey |
+        | | type               | name     | label | repeat_count                |
+        | | select_multiple l1 | r1_count | Q1    |                             |
+        | | begin_repeat       | r1       | R1    | count-selected(${r1_count}) |
+        | | text               | q2       | Q2    |                             |
+        | | end_repeat         |          |       |                             |
+
+        | choices |
+        | | list_name | name | label |
+        | | l1        | c1   | C1    |
+        | | l1        | c2   | C2    |
+        """
+        self.assertPyxformXform(
+            md=md,
+            errored=True,
+            error__contains=[
+                "There are more than one survey elements named 'r1_count' "
+                "(case-insensitive) in the section named 'test_name'."
+            ],
+        )
+
+    def test_expression__generated_element_different_name__ok(self):
+        """Should find that a {repeat_name}_count element is generated for the calculation."""
+        # repro for pyxform 781
+        md = """
+        | survey |
+        | | type               | name | label | repeat_count          |
+        | | select_multiple l1 | q1   | Q1    |                       |
+        | | begin_repeat       | r1   | R1    | count-selected(${q1}) |
+        | | text               | q2   | Q2    |                       |
+        | | end_repeat         |      |       |                       |
+
+        | choices |
+        | | list_name | name | label |
+        | | l1        | c1   | C1    |
+        | | l1        | c2   | C2    |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                xpq.model_instance_item("r1_count"),
+                xpq.model_instance_bind("r1_count", "string"),
+                xpq.model_instance_bind_attr(
+                    "r1_count", "calculate", "count-selected( /test_name/q1 )"
+                ),
+                xpq.model_instance_bind_attr("r1_count", "readonly", "true()"),
+                # repeat references generated repeat_count element.
+                """
+                /h:html/h:body/x:group[@ref='/test_name/r1']/x:repeat[
+                  @nodeset='/test_name/r1'
+                  and @jr:count=' /test_name/r1_count '
+                ]
+                """,
+            ],
+        )
+
+    def test_manual_xpath__generated_element_same_name__error(self):
+        """Should find that a duplicate {repeat_name}_count element raises an error."""
+        md = """
+        | survey |
+        | | type               | name     | label | repeat_count                          |
+        | | select_multiple l1 | r1_count | Q1    |                                       |
+        | | begin_repeat       | r1       | R1    | count-selected( /test_name/r1_count ) |
+        | | text               | q2       | Q2    |                                       |
+        | | end_repeat         |          |       |                                       |
+
+        | choices |
+        | | list_name | name | label |
+        | | l1        | c1   | C1    |
+        | | l1        | c2   | C2    |
+        """
+        self.assertPyxformXform(
+            md=md,
+            errored=True,
+            error__contains=[
+                "There are more than one survey elements named 'r1_count' "
+                "(case-insensitive) in the section named 'test_name'."
+            ],
+        )
+
+    def test_manual_xpath__generated_element_different_name__ok(self):
+        """Should find that a {repeat_name}_count element is generated for the calculation."""
+        md = """
+        | survey |
+        | | type               | name | label | repeat_count                    |
+        | | select_multiple l1 | q1   | Q1    |                                 |
+        | | begin_repeat       | r1   | R1    | count-selected( /test_name/q1 ) |
+        | | text               | q2   | Q2    |                                 |
+        | | end_repeat         |      |       |                                 |
+
+        | choices |
+        | | list_name | name | label |
+        | | l1        | c1   | C1    |
+        | | l1        | c2   | C2    |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                xpq.model_instance_item("r1_count"),
+                xpq.model_instance_bind("r1_count", "string"),
+                xpq.model_instance_bind_attr(
+                    "r1_count", "calculate", "count-selected( /test_name/q1 )"
+                ),
+                xpq.model_instance_bind_attr("r1_count", "readonly", "true()"),
+                # repeat references generated repeat_count element.
+                """
+                /h:html/h:body/x:group[@ref='/test_name/r1']/x:repeat[
+                  @nodeset='/test_name/r1'
+                  and @jr:count=' /test_name/r1_count '
+                ]
+                """,
+            ],
+        )
+
+    def test_constant_integer__generated_element_same_name__error(self):
+        """Should find that a duplicate {repeat_name}_count element raises an error."""
+        # Seems strange, but according to pyxform 435 it's a javarosa limitation.
+        md = """
+        | survey |
+        | | type         | name     | label | repeat_count |
+        | | integer      | r1_count | Q1    |              |
+        | | begin_repeat | r1       | R1    | 2            |
+        | | text         | q2       | Q2    |              |
+        | | end_repeat   |          |       |              |
+        """
+        self.assertPyxformXform(
+            md=md,
+            errored=True,
+            error__contains=[
+                "There are more than one survey elements named 'r1_count' "
+                "(case-insensitive) in the section named 'test_name'."
+            ],
+        )
+
+    def test_constant_integer__generated_element_different_name__ok(self):
+        """Should find that a {repeat_name}_count element is generated for the calculation."""
+        # Seems strange, but according to pyxform 435 it's a javarosa limitation.
+        md = """
+        | survey |
+        | | type         | name | label | repeat_count |
+        | | integer      | q1   | Q1    |              |
+        | | begin_repeat | r1   | R1    | 2            |
+        | | text         | q2   | Q2    |              |
+        | | end_repeat   |      |       |              |
+        """
+        self.assertPyxformXform(
+            md=md,
+            xml__xpath_match=[
+                xpq.model_instance_item("r1_count"),
+                xpq.model_instance_bind("r1_count", "string"),
+                xpq.model_instance_bind_attr("r1_count", "calculate", "2"),
+                xpq.model_instance_bind_attr("r1_count", "readonly", "true()"),
+                # repeat references generated repeat_count element.
+                """
+                /h:html/h:body/x:group[@ref='/test_name/r1']/x:repeat[
+                  @nodeset='/test_name/r1'
+                  and @jr:count=' /test_name/r1_count '
+                ]
+                """,
+            ],
+        )


### PR DESCRIPTION
Closes #781

#### Why is this the best possible solution? Were any other approaches considered?

- this code branch is for `is_pyxform_reference` but it didn't handle the case where there is no match (looks like reference but has other characters) - in which case the iteration over `outer_matches` would fail and throw an error like "None has no group"
- added test coverage for relevant usages of is_pyxform_reference:
  - repeat_count, now with tests showing common usage pattern outcomes
  - seed param, which had alternate usages already (constant/single ref)

#### What are the regression risks?

Fixes a regression, and tries to avoid others of a similar nature by adding more tests.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments