### PR TITLE
785: remove warning for group (or loop) without label

### DIFF
--- a/pyxform/aliases.py
+++ b/pyxform/aliases.py
@@ -148,17 +148,6 @@ yes_no = {
     "FALSE": False,
     "false()": False,
 }
-label_optional_types = [
-    "calculate",
-    "deviceid",
-    "end",
-    "phonenumber",
-    "simserial",
-    "start",
-    "start-geopoint",
-    "today",
-    "username",
-]
 osm = {"osm": constants.OSM_TYPE}
 BINDING_CONVERSIONS = {
     "yes": "true()",

--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -836,16 +836,9 @@ def workbook_to_json(
                 # There isn't an easy and neat place to put this besides here.
                 # Could potentially be simplified for control item cases.
                 if (
-                    constants.LABEL not in row
+                    control_type == constants.REPEAT
+                    and constants.LABEL not in row
                     and row.get(constants.MEDIA) is None
-                    and question_type not in aliases.label_optional_types
-                    and not row.get("bind", {}).get("calculate")
-                    and not row.get("_dynamic_default", False)
-                    and not (
-                        control_type is constants.GROUP
-                        and row.get("control", {}).get("appearance")
-                        == constants.FIELD_LIST
-                    )
                 ):
                     # Row number, name, and type probably enough for user message.
                     # Also means the error message text is stable for tests.

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -10,6 +10,7 @@ from pyxform.xls2json import SURVEY_001, SURVEY_002
 from pyxform.xls2xform import convert
 
 from tests.pyxform_test_case import PyxformTestCase
+from tests.xpath_helpers.group import xpg
 
 
 class TestGroupOutput(PyxformTestCase):
@@ -111,6 +112,144 @@ class TestGroupOutput(PyxformTestCase):
             name="table-list-appearance-mod",
             md=md,
             xml__contains=[xml_contains],
+        )
+
+    def test_group__label__ok(self):
+        """Should find a group control with a child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label |
+        | | begin_group | g1   | G1    |
+        | | text        | q1   | Q1    |
+        | | end_group   |      |       |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_label_no_translation("/test_name/g1", "G1"),
+            ],
+        )
+
+    def test_group__no_label__ok(self):
+        """Should find a group control with no child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label |
+        | | begin_group | g1   |       |
+        | | text        | q1   | Q1    |
+        | | end_group   |      |       |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_no_label("/test_name/g1"),
+            ],
+        )
+
+    def test_group__label__translated__ok(self):
+        """Should find a group control with a child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label::English (en) |
+        | | begin_group | g1   | G1                  |
+        | | text        | q1   | Q1                  |
+        | | end_group   |      |                     |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_label_translation("/test_name/g1"),
+            ],
+        )
+
+    def test_group__no_label__translated__ok(self):
+        """Should find a group control with no child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label::English (en) |
+        | | begin_group | g1   |                     |
+        | | text        | q1   | Q1                  |
+        | | end_group   |      |                     |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_no_label("/test_name/g1"),
+            ],
+        )
+
+    def test_group__label__appearance__ok(self):
+        """Should find a group control with a child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label | appearance |
+        | | begin_group | g1   | G1    | field-list |
+        | | text        | q1   | Q1    |            |
+        | | end_group   |      |       |            |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_label_no_translation_appearance(
+                    "/test_name/g1", "G1", "field-list"
+                ),
+            ],
+        )
+
+    def test_group__no_label__appearance__ok(self):
+        """Should find a group control with no child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label | appearance |
+        | | begin_group | g1   |       | field-list |
+        | | text        | q1   | Q1    |            |
+        | | end_group   |      |       |            |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_no_label_appearance("/test_name/g1", "field-list"),
+            ],
+        )
+
+    def test_group__label__translated__appearance__ok(self):
+        """Should find a group control with a child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label::English (en) | appearance |
+        | | begin_group | g1   | G1                  | field-list |
+        | | text        | q1   | Q1                  |            |
+        | | end_group   |      |                     |            |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_label_translation_appearance("/test_name/g1", "field-list"),
+            ],
+        )
+
+    def test_group__no_label__translated__appearance__ok(self):
+        """Should find a group control with no child `label` element and no warnings."""
+        md = """
+        | survey |
+        | | type        | name | label::English (en) | appearance |
+        | | begin_group | g1   |                     | field-list |
+        | | text        | q1   | Q1                  |            |
+        | | end_group   |      |                     |            |
+        """
+        self.assertPyxformXform(
+            md=md,
+            warnings_count=0,
+            xml__xpath_match=[
+                xpg.group_no_label_appearance("/test_name/g1", "field-list"),
+            ],
         )
 
 
@@ -641,63 +780,6 @@ class TestGroupParsing(PyxformTestCase):
             odk_validate_error__contains=[
                 "Group has no children! Group: ${g1}. The XML is invalid."
             ],
-        )
-
-    def test_unlabeled_group(self):
-        self.assertPyxformXform(
-            md="""
-            | survey |
-            | | type        | name     | label   |
-            | | begin_group | my-group |         |
-            | | text        | my-text  | my-text |
-            | | end_group   |          |         |
-            """,
-            warnings_count=1,
-            warnings__contains=["[row : 2] Group has no label"],
-        )
-
-    def test_unlabeled_group_alternate_syntax(self):
-        self.assertPyxformXform(
-            md="""
-            | survey |
-            | | type        | name     | label::English (en) |
-            | | begin group | my-group |                     |
-            | | text        | my-text  | my-text             |
-            | | end group   |          |                     |
-            """,
-            warnings_count=1,
-            warnings__contains=["[row : 2] Group has no label"],
-        )
-
-    def test_unlabeled_group_fieldlist(self):
-        self.assertPyxformXform(
-            md="""
-            | survey |
-            | | type         | name      | label   | appearance |
-            | | begin_group  | my-group  |         | field-list |
-            | | text         | my-text   | my-text |            |
-            | | end_group    |           |         |            |
-            """,
-            warnings_count=0,
-            xml__xpath_match=[
-                """
-                /h:html/h:body/x:group[
-                  @ref = '/test_name/my-group' and @appearance='field-list'
-                ]
-                """
-            ],
-        )
-
-    def test_unlabeled_group_fieldlist_alternate_syntax(self):
-        self.assertPyxformXform(
-            md="""
-            | survey |
-            | | type        | name     | label::English (en) | appearance |
-            | | begin group | my-group |                     | field-list |
-            | | text        | my-text  | my-text             |            |
-            | | end group   |          |                     |            |
-            """,
-            warnings_count=0,
         )
 
 

--- a/tests/test_xlsform_spec.py
+++ b/tests/test_xlsform_spec.py
@@ -68,8 +68,6 @@ class TestWarnings(PyxformTestCase):
             vc.INVALID_LABEL.format(row=6),
             vc.INVALID_LABEL.format(row=7),
             "[row : 9] Repeat has no label: {'name': 'repeat_test', 'type': 'begin repeat'}",
-            "[row : 10] Group has no label: {'name': 'group_test', 'type': 'begin group'}",
-            "[row : 17] Group has no label: {'name': 'name', 'type': 'begin group'}",
             "[row : 28] Use the max-pixels parameter to speed up submission "
             + "sending and save storage space. Learn more: https://xlsform.org/#image",
         ]

--- a/tests/xpath_helpers/group.py
+++ b/tests/xpath_helpers/group.py
@@ -1,0 +1,90 @@
+class XPathHelper:
+    """
+    XPath expressions for settings assertions.
+    """
+
+    @staticmethod
+    def group_no_label(ref: str) -> str:
+        """There is a @ref, and no inline label."""
+        return f"""
+        /h:html/h:body/x:group[
+          @ref='{ref}'
+          and count(@*) = 1
+          and not(./x:label)
+        ]
+        """
+
+    @staticmethod
+    def group_no_label_appearance(ref: str, appearance: str) -> str:
+        """There is a @ref and @appearance, and no inline label."""
+        return f"""
+        /h:html/h:body/x:group[
+          @ref='{ref}'
+          and @appearance='{appearance}'
+          and count(@*) = 2
+          and not(./x:label)
+        ]
+        """
+
+    @staticmethod
+    def group_label_no_translation(ref: str, label: str, path: str = "") -> str:
+        """There is a @ref, and an inline label."""
+        return f"""
+        /h:html/h:body{path}/x:group[
+          @ref='{ref}'
+          and count(@*) = 1
+          and ./x:label[
+            not(@ref)
+            and text()='{label}'
+          ]
+        ]
+        """
+
+    @staticmethod
+    def group_label_translation(ref: str, path: str = "") -> str:
+        """There is a @ref, and a translated label."""
+        return f"""
+        /h:html/h:body{path}/x:group[
+          @ref='{ref}'
+          and count(@*) = 1
+          and ./x:label[
+            @ref="jr:itext('{ref}:label')"
+            and not(text())
+          ]
+        ]
+        """
+
+    @staticmethod
+    def group_label_no_translation_appearance(
+        ref: str, label: str, appearance: str
+    ) -> str:
+        """There is a @ref and @appearance, and an inline label."""
+        return f"""
+        /h:html/h:body/x:group[
+          @ref='{ref}'
+          and @appearance='{appearance}'
+          and count(@*) = 2
+          and ./x:label[
+            not(@ref)
+            and text()='{label}'
+          ]
+        ]
+        """
+
+    @staticmethod
+    def group_label_translation_appearance(ref: str, appearance: str) -> str:
+        """There is a @ref and @appearance, and a translated label."""
+        return f"""
+        /h:html/h:body/x:group[
+          @ref='{ref}'
+          and @appearance='{appearance}'
+          and count(@*) = 2
+          and ./x:label[
+            @ref="jr:itext('{ref}:label')"
+            and not(text())
+          ]
+        ]
+        """
+
+
+xpg = XPathHelper()


### PR DESCRIPTION
Closes #785

#### Why is this the best possible solution? Were any other approaches considered?

See commit message for details. Generally simplifies the label check code, applies the change to both groups and loops, and improves test coverage to help avoid regressions about this requirement in future.

As mentioned in the commit message, as a follow up (or addition to this PR), the requirement for choice labels used as the source for loops could also be relaxed. I haven't implemented that at this stage since I'm not sure if that is desirable (it probably is - labels aren't usually required for choices and now won't be for groups or loops).

#### What are the regression risks?

If any users or other libraries expect this warning to be there, it won't.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

It might be OK to leave docs as-is with regard to recommending group labels, but if anywhere explicitly says they're required then that should be updated (ODK docs, xlsform.org, or XLSForm template, kapa knowledge base, etc).

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments