### PR TITLE
797: Default range question type to start at 0

### DIFF
--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -157,7 +157,7 @@ def process_range_question_type(
         parameters=parameters, allowed=("start", "end", "step")
     )
     parameters_map = {"start": "start", "end": "end", "step": "step"}
-    defaults = {"start": "1", "end": "10", "step": "1"}
+    defaults = {"start": "0", "end": "10", "step": "1"}
 
     # set defaults
     for key in parameters_map.values():

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -45,7 +45,7 @@ class RangeWidgetTest(PyxformTestCase):
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="int"/>',
-                '<range end="10" ref="/data/level" start="1" step="1">',
+                '<range end="10" ref="/data/level" start="0" step="1">',
             ],
         )
 
@@ -58,7 +58,7 @@ class RangeWidgetTest(PyxformTestCase):
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="int"/>',
-                '<range end="20" ref="/data/level" start="1" step="1">',
+                '<range end="20" ref="/data/level" start="0" step="1">',
             ],
         )
 
@@ -71,7 +71,7 @@ class RangeWidgetTest(PyxformTestCase):
             """,
             xml__contains=[
                 '<bind nodeset="/data/level" type="int"/>',
-                '<range end="10" ref="/data/level" start="1" step="1">',
+                '<range end="10" ref="/data/level" start="0" step="1">',
             ],
         )
 


### PR DESCRIPTION
Closes #797

#### Why is this the best possible solution? Were any other approaches considered?

Changed the default start to 0 instead of 1 based on the XLSForm specification: https://xlsform.org/en/#range

#### What are the regression risks?

Users / libraries expecting the default to be 1. 

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No change required for [XLSForm docs](https://xlsform.org/), it appears [ODK Docs](https://docs.getodk.org/) doesn't specify range question defaults for `start`, `end`, and `step`.

#### Before submitting this PR, please make sure you have:
- [X] included test cases for core behavior and edge cases in `tests`
- [X] run `python -m unittest` and verified all tests pass
- [X] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [X] verified that any code or assets from external sources are properly credited in comments