### PR TITLE
796: allow ${instanceID} reference for longitudinal / entities workflows

### DIFF
--- a/pyxform/xls2json.py
+++ b/pyxform/xls2json.py
@@ -1423,6 +1423,8 @@ def workbook_to_json(
                 "type": "calculate",
             }
         )
+        # Allow ${instanceID} reference for longitudinal / entities workflows.
+        element_names.update(("instanceID",))
 
     if "instance_name" in settings:
         # Automatically add an instanceName element:


### PR DESCRIPTION
Closes #796

#### Why is this the best possible solution? Were any other approaches considered?

This adds `instanceID` to the list of allowed element names that can be referenced with `${}`. This is a key part of entity use cases mentioned in #796.

Considered not covering the related but undocumented / untested settings `instance_id` and `omit_instanceID`, but they impact this feature and may be in use, and could be removed separately.

#### What are the regression risks?

Fixes a regression. If a question named `instanceID` exists, that is still allowed, but if a reference to `${instanceID}` is added, that will raise an error due to a duplicate name - which is the current release behaviour.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

Yes, [filed here](https://github.com/XLSForm/xlsform.github.io/issues/283).

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments