### PR TITLE
Leading and trailing spaces in parameters lead to form error #812

### DIFF
--- a/pyxform/validators/pyxform/parameters_generic.py
+++ b/pyxform/validators/pyxform/parameters_generic.py
@@ -26,7 +26,9 @@ def parse(raw_parameters: str) -> PARAMETERS_TYPE:
             )
         k, v = param.split("=")[:2]
         key = maybe_strip(k.lower())
-        params[key] = v if key in CASE_SENSITIVE_VALUES else maybe_strip(v.lower())
+        params[key] = (
+            maybe_strip(v) if key in CASE_SENSITIVE_VALUES else maybe_strip(v.lower())
+        )
 
     return params
 

--- a/tests/test_external_instances_for_selects.py
+++ b/tests/test_external_instances_for_selects.py
@@ -265,6 +265,27 @@ class TestSelectFromFile(PyxformTestCase):
                     ],
                 )
 
+    def test_param_value_and_label_whitespace_trimmed_case_preserved(self):
+        """Should trim outer spaces for value/label params while preserving case."""
+        md = """
+        | survey |                                        |         |         |                              |
+        |        | type                                   | name    | label   | parameters                   |
+        |        | select_one_from_file cities{ext}       | city    | City    | value = VAL , label = lBl    |
+        |        | select_multiple_from_file suburbs{ext} | suburbs | Suburbs | value = VAL , label = lBl    |
+        """
+        for ext, xp_city, xp_subs in self.xp_test_args:
+            with self.subTest(msg=ext):
+                self.assertPyxformXform(
+                    name="test",
+                    md=md.format(ext=ext),
+                    xml__xpath_match=[
+                        xp_city.model_external_instance_and_bind(),
+                        xp_subs.model_external_instance_and_bind(),
+                        xp_city.body_itemset_nodeset_and_refs(value="VAL", label="lBl"),
+                        xp_subs.body_itemset_nodeset_and_refs(value="VAL", label="lBl"),
+                    ],
+                )
+
     def test_expected_error_message(self):
         """Should get helpful error when select_from_file is missing a file extension."""
         md = """


### PR DESCRIPTION
Why is this the best possible solution? Were any other approaches considered?
This fixes the bug at the source: parameters_generic.parse() was intentionally preserving case for value and label, but it was also preserving leading and trailing whitespace for those two keys only. That caused forms like value = VAL , label = lBl to fail later with an invalid-name error when used in select_one_from_file / select_multiple_from_file.

The chosen fix keeps the existing intended behavior, which is:

preserve case for value and label
trim incidental outer whitespace the same way other parameters are normalized
I considered leaving parsing unchanged and adding a later validation special case, but that would keep the bug’s root cause in the generic parser and make downstream handling more brittle. Normalizing the values once in the parser is smaller, clearer, and benefits every caller consistently.

What are the regression risks?
Low. The change is narrowly scoped to case-sensitive parameter values in parameters_generic.parse(). It does not change:

parameter key parsing
separator handling
case normalization for non-case-sensitive parameters
validation rules for supported/unsupported parameter names
The main regression risk would be accidentally changing the intended case-preservation behavior for value and label, so I added a regression test to confirm that case is still preserved while outer whitespace is removed.

Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.
I do not think this requires a docs update. This change aligns pyxform with the intuitive expectation that incidental leading/trailing spaces around parameter values should not break form compilation.