### PR TITLE
Fix reference-geometry from repeat

### DIFF
--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -676,11 +676,17 @@ class GeoQuestion(_SupportsItemset):
             path = survey.insert_xpaths(
                 text=self.itemset, context=question, reference_parent=True
             ).strip()
+            # A default choice_filter is added here as a workaround for Collect appending
+            # an index predicate (e.g. "/data/r1[1]") to absolute references in a repeat
+            # context (the whole nodeset is desired for the user to choose from). Assumes
+            # that Collect will not alter or replace an existing predicate, and also that
+            # pyxform emits an absolute reference for this topology. See pyxform/#848.
+            choice_filter = "./geometry != ''"
             return ItemsetNode(
                 value_ref="geometry",
                 label_ref="geometry",
                 nodeset=path,
-                choice_filter="./geometry != ''",
+                choice_filter=choice_filter,
             )
 
     def build_xml(self, survey: "Survey"):

--- a/pyxform/question.py
+++ b/pyxform/question.py
@@ -668,6 +668,21 @@ class RangeQuestion(_SupportsItemset):
 
 
 class GeoQuestion(_SupportsItemset):
+    def _build_itemset_reference(
+        self, question: "Question", survey: "Survey"
+    ) -> ItemsetNode | None:
+        """Build a geo-specific itemset node using a reference to a repeat."""
+        if self.itemset_has_ref:
+            path = survey.insert_xpaths(
+                text=self.itemset, context=question, reference_parent=True
+            ).strip()
+            return ItemsetNode(
+                value_ref="geometry",
+                label_ref="geometry",
+                nodeset=path,
+                choice_filter="./geometry != ''",
+            )
+
     def build_xml(self, survey: "Survey"):
         result = self._build_xml(survey=survey)
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -578,6 +578,34 @@ class TestParameterReferenceGeometryOutput(PyxformTestCase):
                     ],
                 )
 
+    def test_pyxform_reference__inside_repeat__ok(self):
+        """Should find that a child itemset is emitted, with geometry value/label."""
+        # RG005 RG007 RG010 RG016
+        md = """
+        | survey |
+        | | type         | name     | label | parameters                 |
+        | | begin_repeat | r1       | R1    |                            |
+        | | {type}       | geometry | Q1    | reference-geometry=${{r1}} |
+        | | end_repeat   | r1       |       |                            |
+        """
+        for t in GEO_TYPES:
+            with self.subTest(t):
+                self.assertPyxformXform(
+                    md=md.format(type=t),
+                    xml__xpath_match=[
+                        xpq.model_instance_item("r1[not(@jr:template)]"),
+                        xpq.model_instance_bind("r1/geometry", t),
+                        xpq.body_itemset(
+                            q_name="r1/geometry",
+                            nodeset="/test_name/r1[./geometry != '']",
+                            value_ref="geometry",
+                            label_ref="geometry",
+                            extra_q_assertions="and not(@reference-geometry)",
+                            body_path="/x:group/x:repeat",
+                        ),
+                    ],
+                )
+
     def test_external_file__ok(self):
         """Should find that a child itemset is emitted, with default value/label."""
         # RG005 RG006 RG011 RG016
@@ -673,6 +701,39 @@ class TestParameterReferenceGeometryOutput(PyxformTestCase):
                             xpq.body_itemset(
                                 q_name="q2",
                                 nodeset="instance('s1')/root/item[region = 1]",
+                                extra_q_assertions="and not(@reference-geometry)",
+                            ),
+                        ],
+                    )
+
+    def test_select_from_file__params_value_label__ok(self):
+        """Should find that a child itemset is emitted, with default value/label."""
+        # RG005 RG006 RG012 RG016
+        md = """
+        | survey |
+        | | type                         | name | label | parameters            |
+        | | select_one_from_file s1{ext} | q1   | Q1    | value=v, label=l      |
+        | | {type}                       | q2   | Q2    | reference-geometry=s1 |
+        """
+        for t in GEO_TYPES:
+            for ext in co.EXTERNAL_INSTANCE_EXTENSIONS:
+                with self.subTest((t, ext)):
+                    self.assertPyxformXform(
+                        md=md.format(type=t, ext=ext),
+                        xml__xpath_match=[
+                            xpq.model_instance_exists("s1"),
+                            # The "select from file" params are separate to reference-geometry.
+                            xpq.body_itemset(
+                                q_name="q1",
+                                q_type="select1",
+                                nodeset="instance('s1')/root/item",
+                                value_ref="v",
+                                label_ref="l",
+                            ),
+                            xpq.model_instance_bind("q2", t),
+                            xpq.body_itemset(
+                                q_name="q2",
+                                nodeset="instance('s1')/root/item",
                                 extra_q_assertions="and not(@reference-geometry)",
                             ),
                         ],

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -522,15 +522,15 @@ class TestParameterReferenceGeometryOutput(PyxformTestCase):
                 )
 
     def test_pyxform_reference__ok(self):
-        """Should find that a child itemset is emitted, with reference-specific value/label."""
+        """Should find that a child itemset is emitted, with geometry value/label."""
         # RG005 RG007 RG010 RG016
         md = """
         | survey |
-        | | type         | name | label | parameters                 |
-        | | begin_repeat | r1   | R1    |                            |
-        | | text         | q1   | Q1    |                            |
-        | | end_repeat   | r1   |       |                            |
-        | | {type}       | q2   | Q2    | reference-geometry=${{r1}} |
+        | | type         | name     | label | parameters                 |
+        | | begin_repeat | r1       | R1    |                            |
+        | | text         | geometry | Q1    |                            |
+        | | end_repeat   | r1       |       |                            |
+        | | {type}       | q2       | Q2    | reference-geometry=${{r1}} |
         """
         for t in GEO_TYPES:
             with self.subTest(t):
@@ -541,9 +541,9 @@ class TestParameterReferenceGeometryOutput(PyxformTestCase):
                         xpq.model_instance_bind("q2", t),
                         xpq.body_itemset(
                             q_name="q2",
-                            nodeset="/test_name[./r1 != '']",
-                            value_ref="r1",
-                            label_ref="r1",
+                            nodeset="/test_name/r1[./geometry != '']",
+                            value_ref="geometry",
+                            label_ref="geometry",
                             extra_q_assertions="and not(@reference-geometry)",
                         ),
                     ],
@@ -554,11 +554,12 @@ class TestParameterReferenceGeometryOutput(PyxformTestCase):
         # RG005 RG007 RG010 RG014 RG016
         md = """
         | survey |
-        | | type         | name | label | parameters                 | choice_filter |
-        | | begin_repeat | r1   | R1    |                            |               |
-        | | text         | q1   | Q1    |                            |               |
-        | | end_repeat   | r1   |       |                            |               |
-        | | {type}       | q2   | Q2    | reference-geometry=${{r1}} | ${{q1}} = 1   |
+        | | type         | name     | label | parameters                 | choice_filter |
+        | | begin_repeat | r1       | R1    |                            |               |
+        | | geopoint     | geometry | Q1    |                            |               |
+        | | text         | q2       | Q2    |
+        | | end_repeat   | r1       |       |                            |               |
+        | | {type}       | q3       | Q3    | reference-geometry=${{r1}} | ${{q2}} = 1   |
         """
         for t in GEO_TYPES:
             with self.subTest(t):
@@ -566,12 +567,12 @@ class TestParameterReferenceGeometryOutput(PyxformTestCase):
                     md=md.format(type=t),
                     xml__xpath_match=[
                         xpq.model_instance_item("r1[not(@jr:template)]"),
-                        xpq.model_instance_bind("q2", t),
+                        xpq.model_instance_bind("q3", t),
                         xpq.body_itemset(
-                            q_name="q2",
-                            nodeset="/test_name[ ./r1/q1  = 1]",
-                            value_ref="r1",
-                            label_ref="r1",
+                            q_name="q3",
+                            nodeset="/test_name/r1[ ./q2  = 1]",
+                            value_ref="geometry",
+                            label_ref="geometry",
                             extra_q_assertions="and not(@reference-geometry)",
                         ),
                     ],

--- a/tests/xpath_helpers/questions.py
+++ b/tests/xpath_helpers/questions.py
@@ -111,10 +111,11 @@ class XPathHelper:
         value_ref: str = "name",
         label_ref: str = "label",
         extra_q_assertions: str = "",
+        body_path: str = "",
     ) -> str:
         """Body has a direct child control with an itemset, and no inline items."""
         return rf"""
-        /h:html/h:body/x:{q_type}[
+        /h:html/h:body{body_path}/x:{q_type}[
           @ref="/test_name/{q_name}"
           and ./x:itemset[@nodeset="{nodeset}"]
           and ./x:itemset/x:value[@ref="{value_ref}"]


### PR DESCRIPTION
I did not look at the test output carefully enough for the nodeset reference case. This PR gets to the expected output. For selects from repeats, users specify a reference to a text field in a repeat. For reference-geometry, they specify a reference to the repeat. For now, the only field that we've said must be in the referenced repeat is `geometry` so we use that as `name` and `label`. In the future, we'll likely also support a mode in which a name and label can be displayed and specified, we can handle that addition then.

@lindsay-stevens feel free to take this PR over if you see changes you'd like to make! 

#### Why is this the best possible solution? Were any other approaches considered?

Overriding `_build_itemset_reference` feels like a clean use of the infrastructure in place. I verified a converted form in Collect and confirmed it works.

#### What are the regression risks?

This is very targeted so I think the only risk is to `reference_geometry` from repeats which doesn't currently work.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments