### PR TITLE
Support vertical and no-ticks for new range parameters

### DIFF
--- a/pyxform/errors.py
+++ b/pyxform/errors.py
@@ -448,8 +448,8 @@ class ErrorCode(Enum):
         msg=(
             "[row : {row}] On the 'survey' sheet, the 'parameters' value is invalid. "
             "For the 'range' question type, the parameters 'tick_interval', 'placeholder', "
-            "and 'tick_labelset' are only supported for the appearances 'vertical', 'no-ticks' "
-            "and the default (empty) horizontal."
+            "and 'tick_labelset' are only supported for the appearances 'vertical', 'no-ticks', "
+            "'vertical no-ticks', and the default (empty) horizontal."
         ),
     )
     RANGE_009 = Detail(

--- a/pyxform/validators/pyxform/question_types/range.py
+++ b/pyxform/validators/pyxform/question_types/range.py
@@ -26,11 +26,6 @@ def process_range_question_type(
     :param choices: The choices data as `{list_name: [choice_items[options], ...]}`.
     :return: The updated row.
     """
-    """
-    Returns a new row that includes the Range parameters start, end and step.
-
-    Raises PyXFormError when invalid range parameters are used.
-    """
     pv.validate(parameters=parameters, accepted=co.ParametersRange, row_number=row_number)
     if (
         appearance
@@ -46,7 +41,6 @@ def process_range_question_type(
         )
     ):
         raise PyXFormError(ErrorCode.RANGE_008.value.format(row=row_number))
-    no_ticks_appearance = appearance and "no-ticks" in appearance
 
     defaults = QUESTION_TYPE_DICT["range"][co.PARAMETERS]
     # set defaults
@@ -137,6 +131,7 @@ def process_range_question_type(
         if tick_list is None:
             raise PyXFormError(ErrorCode.RANGE_006.value.format(row=row_number))
 
+        no_ticks_appearance = appearance and "no-ticks" in appearance
         no_ticks_labels = set()
         for item in tick_list:
             errored = False

--- a/pyxform/validators/pyxform/question_types/range.py
+++ b/pyxform/validators/pyxform/question_types/range.py
@@ -34,7 +34,8 @@ def process_range_question_type(
     pv.validate(parameters=parameters, accepted=co.ParametersRange, row_number=row_number)
     if (
         appearance
-        and appearance not in {"vertical", "no-ticks"}
+        and "vertical" not in appearance
+        and "no-ticks" not in appearance
         and any(
             k in parameters
             for k in (
@@ -45,7 +46,7 @@ def process_range_question_type(
         )
     ):
         raise PyXFormError(ErrorCode.RANGE_008.value.format(row=row_number))
-    no_ticks_appearance = appearance and appearance == "no-ticks"
+    no_ticks_appearance = appearance and "no-ticks" in appearance
 
     defaults = QUESTION_TYPE_DICT["range"][co.PARAMETERS]
     # set defaults

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -672,7 +672,7 @@ class TestRangeParsing(PyxformTestCase):
             ("placeholder=3", {"odk:placeholder": "3"}),
             ("tick_labelset=c1", {}),
         )
-        cases = ("", "vertical", "no-ticks")
+        cases = ("", "vertical", "no-ticks", "no-ticks vertical", "vertical no-ticks")
         for param, attr in params:
             for appearance in cases:
                 with self.subTest((param, attr, appearance)):

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -9,7 +9,7 @@ Each test should reference one (or more) requirements from these lists.
   - RC003: parameter names may in lower case or in mixed case.
   - RC004: parameter names and values must be separated by a single equals sign.
   - RC005: parameter values must be numeric (or for 'tick_labelset', the choices).
-  - RC006: appearance parameters are only valid with default, 'vertical' or 'no-ticks' appearance.
+  - RC006: appearance parameters are only valid with default, 'vertical' or 'no-ticks' (or both) appearance.
   - RC007: parameters may specify ranges that are positive, negative, ascending, or descending.
   - parameter 'step':
     - RS001: must not be zero.


### PR DESCRIPTION
Closes #846

#### Why is this the best possible solution? Were any other approaches considered?

I considered splitting the appearance string into tokens which would be more correct but I think string membership is easier to read and is fine for a short list of well-known tokens.

#### What are the regression risks?

Small fix so should be minimal. Worst case is probably that the new range parameters are allowed to pair with appearances they're not supposed to pair with.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/XLSForm/xlsform.github.io) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] included test cases for core behavior and edge cases in `tests`
- [x] run `python -m unittest` and verified all tests pass
- [x] run `ruff format pyxform tests` and `ruff check pyxform tests` to lint code
- [x] verified that any code or assets from external sources are properly credited in comments